### PR TITLE
hotfix: shouldn't use artifacts to resolve abi for contract

### DIFF
--- a/packages/builder/src/steps/contract.ts
+++ b/packages/builder/src/steps/contract.ts
@@ -5,6 +5,7 @@ import { JTDDataType } from 'ajv/dist/core';
 import { ethers } from 'ethers';
 
 import { ChainBuilderContext, ChainBuilderRuntime, ChainArtifacts } from '../types';
+import { getContractFromPath } from '../util';
 
 const debug = Debug('cannon:builder:contract');
 
@@ -124,7 +125,13 @@ export default {
 
     // override abi?
     if (config.abi) {
-      abi = (await runtime.getArtifact(config.abi)).abi;
+      const implContract = getContractFromPath(ctx, config.abi);
+
+      if (!implContract) {
+        throw new Error(`previously deployed contract with name ${config.abi} for abi not found`);
+      }
+
+      abi = implContract.abi;
     }
 
     debug('contract deployed to address', receipt.contractAddress);


### PR DESCRIPTION
this is because the usecase for this is deploying transparent proxies and the impl
contract should be visible in the deployed contracts. Also, the contract
may be deployed/generated by a run step and therefore is not a known artifact.