### PR TITLE
add a dedicated chainid `13370` to cannon network

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -17,6 +17,8 @@ import {
   BuildOptions,
 } from './types';
 
+import { CANNON_CHAIN_ID } from './constants';
+
 import { ChainDefinition, ActionKinds, RawChainDefinition, StateLayers } from './definition';
 
 import { getExecutionSigner, getStoredArtifact, passThroughArtifact, printChainDefinitionProblems } from './util';
@@ -587,7 +589,7 @@ ${printChainDefinitionProblems(problems)}`);
       const rawDef = await this.getDeploymentRecordedDefinition();
 
       // only store the current chain definition if we are building the local network id and main preset
-      deployInfo.def = this.chainId === 31337 && this.preset === 'main' ? rawDef : deployInfo.def;
+      deployInfo.def = this.chainId === CANNON_CHAIN_ID && this.preset === 'main' ? rawDef : deployInfo.def;
 
       await fs.mkdirp(this.packageDir);
       await fs.writeJson(file, deployInfo);

--- a/packages/builder/src/constants.ts
+++ b/packages/builder/src/constants.ts
@@ -1,0 +1,1 @@
+export const CANNON_CHAIN_ID = 13370;

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -22,6 +22,8 @@ export { handleTxnError } from './error';
 
 export { CannonRegistry, ReadOnlyCannonRegistry } from './registry';
 
+export { CANNON_CHAIN_ID } from './constants';
+
 export async function downloadPackagesRecursive(
   pkg: string,
   chainId: number,

--- a/packages/builder/src/util.ts
+++ b/packages/builder/src/util.ts
@@ -97,10 +97,19 @@ export async function passThroughArtifact(
   name: string
 ) {
   const artifactFile = path.join(packageDir, 'contracts', name + '.json');
-  const artifact = await getArtifact(name);
-
-  await fs.mkdirp(path.dirname(artifactFile));
-  await fs.writeFile(artifactFile, JSON.stringify(artifact));
+  let artifact: ContractArtifact;
+  try {
+    artifact = await getArtifact(name);
+  
+    await fs.mkdirp(path.dirname(artifactFile));
+    await fs.writeJson(artifactFile, artifact);
+  } catch (err) {
+    if (fs.existsSync(artifactFile)) {
+      artifact = await fs.readJson(artifactFile);
+    } else {
+      throw err;
+    }
+  }
 
   return artifact;
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { table } from 'table';
 import { bold, greenBright, green, dim, red } from 'chalk';
 import tildify from 'tildify';
-import { ChainBuilder, ChainDefinition, ContractArtifact, downloadPackagesRecursive, Events } from '@usecannon/builder';
+import { CANNON_CHAIN_ID, ChainBuilder, ChainDefinition, ContractArtifact, downloadPackagesRecursive, Events } from '@usecannon/builder';
 import { findPackage, loadCannonfile } from '../helpers';
 import { runRpc, getProvider } from '../rpc';
 import { ChainId, PackageDefinition } from '../types';
@@ -39,7 +39,6 @@ export async function build({
   cannonDirectory,
   projectDirectory,
   preset = 'main',
-  chainId = 31337,
   registryIpfsUrl,
   registryIpfsAuthorizationHeader,
   registryRpcUrl,
@@ -108,7 +107,7 @@ export async function build({
     writeMode,
 
     provider,
-    chainId,
+    chainId: CANNON_CHAIN_ID,
     baseDir: projectDirectory,
     savedPackagesDir: cannonDirectory,
     async getSigner(addr: string) {
@@ -146,7 +145,7 @@ export async function build({
     try {
       await registry.downloadPackageChain(
         `${packageDefinition.name}:${packageDefinition.version}`,
-        chainId,
+        CANNON_CHAIN_ID,
         preset,
         cannonDirectory
       );

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,9 +1,11 @@
 import {
+  CANNON_CHAIN_ID,
   CannonWrapperGenericProvider,
   ChainBuilder,
   downloadPackagesRecursive,
   Events,
   StorageMode,
+  ContractArtifact,
 } from '@usecannon/builder';
 import { ethers } from 'ethers';
 import { findPackage, loadCannonfile } from '../helpers';
@@ -20,6 +22,8 @@ interface DeployOptions {
   packageDefinition: PackageDefinition;
   cannonDirectory: string;
   projectDirectory?: string;
+
+  getArtifact?: (name: string) => Promise<ContractArtifact>;
 
   overrideCannonfilePath?: string;
 
@@ -109,7 +113,7 @@ export async function deploy(options: DeployOptions) {
   let readMode: StorageMode = options.wipe ? 'none' : 'metadata';
   let writeMode: StorageMode = options.dryRun ? 'none' : 'metadata';
 
-  if (chainId === 31337 || chainId === 1337) {
+  if (chainId === 31337 || chainId === 1337 || chainId === 13370) {
     // local network gets reset on every run, so should not read/write anything
     readMode = 'none';
     writeMode = 'none';
@@ -130,10 +134,11 @@ export async function deploy(options: DeployOptions) {
     savedPackagesDir: options.cannonDirectory,
     getSigner,
     getDefaultSigner,
+    getArtifact: options.getArtifact,
   });
 
   try {
-    await fs.promises.access(`${builder.packageDir}/31337-main`);
+    await fs.promises.access(`${builder.packageDir}/${CANNON_CHAIN_ID}-main`);
   } catch (error) {
     console.log(red('You must build this package before deploying to a remote network.'));
     process.exit();

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs';
 import prompts from 'prompts';
 import { magentaBright, yellowBright, yellow, bold, redBright, red } from 'chalk';
 import toml from '@iarna/toml';
-import { ChainDefinition, DeploymentManifest, RawChainDefinition, ChainBuilderContext } from '@usecannon/builder';
+import { CANNON_CHAIN_ID, ChainDefinition, DeploymentManifest, RawChainDefinition, ChainBuilderContext } from '@usecannon/builder';
 import { ChainId, ChainName } from './types';
 
 export async function setupAnvil(): Promise<void> {
@@ -100,7 +100,7 @@ export function loadCannonfile(filepath: string) {
 
   const ctx: ChainBuilderContext = {
     package: pkg,
-    chainId: 31337,
+    chainId: CANNON_CHAIN_ID,
     settings: {},
     timestamp: '0',
 

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers';
 import { spawn, ChildProcess } from 'child_process';
 
 import Debug from 'debug';
-import { CannonWrapperGenericProvider } from '@usecannon/builder';
+import { CANNON_CHAIN_ID, CannonWrapperGenericProvider } from '@usecannon/builder';
 
 const debug = Debug('cannon:cli:rpc');
 
@@ -38,6 +38,9 @@ export function runRpc({ port, forkUrl, chainId }: RpcOptions): Promise<ChildPro
   const opts = ['--port', port.toString()];
   if (chainId) {
     opts.push('--chain-id', chainId.toString());
+  }
+  else {
+    opts.push('--chain-id', CANNON_CHAIN_ID.toString());
   }
 
   // reduce image size by not creating unnecessary accounts

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -76,6 +76,7 @@ export enum ChainId {
   palm = 11297108109,
   curio = 836542336838601,
   hardhat = 31337,
+  cannon = 13370,
   localhost = 1337,
 }
 

--- a/packages/hardhat-cannon/src/index.ts
+++ b/packages/hardhat-cannon/src/index.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { HardhatConfig, HardhatRuntimeEnvironment, HardhatUserConfig } from 'hardhat/types';
 import { extendConfig, extendEnvironment } from 'hardhat/config';
 import '@nomiclabs/hardhat-ethers';
-import { getSavedPackagesDir } from '@usecannon/builder';
+import { CANNON_CHAIN_ID, getSavedPackagesDir } from '@usecannon/builder';
 import {
   DEFAULT_CANNON_DIRECTORY,
   DEFAULT_REGISTRY_ADDRESS,
@@ -45,6 +45,7 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
     port: 8545,
     ...(config.networks?.hardhat || {}),
     ...(userConfig.networks?.cannon || {}),
+    chainId: CANNON_CHAIN_ID,
   } as any;
 });
 

--- a/packages/hardhat-cannon/src/internal/load-cannonfile.ts
+++ b/packages/hardhat-cannon/src/internal/load-cannonfile.ts
@@ -4,7 +4,7 @@ import toml from '@iarna/toml';
 import { HardhatPluginError } from 'hardhat/plugins';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { ethers } from 'ethers';
-import { ChainBuilderContext, validateChainDefinition, ChainDefinition, RawChainDefinition } from '@usecannon/builder';
+import { CANNON_CHAIN_ID, ChainBuilderContext, validateChainDefinition, ChainDefinition, RawChainDefinition } from '@usecannon/builder';
 
 export default function loadCannonfile(hre: HardhatRuntimeEnvironment, filepath: string) {
   if (!fs.existsSync(filepath)) {
@@ -58,7 +58,7 @@ export default function loadCannonfile(hre: HardhatRuntimeEnvironment, filepath:
 
   const ctx: ChainBuilderContext = {
     package: fs.readJsonSync(hre.config.paths.root + '/package.json'),
-    chainId: hre.network.config.chainId || 31337, // todo: is this right?
+    chainId: hre.network.config.chainId || CANNON_CHAIN_ID,
     settings: {},
     timestamp: '0',
 

--- a/packages/hardhat-cannon/src/tasks/deploy.ts
+++ b/packages/hardhat-cannon/src/tasks/deploy.ts
@@ -89,6 +89,9 @@ task(TASK_DEPLOY, 'Deploy a cannon package to a network')
       // we have to wrap the provider here because of the third argument, prevent any reading-into for the hardhat-network
       provider,
 
+      // it is sometimes necessary (and reasonable) to access different artifacts for subsequent network deployments. this allows for artifact pass-through
+      getArtifact: (contractName: string) => hre.artifacts.readArtifact(contractName),
+
       mnemonic: (hre.network.config.accounts as HttpNetworkHDAccountsConfig).mnemonic,
       privateKey,
       impersonate: opts.impersonate,


### PR DESCRIPTION
also changes `getArtifacts` behavior a bit to attempt to load the artifact, and if fail, load from cannon artifact cache for hardhat