### PR TITLE
Fork and Livenet Deployment Support

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/packages/hardhat-cannon/src/builder/import.ts
+++ b/packages/hardhat-cannon/src/builder/import.ts
@@ -3,7 +3,7 @@ import Debug from 'debug';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { JTDDataType } from 'ajv/dist/core';
 
-import { BundledChainBuilderOutputs, ChainBuilder, ChainBuilderContext } from './';
+import { BundledChainBuilderOutputs, ChainBuilder, ChainBuilderContext, InternalOutputs } from './';
 
 const debug = Debug('cannon:builder:import');
 
@@ -55,7 +55,7 @@ export default {
     return config;
   },
 
-  async exec(hre: HardhatRuntimeEnvironment, config: Config): Promise<BundledChainBuilderOutputs> {
+  async exec(hre: HardhatRuntimeEnvironment, config: Config): Promise<InternalOutputs<BundledChainBuilderOutputs>> {
     debug('exec', config);
 
     // download if necessary upstream
@@ -65,6 +65,9 @@ export default {
 
     await builder.build(config.options || {});
 
-    return builder.getOutputs();
+    return {
+      contracts: builder.getContracts(),
+      outputs: builder.getOutputs(),
+    };
   },
 };

--- a/packages/hardhat-cannon/src/builder/import.ts
+++ b/packages/hardhat-cannon/src/builder/import.ts
@@ -3,7 +3,8 @@ import Debug from 'debug';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { JTDDataType } from 'ajv/dist/core';
 
-import { BundledChainBuilderOutputs, ChainBuilder, ChainBuilderContext, InternalOutputs } from './';
+import { ChainBuilderContext, InternalOutputs } from './types';
+import { ChainBuilder } from '.';
 
 const debug = Debug('cannon:builder:import');
 
@@ -55,7 +56,7 @@ export default {
     return config;
   },
 
-  async exec(hre: HardhatRuntimeEnvironment, config: Config): Promise<InternalOutputs<BundledChainBuilderOutputs>> {
+  async exec(hre: HardhatRuntimeEnvironment, _ctx: ChainBuilderContext, config: Config): Promise<InternalOutputs> {
     debug('exec', config);
 
     // download if necessary upstream
@@ -65,9 +66,11 @@ export default {
 
     await builder.build(config.options || {});
 
+    const outputs = builder.getOutputs();
+
     return {
-      contracts: builder.getContracts(),
-      outputs: builder.getOutputs(),
+      contracts: outputs.contracts,
+      imports: outputs.imports,
     };
   },
 };

--- a/packages/hardhat-cannon/src/builder/index.ts
+++ b/packages/hardhat-cannon/src/builder/index.ts
@@ -291,7 +291,7 @@ export class ChainBuilder {
     const fileList =
       (await fs.pathExists(dirToScan)) && (await fs.stat(dirToScan)).isDirectory() ? await fs.readdir(dirToScan) : [];
 
-    const fileFilter = new RegExp(`^${this.ctx.chainId}-([0-9]*).json$`);
+    const fileFilter = new RegExp(`^${this.ctx.chainId}-([0-9]+).json$`);
 
     const sortedFileList = _.sortBy(
       fileList

--- a/packages/hardhat-cannon/src/builder/index.ts
+++ b/packages/hardhat-cannon/src/builder/index.ts
@@ -18,10 +18,25 @@ const debug = Debug('cannon:builder');
 
 const ajv = new Ajv();
 
+const LAYER_VERSION = 2;
+
 type OptionTypesTs = string | number | boolean;
 
+type ContractMap = {
+  [label: string]: {
+    address: string;
+    abi: any[];
+  };
+};
+
 const ChainDefinitionSchema = {
+  properties: {
+    name: { type: 'string' },
+    version: { type: 'string' },
+  },
   optionalProperties: {
+    description: { type: 'string' },
+    tags: { elements: { type: 'string' } },
     setting: {
       values: {
         optionalProperties: {
@@ -42,7 +57,7 @@ export type ChainDefinition = JTDDataType<typeof ChainDefinitionSchema>;
 
 export type BuildOptions = { [val: string]: string };
 
-export const validateChainDefinition = ajv.compileParser(ChainDefinitionSchema);
+export const validateChainDefinition = ajv.compile(ChainDefinitionSchema);
 
 export interface ChainBuilderContext {
   fork: boolean;
@@ -54,6 +69,8 @@ export interface ChainBuilderContext {
   repositoryBuild: boolean;
 
   package: any;
+
+  contracts: ContractMap;
 
   outputs: BundledChainBuilderOutputs;
 }
@@ -68,6 +85,11 @@ export interface ChainBuilderOutputs {
   imports?: { [key: string]: ChainBuilderOptions };
   invokes?: { [key: string]: ChainBuilderOptions };
   runs?: { [key: string]: ChainBuilderOptions };
+}
+
+export interface InternalOutputs<T> {
+  contracts: ContractMap;
+  outputs: T;
 }
 
 interface ChainBuilderOptions {
@@ -85,6 +107,8 @@ const INITIAL_CHAIN_BUILDER_CONTEXT: ChainBuilderContext = {
   package: {},
 
   settings: {},
+  contracts: {},
+
   outputs: { self: {} },
 };
 
@@ -172,7 +196,7 @@ export class ChainBuilder {
     for (const s of steps.sort()) {
       debug('step', s);
 
-      if (await this.hasLayer(s)) {
+      if (await this.layerMatches(s)) {
         doLoad = s;
       } else {
         if (doLoad !== null) {
@@ -195,7 +219,8 @@ export class ChainBuilder {
           output[name] = output.self;
           delete output.self;
 
-          this.ctx.outputs = { ...this.ctx.outputs, ...output } as any;
+          this.ctx.contracts = { ...this.ctx.contracts, ...output.contracts };
+          this.ctx.outputs = { ...this.ctx.outputs, ...output.outputs } as any;
         }
 
         debug(`contracts step ${s}`);
@@ -205,22 +230,44 @@ export class ChainBuilder {
             this.hre,
             contractSpec.configInject(this.ctx, doContract),
             this.getAuxilleryFilePath('contracts'),
-            this.repositoryBuild
+            this.repositoryBuild,
+            name,
+            this.ctx.fork
           );
-          _.set(this.ctx.outputs.self, `contracts.${name}`, output);
+
+          this.ctx.contracts = { ...this.ctx.contracts, ...output.contracts };
+          _.set(this.ctx.outputs.self, `contracts.${name}`, output.outputs);
         }
 
         debug(`invoke step ${s}`);
         // todo: parallelization can be utilized here
         for (const [name, doInvoke] of steppedInvokes[s] || []) {
-          const output = await invokeSpec.exec(this.hre, invokeSpec.configInject(this.ctx, doInvoke));
-          _.set(this.ctx.outputs.self, `invokes.${name}`, output);
+          const output = await invokeSpec.exec(
+            this.hre,
+            invokeSpec.configInject(this.ctx, doInvoke),
+            this.ctx.contracts,
+            this.ctx.fork
+          );
+
+          this.ctx.contracts = { ...this.ctx.contracts, ...output.contracts };
+          _.set(this.ctx.outputs.self, `invokes.${name}`, output.outputs);
         }
 
         debug(`scripts step ${s}`);
         for (const [name, doScript] of steppedRuns[s] || []) {
-          const output = await scriptSpec.exec(this.hre, scriptSpec.configInject(this.ctx, doScript));
-          _.set(this.ctx.outputs.self, `runs.${name}`, output);
+          const config = scriptSpec.configInject(this.ctx, doScript);
+
+          // normally shouldn't be able to get here
+          if (!config) {
+            throw new Error(
+              'tried to build step without all required files. Please contact the developer of this chain and ask them to make sure config does not affect run steps.'
+            );
+          }
+
+          const output = await scriptSpec.exec(this.hre, config);
+
+          this.ctx.contracts = { ...this.ctx.contracts, ...output.contracts };
+          _.set(this.ctx.outputs.self, `runs.${name}`, output.outputs);
         }
 
         await this.dumpLayer(s);
@@ -244,7 +291,7 @@ export class ChainBuilder {
 
     this.ctx = topLayer[1];
 
-    if (await this.hasLayer(topLayer[0])) {
+    if (await this.layerMatches(topLayer[0])) {
       await this.loadLayer(topLayer[0]);
 
       // run keepers
@@ -264,6 +311,10 @@ export class ChainBuilder {
 
   getOutputs() {
     return _.cloneDeep(this.ctx.outputs);
+  }
+
+  getContracts() {
+    return _.cloneDeep(this.ctx.contracts);
   }
 
   async populateSettings(ctx: ChainBuilderContext, opts: BuildOptions) {
@@ -311,11 +362,11 @@ export class ChainBuilder {
 
     const sortedFileList = _.sortBy(
       fileList
-        .filter((n) => /^[0-9]*-.*.json$/.test(n))
+        .filter((n) => /^[0-9]*-[0-9]*.json$/.test(n))
         .map((n) => {
-          const m = n.match(/^([0-9]*)-/);
+          const m = n.match(/^([0-9]*)-([0-9]*)/);
           if (!m) throw new Error(`Invalid file format "${n}"`);
-          return { n: parseFloat(m[0]), name: n };
+          return { n: parseFloat(m[1]), name: n };
         }),
       'n'
     );
@@ -323,19 +374,57 @@ export class ChainBuilder {
     if (sortedFileList.length > 0) {
       const item = sortedFileList[sortedFileList.length - 1];
 
-      return [item.n, JSON.parse((await fs.readFile(path.join(dirToScan, item.name))).toString())];
+      const contents = JSON.parse((await fs.readFile(path.join(dirToScan, item.name))).toString());
+
+      if (contents.version !== LAYER_VERSION) {
+        throw new Error('cannon file format not supported');
+      }
+
+      return [item.n, contents.ctx];
     } else {
       const newCtx = INITIAL_CHAIN_BUILDER_CONTEXT;
       newCtx.network = this.hre.network.name;
-      newCtx.chainId = this.hre.network.config.chainId || 31337;
+
+      if (this.hre.network.name === 'hardhat') {
+        newCtx.chainId = this.hre.network.config.chainId || 31337;
+
+        // TODO: if we are forking, we probably want to get the chainId of the forked network instead
+        newCtx.fork = !!this.hre.config.networks.hardhat.forking;
+      } else {
+        if (!this.hre.network.config.chainId) {
+          throw new Error('chainId must be defined in selected hardhat network');
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        newCtx.chainId = this.hre.network.config.chainId!;
+
+        // we can verify if its a fork by trying to call `evm_mine`
+        try {
+          await this.hre.network.provider.send('evm_mine');
+          newCtx.fork = true;
+        } catch (err) {
+          newCtx.fork = false;
+        }
+      }
 
       return [0, newCtx];
     }
   }
 
-  async hasLayer(n: number) {
+  async layerMatches(n: number) {
     try {
-      await fs.stat((await this.getLayerFiles(n)).chain);
+      const contents = JSON.parse((await fs.readFile((await this.getLayerFiles(n)).metadata)).toString('utf8'));
+
+      const newHashes = await this.layerHashes(n);
+
+      for (const [i, hash] of newHashes.entries()) {
+        if (!hash) {
+          continue; // assumed this is a free to skip check
+        } else if (contents.hash.indexOf(hash) === -1) {
+          return false;
+        }
+      }
+
       return true;
     } catch {
       return false;
@@ -351,7 +440,7 @@ export class ChainBuilder {
   }
 
   async getLayerFiles(n: number) {
-    const filename = n + '-' + (await this.layerHash(n));
+    const filename = `${this.ctx.chainId}-${n}`;
 
     const basename = path.join(this.getCacheDir(), filename);
 
@@ -362,7 +451,7 @@ export class ChainBuilder {
     };
   }
 
-  async layerHash(step: number = Number.MAX_VALUE) {
+  async layerHashes(step: number = Number.MAX_VALUE) {
     // the purpose of this is to indicate the state of the chain without accounting for
     // derivative factors (ex. contract addreseses, outputs)
 
@@ -384,7 +473,13 @@ export class ChainBuilder {
       obj.push(await scriptSpec.getState(this.hre, this.ctx, d, this.getAuxilleryFilePath('scripts')));
     }
 
-    return crypto.createHash('md5').update(JSON.stringify(obj)).digest('hex');
+    return obj.map((v) => {
+      if (!v) {
+        return null;
+      } else {
+        return crypto.createHash('md5').update(JSON.stringify(v)).digest('hex');
+      }
+    });
   }
 
   clearCache() {
@@ -407,7 +502,13 @@ export class ChainBuilder {
 
     const cacheData = await fs.readFile(chain);
 
-    this.ctx = JSON.parse((await fs.readFile(metadata)).toString('utf8')) as ChainBuilderContext;
+    const contents = JSON.parse((await fs.readFile(metadata)).toString('utf8'));
+
+    if (contents.version !== LAYER_VERSION) {
+      throw new Error('cannon file format not supported: ' + (contents.version || 1));
+    }
+
+    this.ctx = contents.ctx;
 
     await persistableNode.loadState(this.hre, cacheData);
   }
@@ -419,14 +520,23 @@ export class ChainBuilder {
       return; // never save state outside of repository build
     }
 
-    const data = await persistableNode.dumpState(this.hre);
-
     debug('put cache', n);
 
-    await fs.ensureDir(dirname(chain));
-    await fs.writeFile(chain, data);
     await fs.ensureDir(dirname(metadata));
-    await fs.writeFile(metadata, JSON.stringify(this.ctx));
+    await fs.writeFile(
+      metadata,
+      JSON.stringify({
+        version: LAYER_VERSION,
+        hash: await this.layerHashes(n),
+        ctx: this.ctx,
+      })
+    );
+
+    if (this.hre.network.name === 'hardhat') {
+      const data = await persistableNode.dumpState(this.hre);
+      await fs.ensureDir(dirname(chain));
+      await fs.writeFile(chain, data);
+    }
   }
 
   async writeCannonfile() {

--- a/packages/hardhat-cannon/src/builder/keeper.ts
+++ b/packages/hardhat-cannon/src/builder/keeper.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { JTDDataType } from 'ajv/dist/core';
 
-import { ChainBuilderContext } from './';
+import { ChainBuilderContext } from './types';
 import { ChainDefinitionScriptSchema } from './util';
 
 export type Config = JTDDataType<typeof ChainDefinitionScriptSchema>;

--- a/packages/hardhat-cannon/src/builder/run.ts
+++ b/packages/hardhat-cannon/src/builder/run.ts
@@ -4,7 +4,7 @@ import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { JTDDataType } from 'ajv/dist/core';
 import { dirname, join } from 'path';
 
-import { ChainBuilderContext, InternalOutputs } from './';
+import { ChainBuilderContext, InternalOutputs } from './types';
 import { hashDirectory } from './util';
 
 const debug = Debug('cannon:builder:run');
@@ -23,10 +23,6 @@ const config = {
 } as const;
 
 export type Config = JTDDataType<typeof config>;
-
-export interface RunOutputs {
-  [key: string]: string;
-}
 
 // ensure the specified contract is already deployed
 // if not deployed, deploy the specified hardhat contract with specfied options, export address, abi, etc.
@@ -81,7 +77,7 @@ export default {
     return config;
   },
 
-  async exec(hre: HardhatRuntimeEnvironment, config: Config): Promise<InternalOutputs<RunOutputs>> {
+  async exec(hre: HardhatRuntimeEnvironment, _ctx: ChainBuilderContext, config: Config): Promise<InternalOutputs> {
     debug('exec', config);
 
     const runfile = await import(join(dirname(hre.config.paths.configFile), config.exec));

--- a/packages/hardhat-cannon/src/builder/run.ts
+++ b/packages/hardhat-cannon/src/builder/run.ts
@@ -4,7 +4,8 @@ import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { JTDDataType } from 'ajv/dist/core';
 import { dirname, join } from 'path';
 
-import { ChainBuilderContext } from './';
+import { ChainBuilderContext, InternalOutputs } from './';
+import { hashDirectory } from './util';
 
 const debug = Debug('cannon:builder:run');
 
@@ -12,6 +13,7 @@ const config = {
   properties: {
     exec: { type: 'string' },
     func: { type: 'string' },
+    modified: { elements: { type: 'string' } },
   },
   optionalProperties: {
     args: { elements: { type: 'string' } },
@@ -22,7 +24,7 @@ const config = {
 
 export type Config = JTDDataType<typeof config>;
 
-export interface Outputs {
+export interface RunOutputs {
   [key: string]: string;
 }
 
@@ -38,13 +40,31 @@ export default {
     config: Config,
     storage: string // eslint-disable-line @typescript-eslint/no-unused-vars
   ) {
-    return this.configInject(ctx, config);
+    if (ctx.repositoryBuild) {
+      return null; // skip consistency check
+      // todo: might want to do consistency check for config but not files, will see
+    }
+
+    const newConfig = this.configInject(ctx, config);
+
+    const auxHashes = newConfig.modified.map((pathToScan) => {
+      return hashDirectory(pathToScan).toString('hex');
+    });
+
+    return {
+      auxHashes,
+      config: newConfig,
+    };
   },
 
   configInject(ctx: ChainBuilderContext, config: Config) {
     config = _.cloneDeep(config);
 
     config.exec = _.template(config.exec)(ctx);
+
+    config.modified = _.map(config.modified, (v) => {
+      return _.template(v)(ctx);
+    });
 
     if (config.args) {
       config.args = _.map(config.args, (v) => {
@@ -61,11 +81,19 @@ export default {
     return config;
   },
 
-  async exec(hre: HardhatRuntimeEnvironment, config: Config): Promise<Outputs> {
+  async exec(hre: HardhatRuntimeEnvironment, config: Config): Promise<InternalOutputs<RunOutputs>> {
     debug('exec', config);
 
     const runfile = await import(join(dirname(hre.config.paths.configFile), config.exec));
 
-    return await runfile[config.func](...(config.args || []));
+    const outputs = await runfile[config.func](...(config.args || []));
+
+    if (!outputs.contracts) {
+      throw new Error(
+        'contracts not returned from script. Please supply any deployed contract in contracts property of returned json. If no contracts were deployed, return an empty object.'
+      );
+    }
+
+    return outputs;
   },
 };

--- a/packages/hardhat-cannon/src/builder/types.ts
+++ b/packages/hardhat-cannon/src/builder/types.ts
@@ -1,0 +1,91 @@
+import Ajv from 'ajv/dist/jtd';
+import { JTDDataType } from 'ajv/dist/core';
+
+import contractSpec from './contract';
+import importSpec from './import';
+import invokeSpec from './invoke';
+import keeperSpec from './keeper';
+import scriptSpec from './run';
+
+const ajv = new Ajv();
+
+export type OptionTypesTs = string | number | boolean;
+
+export type ContractMap = {
+  [label: string]: {
+    address: string;
+    abi: any[];
+    deployTxnHash: string;
+  };
+};
+
+export type TransactionMap = {
+  [label: string]: {
+    hash: string;
+    events: EventMap;
+  };
+};
+
+export type EventMap = {
+  [name: string]: {
+    args: string[];
+  }[];
+};
+
+const ChainDefinitionSchema = {
+  properties: {
+    name: { type: 'string' },
+    version: { type: 'string' },
+  },
+  optionalProperties: {
+    description: { type: 'string' },
+    tags: { elements: { type: 'string' } },
+    setting: {
+      values: {
+        optionalProperties: {
+          type: { enum: ['number', 'string', 'boolean'] },
+          defaultValue: {},
+        },
+      },
+    },
+    import: { values: importSpec.validate },
+    contract: { values: contractSpec.validate },
+    invoke: { values: invokeSpec.validate },
+    run: { values: scriptSpec.validate },
+    keeper: { values: keeperSpec.validate },
+  },
+} as const;
+
+export type ChainDefinition = JTDDataType<typeof ChainDefinitionSchema>;
+
+export type BuildOptions = { [val: string]: string };
+
+export const validateChainDefinition = ajv.compile(ChainDefinitionSchema);
+
+export interface ChainBuilderContext {
+  fork: boolean;
+  settings: ChainBuilderOptions;
+  network: string;
+  chainId: number;
+  timestamp: string;
+
+  repositoryBuild: boolean;
+
+  package: any;
+
+  contracts: ContractMap;
+
+  txns: TransactionMap;
+
+  imports: BundledChainBuilderOutputs;
+}
+
+export interface BundledChainBuilderOutputs {
+  [module: string]: InternalOutputs;
+}
+
+export type InternalOutputs = Partial<Pick<ChainBuilderContext, 'imports' | 'contracts' | 'txns'>>;
+
+export interface ChainBuilderOptions {
+  [key: string]: OptionTypesTs;
+}

--- a/packages/hardhat-cannon/src/internal/load-cannonfile.ts
+++ b/packages/hardhat-cannon/src/internal/load-cannonfile.ts
@@ -4,6 +4,7 @@ import toml from '@iarna/toml';
 import { HardhatPluginError } from 'hardhat/plugins';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { ethers } from 'ethers';
+import { validateChainDefinition } from '../builder';
 
 export default function loadCannonfile(hre: HardhatRuntimeEnvironment, filepath: string) {
   if (!fs.existsSync(filepath)) {
@@ -41,6 +42,16 @@ export default function loadCannonfile(hre: HardhatRuntimeEnvironment, filepath:
     let msg = 'Invalid "version" property on cannonfile.toml. ';
     if (err instanceof Error) msg += err.message;
     throw new Error(msg);
+  }
+
+  if(!validateChainDefinition(def)) {
+    console.error('cannonfile failed parse:');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    for (const error of validateChainDefinition.errors || []) {
+      console.log(`> at .${error.schemaPath}: ${error.message} (${JSON.stringify(error.params)})`);
+    }
+
+    throw new Error('failed to parse cannonfile');
   }
 
   return def as any;

--- a/packages/hardhat-cannon/src/internal/load-cannonfile.ts
+++ b/packages/hardhat-cannon/src/internal/load-cannonfile.ts
@@ -44,7 +44,7 @@ export default function loadCannonfile(hre: HardhatRuntimeEnvironment, filepath:
     throw new Error(msg);
   }
 
-  if(!validateChainDefinition(def)) {
+  if (!validateChainDefinition(def)) {
     console.error('cannonfile failed parse:');
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     for (const error of validateChainDefinition.errors || []) {

--- a/packages/hardhat-cannon/src/printer.ts
+++ b/packages/hardhat-cannon/src/printer.ts
@@ -1,56 +1,32 @@
 import _ from 'lodash';
 import { table } from 'table';
 
-import { BundledChainBuilderOutputs, ChainBuilderOutputs } from './builder';
+import { ChainBuilderContext } from './builder/types';
 
-export function printBundledChainBuilderOutput(output: BundledChainBuilderOutputs) {
-  printChainBuilderOutput(output.self);
-
-  console.log('====');
-
-  for (const k in output) {
-    if (k == 'self') {
-      continue;
-    }
-
-    console.log(`PACKAGE: ${k}`);
-    printChainBuilderOutput(output[k]);
-    console.log('====');
-  }
-}
-
-function printChainBuilderOutput(output: ChainBuilderOutputs) {
+export function printChainBuilderOutput(output: ChainBuilderContext) {
   if (output.contracts) {
     const formattedData = _.map(output.contracts, (v, k) => [k, v.address]);
 
-    console.log('CONTRACTS:');
-    console.log(table(formattedData));
+    if (formattedData.length) {
+      console.log('CONTRACTS:');
+      console.log(table(formattedData));
+    }
   }
 
-  if (output.runs) {
-    const formattedData = _.sortBy(
-      _.flatten(
-        _.map(output.runs, (v, runName) => {
-          // prevent extremely long values from clogging the terminal
-          const neatValues = _.map(v, (v, k) => [`${runName}.${k}`, `${ellipsize(v.toString(), 70)}`]);
+  if (output.txns) {
+    const formattedData = _.map(output.txns, (v, k) => [k, v.hash]);
 
-          return neatValues;
-        })
-      ),
-      '0'
-    );
-
-    if (formattedData.length > 0) {
-      console.log('RUN OUTPUTS:');
+    if (formattedData.length) {
+      console.log('TRANSACTIONS:');
       console.log(table(formattedData));
     }
   }
 }
 
-function ellipsize(str: string, maxLength: number, ellipsizeText = '...') {
+/*function ellipsize(str: string, maxLength: number, ellipsizeText = '...') {
   if (str.length > maxLength) {
     return str.substr(0, maxLength - ellipsizeText.length) + ellipsizeText;
   }
 
   return str;
-}
+}*/

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -5,8 +5,8 @@ import { TASK_COMPILE } from 'hardhat/builtin-tasks/task-names';
 
 import loadCannonfile from '../internal/load-cannonfile';
 import { ChainBuilder } from '../builder';
-import { SUBTASK_DOWNLOAD, TASK_BUILD } from '../task-names';
-import { printBundledChainBuilderOutput } from '../printer';
+import { SUBTASK_DOWNLOAD, SUBTASK_WRITE_DEPLOYMENTS, TASK_BUILD } from '../task-names';
+import { printChainBuilderOutput } from '../printer';
 
 task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can be used later')
   .addFlag('noCompile', 'Do not execute hardhat compile before build')
@@ -36,7 +36,11 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
 
     await builder.build(mappedOptions);
 
-    printBundledChainBuilderOutput(builder.getOutputs());
+    printChainBuilderOutput(builder.getOutputs());
+
+    await hre.run(SUBTASK_WRITE_DEPLOYMENTS, {
+      outputs: builder.getOutputs(),
+    });
 
     return {
       filepath,

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -1,49 +1,94 @@
 import _ from 'lodash';
 import path from 'path';
-import { task } from 'hardhat/config';
-import { TASK_COMPILE } from 'hardhat/builtin-tasks/task-names';
+import { subtask, task, types } from 'hardhat/config';
+import { TASK_COMPILE, TASK_NODE_SERVER_READY } from 'hardhat/builtin-tasks/task-names';
 
 import loadCannonfile from '../internal/load-cannonfile';
-import { ChainBuilder } from '../builder';
+import { ChainBuilder, StorageMode } from '../builder';
 import { SUBTASK_DOWNLOAD, SUBTASK_WRITE_DEPLOYMENTS, TASK_BUILD } from '../task-names';
 import { printChainBuilderOutput } from '../printer';
+import { HardhatRuntimeEnvironment, HttpNetworkConfig } from 'hardhat/types';
 
 task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can be used later')
   .addFlag('noCompile', 'Do not execute hardhat compile before build')
   .addOptionalParam('file', 'TOML definition of the chain to assemble', 'cannonfile.toml')
+  .addOptionalParam(
+    'dryRun',
+    'When deploying to a live network, instead deploy and start a local hardhat node. Specify the target network here',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'port',
+    'If declared, keep running with hardhat network exposed to the specified local port',
+    undefined,
+    types.int
+  )
   .addOptionalVariadicPositionalParam('options', 'Key values of chain which should be built')
-  .setAction(async ({ noCompile, file, options }, hre) => {
+  .setAction(async ({ noCompile, file, options, dryRun, port }, hre) => {
     if (!noCompile) {
       await hre.run(TASK_COMPILE);
     }
 
-    const filepath = path.resolve(hre.config.paths.root, file);
+    const storageMode: StorageMode = !dryRun && hre.network.name === 'hardhat' ? 'full' : dryRun ? 'none' : 'metadata';
 
-    console.log('Building cannonfile: ', path.relative(process.cwd(), filepath));
+    subtask(TASK_NODE_SERVER_READY).setAction(async (_, hre) => {
+      await buildCannon(hre, options, file, storageMode);
 
-    const def = loadCannonfile(hre, filepath);
-    const { name, version } = def;
-
-    const builder = new ChainBuilder({ name, version, hre, def });
-    const dependencies = builder.getDependencies();
-
-    if (dependencies.length > 0) {
-      await hre.run(SUBTASK_DOWNLOAD, { images: dependencies });
-    }
-
-    // options can be passed through commandline, or environment
-    const mappedOptions: { [key: string]: string } = _.fromPairs((options || []).map((kv: string) => kv.split('=')));
-
-    await builder.build(mappedOptions);
-
-    printChainBuilderOutput(builder.getOutputs());
-
-    await hre.run(SUBTASK_WRITE_DEPLOYMENTS, {
-      outputs: builder.getOutputs(),
+      console.log('build complete. rpc now available on port', port);
     });
 
-    return {
-      filepath,
-      builder,
-    };
+    if (dryRun) {
+      if (hre.network.name != 'hardhat') throw new Error('Hardhat selected network must be `hardhat` in order to dryRun.');
+
+      const network = hre.config.networks[dryRun] as HttpNetworkConfig;
+
+      if (!network) throw new Error('Selected dryRun network not found in hardhat configuration');
+
+      if (!network.chainId) throw new Error('Selected network must have chainId set in hardhat configuration');
+
+      hre.config.networks.hardhat.forking = {
+        enabled: true,
+        url: network.url,
+      };
+
+      // TODO: would be better to pass this as an option for the builder rather than messing with hh config here
+      hre.config.networks.hardhat.chainId = network.chainId;
+    }
+
+    if (port) {
+      // ensure forking configuration is set and ready
+      await hre.run('node', { port });
+    } else {
+      await buildCannon(hre, options, file, storageMode);
+    }
+
+    return {};
   });
+
+async function buildCannon(hre: HardhatRuntimeEnvironment, options: string[], file: string, storageMode: StorageMode) {
+  const filepath = path.resolve(hre.config.paths.root, file);
+
+  console.log('Building cannonfile: ', path.relative(process.cwd(), filepath));
+
+  const def = loadCannonfile(hre, filepath);
+  const { name, version } = def;
+
+  const builder = new ChainBuilder({ name, version, hre, def, storageMode });
+  const dependencies = builder.getDependencies();
+
+  if (dependencies.length > 0) {
+    await hre.run(SUBTASK_DOWNLOAD, { images: dependencies });
+  }
+
+  // options can be passed through commandline, or environment
+  const mappedOptions: { [key: string]: string } = _.fromPairs((options || []).map((kv: string) => kv.split('=')));
+
+  await builder.build(mappedOptions);
+
+  printChainBuilderOutput(builder.getOutputs());
+
+  await hre.run(SUBTASK_WRITE_DEPLOYMENTS, {
+    outputs: builder.getOutputs(),
+  });
+}

--- a/packages/sample-project/cannonfile.consumer.toml
+++ b/packages/sample-project/cannonfile.consumer.toml
@@ -8,17 +8,14 @@ defaultValue = "new greeting!"
 
 [import.greeters]
 source = "greeter:<%= package.version %>"
-options.salt = "first"
-options.change_msg = "a message from first greeter set"
 
 [import.more_greeters]
 source = "greeter:<%= package.version %>"
 options.salt = "second"
-options.change_msg = "a message from second greeter set"
+options.msg = "a message from second greeter set"
 
 [invoke.change_greeting2]
-addresses = ["<%= outputs.greeters.contracts.greeter.address %>"]
-abi = "<%= outputs.greeters.contracts.greeter.abi %>"
+on = ["greeters.greeter"]
 func = "setGreeting"
 args = ["<%= settings.change_greeting2 %>"]
 step = 1

--- a/packages/sample-project/cannonfile.toml
+++ b/packages/sample-project/cannonfile.toml
@@ -14,9 +14,7 @@ artifact = "Library"
 [contract.greeter]
 artifact = "Greeter"
 args = ["<%= settings.msg %>"]
-libraries.Library = ["<%= outputs.self.contracts.library.address %>"]
+libraries.Library = "<%= contracts.library.address %>"
 salt = "<%= settings.salt %>"
-detect.method = "folder"
-detect.path = "deployments/${network}"
 
 step = 1

--- a/packages/sample-project/hardhat.config.ts
+++ b/packages/sample-project/hardhat.config.ts
@@ -44,6 +44,10 @@ const config: HardhatUserConfig = {
       chainId: 4,
       accounts: [process.env.PRIVATE_KEY || ''],
     },
+    mainnet: {
+      url: process.env.PROVIDER_URL || `https://mainnet.infura.io/v3/${process.env.INFURA_KEY}`,
+      chainId: 1,
+    },
   },
   gasReporter: {
     enabled: process.env.REPORT_GAS !== undefined,

--- a/packages/sample-project/hardhat.config.ts
+++ b/packages/sample-project/hardhat.config.ts
@@ -37,12 +37,12 @@ const config: HardhatUserConfig = {
     ropsten: {
       url: process.env.PROVIDER_URL || `https://ropsten.infura.io/v3/${process.env.INFURA_KEY}`,
       chainId: 3,
-      accounts: [process.env.PRIVATE_KEY || ''],
+      accounts: process.env.PRIVATE_KEY?.split(','),
     },
     rinkeby: {
       url: process.env.PROVIDER_URL || `https://rinkeby.infura.io/v3/${process.env.INFURA_KEY}`,
       chainId: 4,
-      accounts: [process.env.PRIVATE_KEY || ''],
+      accounts: process.env.PRIVATE_KEY?.split(','),
     },
     mainnet: {
       url: process.env.PROVIDER_URL || `https://mainnet.infura.io/v3/${process.env.INFURA_KEY}`,

--- a/packages/sample-project/hardhat.config.ts
+++ b/packages/sample-project/hardhat.config.ts
@@ -5,6 +5,8 @@ import 'hardhat-gas-reporter';
 import 'solidity-coverage';
 import '@nomiclabs/hardhat-ethers';
 
+import 'hardhat-interact';
+
 import '../hardhat-cannon/src/index';
 
 import * as dotenv from 'dotenv';
@@ -25,8 +27,22 @@ task('accounts', 'Prints the list of accounts', async (taskArgs, hre) => {
 const config: HardhatUserConfig = {
   solidity: '0.8.4',
   networks: {
+    hardhat: {
+      chainId: 31338,
+    },
     local: {
       url: 'http://127.0.0.1:8545/',
+      chainId: 31338,
+    },
+    ropsten: {
+      url: process.env.PROVIDER_URL || `https://ropsten.infura.io/v3/${process.env.INFURA_KEY}`,
+      chainId: 3,
+      accounts: [process.env.PRIVATE_KEY || ''],
+    },
+    rinkeby: {
+      url: process.env.PROVIDER_URL || `https://rinkeby.infura.io/v3/${process.env.INFURA_KEY}`,
+      chainId: 4,
+      accounts: [process.env.PRIVATE_KEY || ''],
     },
   },
   gasReporter: {

--- a/packages/website/content/docs.md
+++ b/packages/website/content/docs.md
@@ -127,14 +127,29 @@ See [cannonfile.toml Specification](#cannonfiletoml-specification) for more deta
 
 ## Deploy to Production
 
-**Coming soon**
+Cannon uses Hardhat's internal network to load settings required to deploy to your desired network. At minimum, you must supply:
+* JSON-RPC URL which can receive submitted transactions for the network
+* Signer . To submit transactions to this network, you will need to 
 
-Make sure `detect` is set in `cannonfile.toml` for all your on-chain dependencies.
+When everything is ready, you can deploy to a live network:
 
-Then run
 ```bash
 npx hardhat --network <network name> cannon:build
 ```
+
+Artifacts for your deployment will be written to `deployments`, and if you choose to publish your package (see below),
+it will be 
+
+### Test Deployment on a Fork
+
+You can verify the steps cannon would take when deploying to a live network. No "fake" signers are required.
+Just run the build command:
+
+```
+npx hardhat --network <network name> cannon:build --dry-run --run 8545
+```
+
+After the run is complete, a forked `hardhat` remains running on the port specified above, so you can run on-chain tests in a separate terminal.
 
 ## Publish a Package
 
@@ -206,6 +221,7 @@ The `import` action allows for composability by letting you specify another cann
 * `source` - The name of the package to import
 
 **Optional Inputs**
+* `chainId` - Override network to load contract/txn configurations for. Useful for cross-chain contract configuration.
 * `options` - The options to be used when initializing this cannonfile
 
 **Outputs**
@@ -215,8 +231,11 @@ The outputs of the imported cannonfile are provided under the namespace of the i
 
 The `invoke` action calls a specified function on-chain.
 
+In addition to required inputs below, of these 2 inputs must be provided:
+* `on` - List of names for previously deployed contracts to invoke. If contract is within a `import`ed module, it can be referenced using dot notion (i.e. a module imported earlier like `[import.fun]` could call a function using `fun.mycontract`) Cannot be used with `addresses`
+* `addresses` - List of addresses for which the same call should be executed. Cannot be used with `on`
+
 **Required Inputs**
-* `addresses` - List of all addresses for which the same call should be executed
 * `abi` - The ABI of the contract to call
 * `func` - The name of the function to call
 


### PR DESCRIPTION
Fundamentally, this adds capabilities to deploy to JSONRPC which are unable to dump the hardhat network state. This includes forks, livenets, and alternative test engines.

Some overhauls which have been required:
* not dumping state when connected to non-hardhat network
* recording contracts in a more repeatable format for loading and deploy
* splitting deployment context and artifacts by network
* removing hashing system used later for detecting duplicate deployments
* using signer from hardhat 

still needs to be done:
* tests on forks
* some fixes for `imports`
* cleanup of some of the terrible code things that have happened to the submodules in the chain builder