### PR TITLE
its important we store the exact same def which corresponded to the d…

### DIFF
--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -110,6 +110,10 @@ export interface ChainBuilderOptions {
 }
 
 export type DeploymentInfo = {
+  // contents of cannonfile.toml used for this build in raw json form
+  // if not included, defaults to the chain definition at the DeploymentManifest instead
+  def?: RawChainDefinition;
+
   // setting overrides used to build this chain
   options: ChainBuilderOptions;
 


### PR DESCRIPTION
…eployment

otherwise, it tries to rebuild the chain and this causes errors because the chain
state doesn't exactly match up with reality.

in the future we may want to find a better wya to store/connect to this, but for
now this will ensure the builds match up