### PR TITLE
misc bugs found while using cannon with legacymarket

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -307,6 +307,7 @@ ${printChainDefinitionProblems(problems)}`);
 
     //const analysis = await this.analyzeActions(opts);
     const completed = new Map<string, ChainBuilderContext>();
+    const tainted = new Set<string>();
     const topologicalActions = this.def.topologicalActions;
 
     if (this.writeMode === 'all' || this.readMode === 'all') {
@@ -314,7 +315,7 @@ ${printChainDefinitionProblems(problems)}`);
       const layers = this.def.getStateLayers();
 
       for (const leaf of this.def.leaves) {
-        await this.buildLayer(ctx, layers, leaf, completed);
+        await this.buildLayer(ctx, layers, leaf, completed, tainted);
       }
     } else {
       for (const n of topologicalActions) {

--- a/packages/builder/src/steps/contract.ts
+++ b/packages/builder/src/steps/contract.ts
@@ -56,8 +56,9 @@ export default {
     config.abi = _.template(config.abi)(ctx);
 
     if (config.args) {
-      config.args = config.args.map((a) => {
-        return typeof a == 'string' ? _.template(a)(ctx) : a;
+      config.args = _.map(config.args, (a) => {
+        // just convert it to a JSON string when. This will allow parsing of complicated nested structures
+        return JSON.parse(_.template(JSON.stringify(a))(ctx));
       });
     }
 

--- a/packages/builder/src/steps/invoke.ts
+++ b/packages/builder/src/steps/invoke.ts
@@ -133,7 +133,8 @@ export default {
 
     if (config.args) {
       config.args = _.map(config.args, (a) => {
-        return typeof a == 'string' ? _.template(a)(ctx) : a;
+        // just convert it to a JSON string when. This will allow parsing of complicated nested structures
+        return JSON.parse(_.template(JSON.stringify(a))(ctx));
       });
     }
 
@@ -144,7 +145,8 @@ export default {
     if (config.fromCall) {
       config.fromCall.func = _.template(config.fromCall.func)(ctx);
       config.fromCall.args = _.map(config.fromCall.args, (a) => {
-        return typeof a == 'string' ? _.template(a)(ctx) : a;
+        // just convert it to a JSON string when. This will allow parsing of complicated nested structures
+        return JSON.parse(_.template(JSON.stringify(a))(ctx));
       });
     }
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -161,5 +161,7 @@ export async function build({
     )
   );
 
+  provider.artifacts = outputs;
+
   return { outputs, provider };
 }

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -88,7 +88,9 @@ export async function deploy(options: DeployOptions) {
       }
     }
 
-    throw new Error(`signer not found from configuration: ${addr}`);
+    throw new Error(
+      `the current step requests usage of the signer with address ${addr}, but this signer is not found. Please either supply the private key, or change the cannon configuration to use a different signer.`
+    );
   };
 
   let getDefaultSigner = () => Promise.resolve(signers[0]);
@@ -184,6 +186,8 @@ export async function deploy(options: DeployOptions) {
   }
 
   printChainBuilderOutput(outputs);
+
+  cannonProvider.artifacts = outputs;
 
   return { outputs, signers, provider: cannonProvider };
 }


### PR DESCRIPTION
these bugs are all very small and all had workarounds, so I can package them all here like this

* configuration for possibly nested properties (such as `args` for contacts) now converts to JSON before injecting template. This allows for us to inject anywhere in the data structure, or even to inject entirely new json structures perhaps
* topology error--did not carry over taints between leaves
* returned provider from the cli does not include the latest set of artifacts after build is completed