### PR TITLE
add etherscan verification

### DIFF
--- a/packages/hardhat-cannon/package.json
+++ b/packages/hardhat-cannon/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",
+    "@nomiclabs/hardhat-etherscan": "^3.0.0",
     "hardhat": "^2.0.0"
   },
   "dependencies": {

--- a/packages/hardhat-cannon/src/builder/contract.ts
+++ b/packages/hardhat-cannon/src/builder/contract.ts
@@ -159,6 +159,7 @@ export default {
         [selfLabel]: {
           address: receipt.contractAddress,
           abi: JSON.parse(factory.interface.format(hre.ethers.utils.FormatTypes.json) as string),
+          constructorArgs: config.args || [],
           deployTxnHash: receipt.transactionHash,
         },
       },

--- a/packages/hardhat-cannon/src/builder/invoke.ts
+++ b/packages/hardhat-cannon/src/builder/invoke.ts
@@ -14,8 +14,7 @@ const config = {
     func: { type: 'string' },
   },
   optionalProperties: {
-    on: { elements: { type: 'string' } },
-    addresses: { elements: { type: 'string' } },
+    target: { elements: { type: 'string' } },
     abi: { type: 'string' },
 
     args: { elements: {} },
@@ -29,12 +28,14 @@ const config = {
       },
     },
     factory: {
-      elements: {
+      values: {
         properties: {
-          name: { type: 'string' },
           event: { type: 'string' },
           arg: { type: 'int32' },
           artifact: { type: 'string' },
+        },
+        optionalProperties: {
+          constructorArgs: { elements: {} },
         },
       },
     },
@@ -115,12 +116,8 @@ export default {
   configInject(ctx: ChainBuilderContext, config: Config) {
     config = _.cloneDeep(config);
 
-    if (config.on) {
-      config.on = config.on.map((a) => _.template(a)(ctx));
-    }
-
-    if (config.addresses) {
-      config.addresses = config.addresses.map((a) => _.template(a)(ctx));
+    if (config.target) {
+      config.target = config.target.map((v) => _.template(v)(ctx));
     }
 
     if (config.abi) {
@@ -146,15 +143,11 @@ export default {
       });
     }
 
-    if (config.factory) {
-      config.factory = config.factory.map((f) => {
-        return {
-          name: _.template(f.name)(ctx),
-          event: _.template(f.event)(ctx),
-          arg: f.arg, //_.template(f.arg)(ctx),
-          artifact: _.template(f.artifact)(ctx),
-        };
-      });
+    for (const name in config.factory) {
+      const f = config.factory[name];
+
+      f.event = _.template(f.event)(ctx);
+      f.artifact = _.template(f.artifact)(ctx);
     }
 
     return config;
@@ -173,31 +166,27 @@ export default {
 
     const mainSigner = config.from ? await initializeSigner(hre, config.from) : await getExecutionSigner(hre, '', ctx.fork);
 
-    for (const contractOn of config.on || []) {
-      const contract = getContractFromPath(ctx, contractOn);
+    for (const t of config.target || []) {
+      let contract: ethers.Contract | null;
+      if (ethers.utils.isAddress(t)) {
+        if (!config.abi) {
+          throw new Error('abi must be defined if addresses is used for target');
+        }
+
+        contract = new hre.ethers.Contract(t, JSON.parse(config.abi));
+      } else {
+        contract = getContractFromPath(ctx, t);
+      }
 
       if (!contract) {
-        throw new Error(`field on: contract at path ${contractOn} not found. Please double check input and try again!`);
+        throw new Error(`field on: contract with identifier '${t}' not found. The valid list of recognized contracts is:`);
       }
 
       const [receipt, txnEvents] = await runTxn(hre, config, contract, mainSigner);
 
-      txns[`${selfLabel}_${contractOn}`] = {
-        hash: receipt.transactionHash,
-        events: txnEvents,
-      };
-    }
+      const label = config.target?.length === 1 ? selfLabel : `${selfLabel}_${t}`;
 
-    for (const address of config.addresses || []) {
-      if (!config.abi) {
-        throw new Error('abi must be defined if addresses is defined');
-      }
-
-      const contract = new hre.ethers.Contract(address, JSON.parse(config.abi));
-
-      const [receipt, txnEvents] = await runTxn(hre, config, contract, mainSigner);
-
-      txns[`${selfLabel}_${address}`] = {
+      txns[label] = {
         hash: receipt.transactionHash,
         events: txnEvents,
       };
@@ -207,20 +196,32 @@ export default {
 
     if (config.factory) {
       for (const n in txns) {
-        for (const factory of config.factory) {
+        for (const [name, factory] of Object.entries(config.factory)) {
           const abi = (await hre.artifacts.readArtifact(factory.artifact)).abi;
 
-          for (const [i, e] of _.entries(txns[n].events[factory.event])) {
+          const events = _.entries(txns[n].events[factory.event]);
+          for (const [i, e] of events) {
             const addr = e.args[factory.arg];
 
             if (!addr) {
               throw new Error(`address was not resolvable in ${factory.event}. Ensure "arg" parameter is correct`);
             }
 
-            contracts[`${factory.name}.${n}.${i}`] = {
+            let label = name;
+
+            if ((config.target || []).length > 1) {
+              label += '_' + n;
+            }
+
+            if (events.length > 1) {
+              label += '_' + i;
+            }
+
+            contracts[label] = {
               address: addr,
               abi: abi,
               deployTxnHash: txns[n].hash,
+              constructorArgs: factory.constructorArgs,
             };
           }
         }

--- a/packages/hardhat-cannon/src/builder/types.ts
+++ b/packages/hardhat-cannon/src/builder/types.ts
@@ -15,6 +15,7 @@ export type ContractMap = {
   [label: string]: {
     address: string;
     abi: any[];
+    constructorArgs?: any[]; // only needed for etherscan verification
     deployTxnHash: string;
   };
 };

--- a/packages/hardhat-cannon/src/index.ts
+++ b/packages/hardhat-cannon/src/index.ts
@@ -3,6 +3,7 @@ import '@nomiclabs/hardhat-ethers';
 
 import './tasks/cannon';
 import './tasks/build';
+import './tasks/verify';
 import './tasks/publish';
 import './tasks/import';
 import './tasks/export';

--- a/packages/hardhat-cannon/src/task-names.ts
+++ b/packages/hardhat-cannon/src/task-names.ts
@@ -3,6 +3,7 @@ export const TASK_PREFIX = 'cannon';
 export const TASK_CANNON = TASK_PREFIX;
 export const TASK_BUILD = `${TASK_PREFIX}:build`;
 export const TASK_PUBLISH = `${TASK_PREFIX}:publish`;
+export const TASK_VERIFY = `${TASK_PREFIX}:verify`;
 export const TASK_IMPORT = `${TASK_PREFIX}:import`;
 export const TASK_EXPORT = `${TASK_PREFIX}:export`;
 

--- a/packages/hardhat-cannon/src/tasks/verify.ts
+++ b/packages/hardhat-cannon/src/tasks/verify.ts
@@ -1,0 +1,46 @@
+import _ from 'lodash';
+import { task } from 'hardhat/config';
+
+import { TASK_VERIFY } from '../task-names';
+import { ChainBuilder } from '../builder';
+import loadCannonfile from '../internal/load-cannonfile';
+
+task(TASK_VERIFY, 'Run etherscan verification on a cannon deployment sent to mainnet')
+  .addOptionalPositionalParam('label', 'Label of a built cannon chain to verify on Etherscan')
+  .addOptionalVariadicPositionalParam('opts', 'Settings used for execution', [])
+  .setAction(async ({ label, opts }, hre) => {
+    if (!label) {
+      // load from base cannonfile
+      const def = loadCannonfile(hre, hre.config.paths.root + '/cannonfile.toml');
+      label = `${def.name}:${def.version}`;
+    }
+
+    console.log('Verifying cannon deployment', label);
+
+    const [name, version] = label.split(':');
+
+    // get the list of all deployed contracts
+    const builder = new ChainBuilder({ name, version, hre, storageMode: 'none' });
+
+    // TODO: prevent builder from taking any action here, it should
+    // only be loading and validating everything
+    const options: any = _.fromPairs(opts.map((o: string) => o.split('=')));
+    await builder.build(options);
+    const outputs = builder.getOutputs();
+
+    for (const c in outputs.contracts) {
+      console.log('Verifying contract:', c);
+      try {
+        await hre.run('verify:verify', {
+          address: outputs.contracts[c].address,
+          constructorArguments: outputs.contracts[c].constructorArgs || [],
+        });
+      } catch (err) {
+        if ((err as Error).message.includes('already verified')) {
+          console.log('Already verified');
+        } else {
+          throw err;
+        }
+      }
+    }
+  });

--- a/packages/sample-project/cannonfile.consumer.toml
+++ b/packages/sample-project/cannonfile.consumer.toml
@@ -15,19 +15,17 @@ options.salt = "second"
 options.msg = "a message from second greeter set"
 
 [invoke.change_greeting2]
-on = ["greeters.greeter"]
+target = ["greeters.greeter"]
 func = "setGreeting"
 args = ["<%= settings.change_greeting2 %>"]
 step = 1
 
 # test for factory functionality
 [invoke.clone]
-on = ["greeters.greeter"]
+target = ["greeters.greeter"]
 func = "doCloning"
 step = 1
 
-[[invoke.clone.factory]]
-name = "cloned"
-event = "NewClonedGreeter"
-arg = 0
-artifact = "Greeter"
+factory.cloned.event = "NewClonedGreeter"
+factory.cloned.arg = 0
+factory.cloned.artifact = "Greeter"


### PR DESCRIPTION
after running a deployment on a live network, user can run `npx hardhat --network <whatever> cannon:verify` to automatically
verify all contracts deployed by cannon.

also some updates on `invoke`, now it write dependencies to be much more clean for most circumstances. See documentation
updates for details