### PR TITLE
fix default value given to hardhat_setBalances

### DIFF
--- a/packages/builder/src/util.ts
+++ b/packages/builder/src/util.ts
@@ -68,7 +68,7 @@ export async function getExecutionSigner(
   const address = '0x' + hash.slice(0, 40);
 
   await provider.send('hardhat_impersonateAccount', [address]);
-  await provider.send('hardhat_setBalance', [address, ethers.utils.parseEther('10000').toHexString()]);
+  await provider.send('hardhat_setBalance', [address, `0x${(1e22).toString(16)}`]);
 
   return await provider.getSigner(address);
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -103,7 +103,7 @@ export async function build({
     async getSigner(addr: string) {
       // on test network any user can be conjured
       await provider.send('hardhat_impersonateAccount', [addr]);
-      await provider.send('hardhat_setBalance', [addr, ethers.utils.parseEther('10000').toHexString()]);
+      await provider.send('hardhat_setBalance', [addr, `0x${(1e22).toString(16)}`]);
       return provider.getSigner(addr);
     },
     getArtifact,

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -97,7 +97,7 @@ export async function deploy(options: DeployOptions) {
     getSigner = async (addr: string) => {
       // on test network any user can be conjured
       await cannonProvider.send('hardhat_impersonateAccount', [addr]);
-      await cannonProvider.send('hardhat_setBalance', [addr, ethers.utils.parseEther('10000').toHexString()]);
+      await cannonProvider.send('hardhat_setBalance', [addr, `0x${(1e22).toString(16)}`]);
       return cannonProvider.getSigner(addr);
     };
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -62,7 +62,7 @@ export async function run(packages: PackageDefinition[], options: RunOptions) {
 
   if (options.fundAddresses && options.fundAddresses.length) {
     for (const fundAddress of options.fundAddresses) {
-      await node.provider.send('hardhat_setBalance', [fundAddress, ethers.utils.parseEther('10000').toHexString()]);
+      await node.provider.send('hardhat_setBalance', [fundAddress, `0x${(1e22).toString(16)}`]);
     }
   }
 
@@ -123,7 +123,7 @@ export async function run(packages: PackageDefinition[], options: RunOptions) {
       if (options.impersonate) {
         for (const addr of options.impersonate.split(',')) {
           await node.provider.send('hardhat_impersonateAccount', [addr]);
-          await node.provider.send('hardhat_setBalance', [addr, 1e18]);
+          await node.provider.send('hardhat_setBalance', [addr, `0x${(1e22).toString(16)}`]);
           signers = [node.provider.getSigner(addr)];
         }
       }


### PR DESCRIPTION
There's an error that happens when calling `ethers.utils.parseEther('10000')`, which returns `'0x021e19e0c9bab2400000'` which contains an extra leading `0` and makes it throw an error when using it for `hardhat_setBalance`.

This fix resolves that not relying on ethers to generate 10.000ETH in hex wei.