### PR TITLE
even better error handling, support for overriding hardhat config

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -27,6 +27,7 @@ const debug = Debug('cannon:builder');
 const BUILD_VERSION = 3;
 
 import {
+  CannonWrapperJsonRpcProvider,
   ChainArtifacts,
   clearDeploymentInfo,
   combineCtx,
@@ -56,7 +57,7 @@ export class ChainBuilder extends EventEmitter implements ChainBuilderRuntime {
   readonly preset: string;
 
   readonly chainId: number;
-  readonly provider: ethers.providers.JsonRpcProvider;
+  readonly provider: CannonWrapperJsonRpcProvider;
   readonly getSigner: (addr: string) => Promise<ethers.Signer>;
   readonly getDefaultSigner: (addr: ethers.providers.TransactionRequest, salt?: string) => Promise<ethers.Signer>;
   readonly getArtifact: (name: string) => Promise<ContractArtifact>;
@@ -140,15 +141,9 @@ export class ChainBuilder extends EventEmitter implements ChainBuilderRuntime {
 
     this.emit(Events.PreStepExecute, type, label, cfg);
 
-    let output: ChainArtifacts;
-    try {
-      output = await ActionKinds[type].exec(this, ctx, cfg as any);
-    } catch (err) {
-      handleTxnError(ctx, this.provider, err);
+    this.provider.artifacts = ctx;
 
-      // note: technically `handleTxnError` reverts so ctx is unset
-      return ctx;
-    }
+    const output = await ActionKinds[type].exec(this, ctx, cfg as any);
 
     if (type === 'import') {
       ctx.imports[label] = output;

--- a/packages/builder/src/error/index.ts
+++ b/packages/builder/src/error/index.ts
@@ -5,7 +5,6 @@ import { ChainArtifacts } from "../types";
 const CONSOLE_LOG_ADDRESS = '0x000000000000000000636f6e736f6c652e6c6f67';
 
 export async function handleTxnError(artifacts: ChainArtifacts, provider: ethers.providers.JsonRpcProvider, err: any): Promise<any> {
-
     if (err instanceof CannonTraceError) {
         // error already parsed
         throw err;

--- a/packages/builder/src/error/provider.ts
+++ b/packages/builder/src/error/provider.ts
@@ -1,52 +1,68 @@
-import { BlockTag } from "@ethersproject/abstract-provider";
-import { ethers } from "ethers";
-import { Deferrable } from "ethers/lib/utils";
-import { handleTxnError } from ".";
-import { ChainArtifacts } from "../types";
-
+import { BlockTag } from '@ethersproject/abstract-provider';
+import { ethers } from 'ethers';
+import { Deferrable } from 'ethers/lib/utils';
+import { handleTxnError } from '.';
+import { ChainArtifacts } from '../types';
 
 export class CannonWrapperJsonRpcProvider extends ethers.providers.JsonRpcProvider {
-    artifacts: ChainArtifacts;
-    passThroughProvider: ethers.providers.JsonRpcProvider;
+  artifacts: ChainArtifacts;
+  readonly passThroughProvider: ethers.providers.JsonRpcProvider;
 
-    constructor(artifacts: ChainArtifacts, ...args: ConstructorParameters<typeof ethers.providers.JsonRpcProvider>) {
-        super(...args);
+  constructor(artifacts: ChainArtifacts, ...args: ConstructorParameters<typeof ethers.providers.JsonRpcProvider>) {
+    super(...args);
 
-        this.artifacts = artifacts;
+    this.artifacts = artifacts;
 
-        // construct second uninhibited instance
-        this.passThroughProvider = new ethers.providers.JsonRpcProvider(...args);
+    // construct second uninhibited instance
+    this.passThroughProvider = new ethers.providers.JsonRpcProvider(...args);
+  }
+
+  override async waitForTransaction(
+    transactionHash: string,
+    confirmations?: number,
+    timeout?: number
+  ): Promise<ethers.providers.TransactionReceipt> {
+    try {
+      return await super.waitForTransaction(transactionHash, confirmations, timeout);
+    } catch (err) {
+      return await handleTxnError(this.artifacts, this.passThroughProvider, err);
     }
+  }
 
-    async waitForTransaction(transactionHash: string, confirmations?: number, timeout?: number): Promise<ethers.providers.TransactionReceipt> {
-        try {
-            return await super.waitForTransaction(transactionHash, confirmations, timeout);
-        } catch(err) {
-            throw handleTxnError(this.artifacts, this.passThroughProvider, err);
-        }
+  override async sendTransaction(
+    signedTransaction: string | Promise<string>
+  ): Promise<ethers.providers.TransactionResponse> {
+    try {
+      return await super.sendTransaction(signedTransaction);
+    } catch (err) {
+      return await handleTxnError(this.artifacts, this.passThroughProvider, err);
     }
+  }
 
-    async sendTransaction(signedTransaction: string | Promise<string>): Promise<ethers.providers.TransactionResponse> {
-        try {
-            return await super.sendTransaction(signedTransaction);
-        } catch(err) {
-            throw handleTxnError(this.artifacts, this.passThroughProvider, err);
-        }
+  override async estimateGas(transaction: Deferrable<ethers.providers.TransactionRequest>): Promise<ethers.BigNumber> {
+    try {
+      return await super.estimateGas(transaction);
+    } catch (err) {
+      return await handleTxnError(this.artifacts, this.passThroughProvider, err);
     }
+  }
 
-    async estimateGas(transaction: Deferrable<ethers.providers.TransactionRequest>): Promise<ethers.BigNumber> {
-        try {
-            return await super.estimateGas(transaction);
-        } catch(err) {
-            throw handleTxnError(this.artifacts, this.passThroughProvider, err);
-        }
+  override async call(
+    transaction: Deferrable<ethers.providers.TransactionRequest>,
+    blockTag?: BlockTag | Promise<BlockTag>
+  ): Promise<string> {
+    try {
+      return await super.call(transaction, blockTag);
+    } catch (err) {
+      return await handleTxnError(this.artifacts, this.passThroughProvider, err);
     }
+  }
 
-    async call(transaction: Deferrable<ethers.providers.TransactionRequest>, blockTag?: BlockTag | Promise<BlockTag>): Promise<string> {
-        try {
-            return await super.call(transaction, blockTag);
-        } catch(err) {
-            throw handleTxnError(this.artifacts, this.passThroughProvider, err);
-        }
+  override async perform(method: string, params: any) {
+    try {
+      return await super.perform(method, params);
+    } catch (err) {
+      return await handleTxnError(this.artifacts, this.passThroughProvider, err);
     }
+  }
 }

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -18,6 +18,8 @@ export * from './storage';
 
 export * from './error/provider';
 
+export { handleTxnError } from './error';
+
 export { CannonRegistry } from './registry';
 
 export async function downloadPackagesRecursive(

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -5,6 +5,7 @@ import { JsonFragment } from '@ethersproject/abi';
 import _ from 'lodash';
 
 import type { RawChainDefinition } from './definition';
+import { CannonWrapperJsonRpcProvider } from './error/provider';
 
 export type OptionTypesTs = string | number | boolean;
 
@@ -70,7 +71,7 @@ export type StorageMode = 'all' | 'metadata' | 'none';
 
 export interface ChainBuilderRuntime {
   // Interface to which all transactions should be sent and all state queried
-  provider: ethers.providers.JsonRpcProvider;
+  provider: CannonWrapperJsonRpcProvider;
 
   // chainID to interact with
   chainId: number;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,7 +12,7 @@ import {
   ChainArtifacts,
   downloadPackagesRecursive,
   ChainBuilderContext,
-  CannonWrapperJsonRpcProvider
+  CannonWrapperJsonRpcProvider,
 } from '@usecannon/builder';
 
 import pkg from '../package.json';

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 import { spawn, ChildProcess } from 'child_process';
 
 import Debug from 'debug';
+import { CannonWrapperJsonRpcProvider } from '@usecannon/builder';
 
 const debug = Debug('cannon:cli:rpc');
 
@@ -60,15 +61,15 @@ export function runRpc({ port, forkUrl }: RpcOptions): Promise<ChildProcess> {
   ]);
 }
 
-export function getProvider(anvilInstance: ChildProcess): Promise<ethers.providers.JsonRpcProvider> {
-  return new Promise<ethers.providers.JsonRpcProvider>((resolve) => {
+export function getProvider(anvilInstance: ChildProcess): Promise<CannonWrapperJsonRpcProvider> {
+  return new Promise<CannonWrapperJsonRpcProvider>((resolve) => {
     anvilInstance.stdout!.on('data', (rawChunk) => {
       // right now check for expected output string to connect to node
       const chunk = rawChunk.toString('utf8');
       const m = chunk.match(/Listening on (.*)/);
       if (m) {
         const host = 'http://' + m[1];
-        resolve(new ethers.providers.JsonRpcProvider(host));
+        resolve(new CannonWrapperJsonRpcProvider({}, host));
       }
     });
   });

--- a/packages/hardhat-cannon/src/index.ts
+++ b/packages/hardhat-cannon/src/index.ts
@@ -14,8 +14,9 @@ import './type-extensions';
 
 import { getSavedPackagesDir } from '@usecannon/builder';
 
-import { HardhatConfig, HardhatUserConfig } from 'hardhat/types';
-import { extendConfig } from 'hardhat/config';
+import { HardhatConfig, HardhatRuntimeEnvironment, HardhatUserConfig } from 'hardhat/types';
+import { extendConfig, extendEnvironment } from 'hardhat/config';
+import { augmentProvider } from './internal/augment-provider';
 
 extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
   config.paths.deployments = userConfig.paths?.deployments
@@ -35,4 +36,13 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
       url: 'https://usecannon.infura-ipfs.io',
     },
   };
+
+  config.networks.cannon = {
+    ...config.networks?.hardhat,
+    ...(userConfig.networks?.cannon || { port: 8545 }),
+  } as any;
+});
+
+extendEnvironment((env: HardhatRuntimeEnvironment) => {
+  augmentProvider(env);
 });

--- a/packages/hardhat-cannon/src/internal/augment-provider.ts
+++ b/packages/hardhat-cannon/src/internal/augment-provider.ts
@@ -1,0 +1,47 @@
+import { EIP1193Provider, HardhatRuntimeEnvironment, RequestArguments } from "hardhat/types";
+
+//import { HttpProvider } from 'hardhat/internal/core/providers/http';
+import { ProviderWrapper } from 'hardhat/internal/core/providers/wrapper';
+
+import { BackwardsCompatibilityProviderAdapter } from 'hardhat/internal/core/providers/backwards-compatibility';
+import { ChainArtifacts, handleTxnError } from '@usecannon/builder';
+import { ethers } from 'ethers';
+
+import { createProvider } from 'hardhat/internal/core/providers/construction';
+
+import { createProviderProxy } from '@nomiclabs/hardhat-ethers/internal/provider-proxy';
+
+class CannonWrapperProvider extends ProviderWrapper {
+  artifacts: ChainArtifacts;
+
+  constructor(provider: EIP1193Provider, artifacts: ChainArtifacts) {
+    super(provider);
+    this.artifacts = artifacts;
+  }
+
+  public async request(args: RequestArguments): Promise<unknown> {
+    try {
+      return this._wrappedProvider.request(args);
+    } catch (err) {
+      handleTxnError(this.artifacts, new ethers.providers.Web3Provider(this._wrappedProvider), err);
+    }
+  }
+}
+
+export function augmentProvider(hre: HardhatRuntimeEnvironment, artifacts: ChainArtifacts = {}) {
+  if (hre.network.name === 'cannon') {
+    const baseProvider = createProvider(
+      hre.network.name,
+      { ...hre.network.config, url: 'http://localhost:8545' },
+      hre.config.paths,
+      hre.artifacts
+    );
+    const cannonProvider = new CannonWrapperProvider(baseProvider, artifacts);
+
+    hre.network.provider = new BackwardsCompatibilityProviderAdapter(cannonProvider);
+
+    // refresh hardhat ethers
+    // todo this is hacky but somehow normal for hardhat network extension
+    hre.ethers.provider = createProviderProxy(hre.network.provider);
+  }
+}

--- a/packages/hardhat-cannon/src/subtasks/rpc.ts
+++ b/packages/hardhat-cannon/src/subtasks/rpc.ts
@@ -8,6 +8,7 @@ import Debug from 'debug';
 const debug = Debug('cannon:hardhat:rpc');
 
 import { SUBTASK_RPC } from '../task-names';
+import { CannonWrapperJsonRpcProvider } from '@usecannon/builder';
 
 const ANVIL_OP_TIMEOUT = 10000;
 
@@ -82,7 +83,7 @@ For more info, see https://book.getfoundry.sh/getting-started/installation.html
           const host = 'http://' + m[1];
           state = 'listening';
           //console.log('anvil spawned at', host);
-          resolve(new ethers.providers.JsonRpcProvider(host));
+          resolve(new CannonWrapperJsonRpcProvider({}, host));
         }
 
         debug(chunk);

--- a/packages/hardhat-cannon/src/tasks/publish.ts
+++ b/packages/hardhat-cannon/src/tasks/publish.ts
@@ -15,7 +15,7 @@ task(TASK_PUBLISH, 'Provision and publish to the registry the current Cannonfile
   .setAction(async ({ file, tags, registryAddress }, hre) => {
     await setupAnvil();
 
-    if (hre.network.name == 'hardhat') {
+    if (hre.network.name == 'cannon') {
       console.log(yellowBright(`The ${TASK_PUBLISH} task must be run with ${bold('--network mainnet')}`));
       process.exit();
     }

--- a/packages/hardhat-cannon/src/tasks/verify.ts
+++ b/packages/hardhat-cannon/src/tasks/verify.ts
@@ -2,10 +2,10 @@ import _ from 'lodash';
 import { task } from 'hardhat/config';
 
 import { TASK_VERIFY } from '../task-names';
-import { ChainBuilder } from '@usecannon/builder';
+import { CannonWrapperJsonRpcProvider, ChainBuilder } from '@usecannon/builder';
 import { setupAnvil } from '@usecannon/cli';
 import loadCannonfile from '../internal/load-cannonfile';
-import { ethers } from 'ethers';
+import { HttpNetworkConfig } from 'hardhat/types';
 
 task(TASK_VERIFY, 'Run etherscan verification on a cannon deployment sent to mainnet')
   .addOptionalPositionalParam('label', 'Label of a built cannon chain to verify on Etherscan')
@@ -30,7 +30,7 @@ task(TASK_VERIFY, 'Run etherscan verification on a cannon deployment sent to mai
       version,
       readMode: 'metadata',
       chainId: (await hre.ethers.provider.getNetwork()).chainId,
-      provider: hre.ethers.provider as ethers.providers.JsonRpcProvider,
+      provider: new CannonWrapperJsonRpcProvider({}, (hre.network.config as HttpNetworkConfig).url),
       async getSigner(addr: string) {
         return hre.ethers.getSigner(addr);
       },

--- a/packages/hardhat-cannon/src/type-extensions.ts
+++ b/packages/hardhat-cannon/src/type-extensions.ts
@@ -1,4 +1,4 @@
-import 'hardhat/types/config';
+import { HardhatNetworkConfig, HttpNetworkConfig } from 'hardhat/types/config';
 
 import { Options as IPFSConnectionOptions } from 'ipfs-http-client';
 
@@ -14,6 +14,20 @@ declare module 'hardhat/types/config' {
       registryAddress?: string;
       ipfsConnection?: IPFSConnectionOptions;
     };
+  }
+
+  export interface NetworksConfig {
+    cannon: CannonNetworkConfig;
+  }
+
+  //export type NetworkConfig = NetworkConfig | HttpNetworkConfig;
+
+  // TODO: this is a known (and apparently decided to be unsolved) issue with ts https://github.com/microsoft/TypeScript/issues/28078
+  // therefore, in the future it would be best to update hardhat upstream to use the reccomended workaround and
+  // remove the hardhatntework extension
+  export interface CannonNetworkConfig extends HardhatNetworkConfig {
+    // nothing for now
+    port: number;
   }
 
   export interface ProjectPathsConfig {


### PR DESCRIPTION
one of the problems is that many plugins fail to work properly with cannon because its not properly overriding the hardhat configuration.

not anymore!

the only requirement is to adjust the `defaultNetwork` property to be `defaultNetwork: 'cannon'`. `cannon` is a well-known name recognized by the hardhat-cannon project which will cause it to recognize the network as used for snapshotting/forks.

this fixes plugins like `hardhat-gas-reporter` which depend on usage of the hre for provider information

also I tried to implement error handling, but I think some aspects of it may still be malfunctioning. Its fine if you use the provider returned by cannon, but you may run into problems if you don't use it.

Finally, it may be a little awkward how the `CannonWrapperProvider` (or whatever its called) uses a field `artifacts` to determine the decoding configuration for errors. It may be better to have an actual setter function instead.