### PR TITLE
need ability to use `abiOf` with an array of previous contracts

### DIFF
--- a/packages/builder/src/steps/contract.ts
+++ b/packages/builder/src/steps/contract.ts
@@ -141,8 +141,7 @@ export default {
       }
 
       abi = JSON.parse(implContract.interface.format(ethers.utils.FormatTypes.json) as string);
-    }
-    else if (config.abiOf) {
+    } else if (config.abiOf) {
       abi = [];
       for (const ofContract of config.abiOf) {
         const implContract = getContractFromPath(ctx, ofContract);

--- a/packages/builder/src/steps/contract.ts
+++ b/packages/builder/src/steps/contract.ts
@@ -5,7 +5,7 @@ import { JTDDataType } from 'ajv/dist/core';
 import { ethers } from 'ethers';
 
 import { ChainBuilderContext, ChainBuilderRuntime, ChainArtifacts } from '../types';
-import { getContractFromPath } from '../util';
+import { getContractFromPath, getMergedAbiFromContractPaths } from '../util';
 
 const debug = Debug('cannon:builder:contract');
 
@@ -142,16 +142,7 @@ export default {
 
       abi = JSON.parse(implContract.interface.format(ethers.utils.FormatTypes.json) as string);
     } else if (config.abiOf) {
-      abi = [];
-      for (const ofContract of config.abiOf) {
-        const implContract = getContractFromPath(ctx, ofContract);
-
-        if (!implContract) {
-          throw new Error(`previously deployed contract with identifier "${ofContract}" for factory not found`);
-        }
-
-        abi.push(...JSON.parse(implContract.interface.format(ethers.utils.FormatTypes.json) as string));
-      }
+      abi = getMergedAbiFromContractPaths(ctx, config.abiOf);
     }
 
     debug('contract deployed to address', receipt.contractAddress);

--- a/packages/builder/src/steps/contract.ts
+++ b/packages/builder/src/steps/contract.ts
@@ -14,7 +14,9 @@ const config = {
     artifact: { type: 'string' },
   },
   optionalProperties: {
+    from: { type: 'string' },
     abi: { type: 'string' },
+    abiOf: { elements: { type: 'string' } },
     args: { elements: {} },
     libraries: { values: { type: 'string' } },
 
@@ -51,9 +53,15 @@ export default {
   configInject(ctx: ChainBuilderContext, config: Config) {
     config = _.cloneDeep(config);
 
+    config.from = _.template(config.from)(ctx);
+
     config.artifact = _.template(config.artifact)(ctx);
 
     config.abi = _.template(config.abi)(ctx);
+
+    if (config.abiOf) {
+      config.abiOf = _.map(config.abiOf, (v) => _.template(v)(ctx));
+    }
 
     if (config.args) {
       config.args = _.map(config.args, (a) => {
@@ -116,7 +124,7 @@ export default {
 
     const txn = factory.getDeployTransaction(...(config.args || []));
 
-    const signer = await runtime.getDefaultSigner(txn, config.salt);
+    const signer = config.from ? await runtime.getSigner(config.from) : await runtime.getDefaultSigner(txn, config.salt);
 
     const txnData = await signer.sendTransaction(txn);
 
@@ -133,6 +141,18 @@ export default {
       }
 
       abi = JSON.parse(implContract.interface.format(ethers.utils.FormatTypes.json) as string);
+    }
+    else if (config.abiOf) {
+      abi = [];
+      for (const ofContract of config.abiOf) {
+        const implContract = getContractFromPath(ctx, ofContract);
+
+        if (!implContract) {
+          throw new Error(`previously deployed contract with identifier "${ofContract}" for factory not found`);
+        }
+
+        abi.push(...JSON.parse(implContract.interface.format(ethers.utils.FormatTypes.json) as string));
+      }
     }
 
     debug('contract deployed to address', receipt.contractAddress);

--- a/packages/builder/src/steps/invoke.ts
+++ b/packages/builder/src/steps/invoke.ts
@@ -3,7 +3,7 @@ import Debug from 'debug';
 import { JTDDataType } from 'ajv/dist/core';
 
 import { ChainBuilderContext, ChainBuilderRuntime, ChainArtifacts, TransactionMap } from '../types';
-import { getContractDefinitionFromPath, getContractFromPath } from '../util';
+import { getContractDefinitionFromPath, getContractFromPath, getMergedAbiFromContractPaths } from '../util';
 import { ethers } from 'ethers';
 
 import { getAllContractPaths } from '../util';
@@ -228,16 +228,7 @@ ${getAllContractPaths(ctx).join('\n')}`);
             sourceName = artifact.sourceName;
             contractName = artifact.contractName;
           } else if (factory.abiOf) {
-            abi = [];
-            for (const ofContract of factory.abiOf) {
-              const implContract = getContractFromPath(ctx, ofContract);
-
-              if (!implContract) {
-                throw new Error(`previously deployed contract with identifier "${ofContract}" for factory not found`);
-              }
-
-              abi.push(...JSON.parse(implContract.interface.format(ethers.utils.FormatTypes.json) as string));
-            }
+            abi = getMergedAbiFromContractPaths(ctx, factory.abiOf);
 
             sourceName = ''; // TODO: might cause a problem, might be able to load from the resolved contract itself. update `getContractFromPath`
             contractName = '';

--- a/packages/builder/src/steps/invoke.ts
+++ b/packages/builder/src/steps/invoke.ts
@@ -227,10 +227,10 @@ ${getAllContractPaths(ctx).join('\n')}`);
               if (!implContract) {
                 throw new Error(`previously deployed contract with identifier "${ofContract}" for factory not found`);
               }
-  
+
               abi.push(...JSON.parse(implContract.interface.format(ethers.utils.FormatTypes.json) as string));
             }
-            
+
             sourceName = ''; // TODO: might cause a problem, might be able to load from the resolved contract itself. update `getContractFromPath`
             contractName = '';
           } else {

--- a/packages/builder/src/steps/run.ts
+++ b/packages/builder/src/steps/run.ts
@@ -61,7 +61,8 @@ export default {
 
     if (config.args) {
       config.args = _.map(config.args, (v) => {
-        return _.template(v)(ctx);
+        // just convert it to a JSON string when. This will allow parsing of complicated nested structures
+        return JSON.parse(_.template(JSON.stringify(v))(ctx));
       });
     }
 

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -28,7 +28,7 @@ export type ContractArtifact = {
 export type ContractMap = {
   [label: string]: {
     address: string;
-    abi: any[];
+    abi: JsonFragment[];
     constructorArgs?: any[]; // only needed for etherscan verification
     deployTxnHash: string;
     contractName: string;

--- a/packages/builder/src/util.ts
+++ b/packages/builder/src/util.ts
@@ -122,6 +122,28 @@ export function getContractDefinitionFromPath(ctx: ChainBuilderContext, path: st
   return c || null;
 }
 
+export function getMergedAbiFromContractPaths(ctx: ChainBuilderContext, paths: string[]) {
+  return paths
+    .flatMap((contractPath) => {
+      const c = getContractDefinitionFromPath(ctx, contractPath);
+
+      if (!c) {
+        throw new Error(`previously deployed contract with identifier "${contractPath}" for factory not found`);
+      }
+
+      if (!Array.isArray(c.abi)) {
+        throw new Error(`Contract definition for "${contractPath}" does not have a valid abi`);
+      }
+
+      return c.abi;
+    })
+    .filter((a, index, abi) => {
+      if (index === 0) return true;
+      const alreadyExists = abi.slice(0, index - 1).some((b) => b.name === a.name && b.type === a.type);
+      return !alreadyExists;
+    });
+}
+
 export function getContractFromPath(ctx: ChainBuilderContext, path: string, customAbi?: JsonFragment[]) {
   const contract = getContractDefinitionFromPath(ctx, path);
 

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -19,10 +19,10 @@ export async function inspect(cannonDirectory: string, packageRef: string, json:
     console.log(JSON.stringify(deployInfo, null, 2));
   } else {
     console.log(green(bold(`\n=============== ${name}:${version} ===============`)));
-    console.log(cyan(bold(`\nCannonfile Topology`)));
+    console.log(cyan(bold('\nCannonfile Topology')));
     console.log(cyan(chainDefinition.printTopology().join('\n')));
     if (!_.isEmpty(deployInfo?.deploys)) {
-      console.log(cyan(bold(`\n\nCannonfile Builds/Deployments`)));
+      console.log(cyan(bold('\n\nCannonfile Builds/Deployments')));
       for (const [chainId, chainData] of Object.entries(deployInfo.deploys)) {
         const chainName = getChainName(parseInt(chainId));
         renderDeployment(chainName, chainId, chainData);


### PR DESCRIPTION
for "diamond" style proxies which have multiple implementations behind the main, it is required to supply an array for `abiOf` instaed of a single target.

Additionally, (this is extremely minor, but) it should be possible to specify the `from` address on the `contract` step