### PR TITLE
Guides, etc.

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -136,7 +136,7 @@ program
   .option('-h --host <name>', 'Host which the JSON-RPC server will be exposed')
   .option('-p --port <number>', 'Port which the JSON-RPC server will be exposed')
   .option('-f --fork <url>', 'Fork the network at the specified RPC url')
-  .option('--logs', 'Show RPC logs instead of interact prompt. If unspecified, defaults to terminal interactability.')
+  .option('--logs', 'Show RPC logs instead of interact prompt. If unspecified, defaults to an interactive terminal.')
   .option('--preset <name>', 'Load an alternate setting preset (default: main)')
   .option('--write-deployments <path>', 'Path to write the deployments data (address and ABIs)')
   .option('-e --exit', 'Exit after building')
@@ -199,7 +199,9 @@ async function run() {
     const chunk = rawChunk.toString('utf8');
     let newData = chunk
       .split('\n')
-      .map((m: string) => 'anvil: ' + m)
+      .map((m: string) => {
+        return gray('anvil: ') + m;
+      })
       .join('\n');
     if (showAnvilLogs) {
       console.log(newData);
@@ -316,6 +318,7 @@ async function run() {
             }
           } else {
             console.log(gray('Paused anvil logs...'));
+            console.log(INSTRUCTIONS);
           }
         } else if (str === 'i' && !interacting) {
           // Enter the interact tool when the user presses "i"

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -19,7 +19,6 @@ const config: HardhatUserConfig = {
     },
   },
   cannon: {
-    publisherPrivateKey: process.env.PRIVATE_KEY,
     ipfsConnection: {
       protocol: 'https',
       host: 'ipfs.infura.io',

--- a/packages/hardhat-cannon/src/index.ts
+++ b/packages/hardhat-cannon/src/index.ts
@@ -27,11 +27,9 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
     : getSavedPackagesDir();
 
   config.cannon = {
-    registryEndpoint: userConfig.cannon?.registryEndpoint || 'https://mainnet.infura.io/v3/2ec6e503197e468ca2f04b8a017ee1b0',
+    registryEndpoint: userConfig.cannon?.registryEndpoint || 'https://cloudflare-eth.com/v1/mainnet',
 
     registryAddress: userConfig.cannon?.registryAddress || '0xA98BE35415Dd28458DA4c1C034056766cbcaf642',
-
-    publisherPrivateKey: userConfig.cannon?.publisherPrivateKey,
 
     ipfsConnection: userConfig.cannon?.ipfsConnection || {
       url: 'https://usecannon.infura-ipfs.io',

--- a/packages/hardhat-cannon/src/tasks/publish.ts
+++ b/packages/hardhat-cannon/src/tasks/publish.ts
@@ -10,7 +10,8 @@ import prompts from 'prompts';
 task(TASK_PUBLISH, 'Provision and publish to the registry the current Cannonfile.toml')
   .addOptionalParam('file', 'TOML definition of the chain to assemble', 'cannonfile.toml')
   .addOptionalParam('tags', 'Comma separated list of labels for your package to be uploaded with.', 'latest')
-  .setAction(async ({ file, tags }, hre) => {
+  .addOptionalParam('registryAddress', 'Address for a custom package registry.')
+  .setAction(async ({ file, tags, registryAddress }, hre) => {
     await installAnvil();
 
     const filepath = path.resolve(hre.config.paths.root, file);
@@ -37,7 +38,7 @@ task(TASK_PUBLISH, 'Provision and publish to the registry the current Cannonfile
     const registry = new CannonRegistry({
       ipfsOptions: hre.config.cannon.ipfsConnection,
       signerOrProvider: signers[0],
-      address: hre.config.cannon.registryAddress,
+      address: registryAddress || hre.config.cannon.registryAddress,
     });
 
     const splitTags = tags.split(',');

--- a/packages/hardhat-cannon/src/type-extensions.ts
+++ b/packages/hardhat-cannon/src/type-extensions.ts
@@ -12,7 +12,6 @@ declare module 'hardhat/types/config' {
     cannon?: {
       registryEndpoint?: string;
       registryAddress?: string;
-      publisherPrivateKey?: string;
       ipfsConnection?: IPFSConnectionOptions;
     };
   }
@@ -26,7 +25,6 @@ declare module 'hardhat/types/config' {
     cannon: {
       registryEndpoint: string;
       registryAddress: string;
-      publisherPrivateKey?: string;
       ipfsConnection: IPFSConnectionOptions;
     };
   }

--- a/packages/registry/hardhat.config.ts
+++ b/packages/registry/hardhat.config.ts
@@ -29,7 +29,6 @@ const config: HardhatUserConfig = {
     apiKey: process.env.ETHERSCAN_API_KEY || '',
   },
   cannon: {
-    publisherPrivateKey: process.env.PRIVATE_KEY,
     ipfsConnection: {
       protocol: 'https',
       host: 'ipfs.infura.io',

--- a/packages/sample-project/hardhat.config.ts
+++ b/packages/sample-project/hardhat.config.ts
@@ -59,7 +59,6 @@ const config: HardhatUserConfig = {
     apiKey: process.env.ETHERSCAN_API_KEY,
   },
   cannon: {
-    publisherPrivateKey: process.env.PRIVATE_KEY,
     ipfsConnection: {
       protocol: 'https',
       host: 'ipfs.infura.io',

--- a/packages/website/content/docs.md
+++ b/packages/website/content/docs.md
@@ -422,7 +422,7 @@ npx hardhat cannon:build --network <network name> --dry-run --port <number>
 
 ### Deploy to a live network
 
-Then remove the --dry-run flag
+Then remove the `--dry-run` flag to actually deploy. This will use the account associated with the private key for the network you select in your `hardhat.config.js` file.
 
 ```bash
 npx hardhat cannon:build --network <network name>
@@ -440,7 +440,7 @@ npx hardhat cannon:verify --network <network name>
 
 ### Inspect your package
 
-Prior to publishing your package to a registry, inspect its contents with the following command. Your package contains information about your live network deployments which can be retrieved by the CLI when passing the `--write-deployments <path>` flag.
+Prior to publishing your package to a registry, inspect its contents with the following command. Your package contains information about your live network deployments which can be retrieved by the CLI when passing the `--write-deployments <path>` option.
 
 ```bash
 npx hardhat cannon:inspect

--- a/packages/website/content/docs.md
+++ b/packages/website/content/docs.md
@@ -172,7 +172,6 @@ Add this section to your `hardhat.config.json`:
 ```json
 {
   cannon: {
-    publisherPrivateKey: process.env.PRIVATE_KEY,
     ipfsConnection: {
       protocol: 'https',
       host: 'ipfs.infura.io',
@@ -351,16 +350,114 @@ This action updates the return object by merging the object returned from the sc
 
 ## Build a Protocol
 
-**Coming soon.** Set up a Hardhat project and Cannonfile for a contract that integrates with the Synthetix package.
+**Coming soon.**
+
+- Set up a Hardhat project
+- Write a contract and cannonfile that interacts with Synthetix
+- Deploy it connected to the live protocol
 
 ## Build a dApp
 
-**Coming soon.** Use the CLI to load the Synthetix package, export ABIs/addresses, and interact with the protocol using wagmi.sh.
+**Coming soon.**
+
+- Use the CLI to load the Synthetix package
+- Export ABIs/addresses
+- Interact with the protocol using wagmi.sh
 
 ## Build an e2e Test
 
-**Coming soon.** Use the CLI to load the Synthetix package, run a basic test (using Synpress), and integrate with a CI tool.
+**Coming soon.**
+
+- Use the CLI to load the Synthetix package
+- un a basic test using Synpress
+- Integrate with a CI tool
 
 ## Deploy a Protocol
 
-**Coming soon.** Set up a Cannonfile, configure your Hardhat project, do a dry run, deploy to testnet, deploy to mainnet, verify the contracts on Etherscan, and publish the package to the Cannon registry.
+For this guide, we’ll assume you have a Hardhat project with the `hardhat-cannon` plug-in installed and a `cannonfile.toml` that successfully builds when you call `npx hardhat cannon:build`.
+
+### Properly configure Hardhat
+
+To perform all of the tasks below, your `hardhat.config.js` should look something like this (with the proper values in your `.env` file):
+
+```json
+{
+  networks: {
+    rinkeby: {
+      url: process.env.RINKEBY_PROVIDER_URL
+      chainId: 4,
+      accounts: [process.env.PRIVATE_KEY],
+    },
+    mainnet: {
+      url: process.env.MAINNET_PROVIDER_URL
+      chainId: 1,
+      accounts: [process.env.PRIVATE_KEY],
+    }
+  },
+  cannon: {
+    ipfsConnection: {
+      protocol: 'https',
+      host: 'ipfs.infura.io',
+      port: 5001,
+      headers: {
+        authorization: `Basic ${Buffer.from(process.env.INFURA_IPFS_ID + ':' + process.env.INFURA_IPFS_SECRET).toString(
+          'base64'
+        )}`
+      }
+    }
+  },
+  etherscan: {
+    apiKey: process.env.ETHERSCAN_API_KEY,
+  }
+}
+```
+
+### Do a dry run
+
+You can verify the steps Cannon would take when deploying to a live network with the `--dry-run` flag. If you add the `--port` option, it will continue running at the specified port.
+
+```bash
+npx hardhat cannon:build --network <network name> --dry-run --port <number>
+```
+
+### Deploy to a live network
+
+Then remove the --dry-run flag
+
+```bash
+npx hardhat cannon:build --network <network name>
+```
+
+### Verify your contracts on Etherscan
+
+After deploying to a live network, you can use the `cannon:verify` command to verify all of the deployed contracts on [Etherscan](https://www.etherscan.com).
+
+First, install [hardhat-etherscan](https://hardhat.org/plugins/nomiclabs-hardhat-etherscan) in your project. Then run:
+
+```bash
+npx hardhat cannon:verify --network <network name>
+```
+
+### Inspect your package
+
+Prior to publishing your package to a registry, inspect its contents with the following command. Your package contains information about your live network deployments which can be retrieved by the CLI when passing the `--write-deployments <path>` flag.
+
+```bash
+npx hardhat cannon:inspect
+```
+
+### Publish your package to the registry
+
+You can push your package to the registry, backed on Ethereum and IPFS, so that others can run it with the CLI or import it into their own cannonfiles.
+
+This will use the account associated with the private key in the `networks.mainnet` section of your Hardhat configuration file to execute the `publish` function on [the registry](https://etherscan.io/address/0xA98BE35415Dd28458DA4c1C034056766cbcaf642) after uploading the package to IPFS.
+
+```bash
+npx hardhat cannon:publish --network mainnet
+```
+
+For unofficial releases, you can use other deployments of the [package registry](https://usecannon.com/packages/registry). We’ve deployed an instance on rinkeby that can be used with the following command:
+
+```bash
+npx hardhat cannon:publish --network rinkeby --registry-address 0x79E25D87432920FC5C187e14676FA6a8A8a00418
+```


### PR DESCRIPTION
- Main addition is the `--registry-address` option. Let's do a release after this is in.
- We're defaulting to the cloudflare rpc in the cli, so I switched it to this in the hardhat plug-in
- Wrote the deployments guide
- Removed `publisherPrivateKey`, doesn't seem to be used.
- Made the `anvil: ` part of the CLI output gray. It's still rendering twice sometimes, but didn't nail down why yet.