### PR TITLE
Fix params definition on CLI

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -118,12 +118,16 @@ export async function run(packages: PackageDefinition[], options: RunOptions) {
         `${bold(`${name}:${version}`)} has been deployed to a local node running at ${bold('localhost:' + node.port)}`
       )
     );
+
+    if (node.forkUrl) {
+      console.log(gray(`Running from fork ${bold(node.forkUrl)}`));
+    }
   }
 
   if (!signers.length) {
     console.warn(
       yellow(
-        'WARNING: no signers resolved. Specify signers with --mnemonic or --private-key (or use --impersonate if on a fork).'
+        '\nWARNING: no signers resolved. Specify signers with --mnemonic or --private-key (or use --impersonate if on a fork).'
       )
     );
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -46,66 +46,63 @@ program
     await checkCannonVersion(pkg.version);
   });
 
-configureRun(program.command('run'));
+program
+  .command('run')
+  .description('Utility for instantly loading cannon packages in standalone contexts')
+  .usage('[global options] ...[<name>[:<semver>] ...[<key>=<value>]]')
+  .argument(
+    '<packageNames...>',
+    'List of packages to load, optionally with custom settings for each one',
+    parsePackagesArguments
+  )
+  .option('-p --port <number>', 'Port which the JSON-RPC server will be exposed', '8545')
+  .option('-f --fork <url>', 'Fork the network at the specified RPC url')
+  .option('--logs', 'Show RPC logs instead of an interactive prompt')
+  .option('--preset <name>', 'Load an alternate setting preset', 'main')
+  .option('--write-deployments <path>', 'Path to write the deployments data (address and ABIs), like "./deployments"')
+  .option('--project-directory <directory>', 'Path to a custom running environment directory')
+  .option('-d --cannon-directory <directory>', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
+  .option(
+    '--registry-ipfs-url <https://...>',
+    'URL of the JSON-RPC server used to query the registry',
+    DEFAULT_REGISTRY_IPFS_ENDPOINT
+  )
+  .option(
+    '--registry-ipfs-authorization-header <ipfsAuthorizationHeader>',
+    'Authorization header for requests to the IPFS endpoint'
+  )
+  .option(
+    '--registry-rpc-url <https://...>',
+    'Network endpoint for interacting with the registry',
+    DEFAULT_REGISTRY_ENDPOINT
+  )
+  .option('--registry-address <0x...>', 'Address of the registry contract', DEFAULT_REGISTRY_ADDRESS)
+  .option('--fund-addresses <fundAddresses...>', 'Pass a list of addresses to receive a balance of 10,000 ETH')
+  .option(
+    '--impersonate <address>',
+    'Impersonate all calls from the given signer instead of a real wallet. Only works with --fork',
+    '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+  )
+  .option('--mnemonic <phrase>', 'Use the specified mnemonic to initialize a chain of signers while running')
+  .option('--private-key <0x...>', 'Use the specified private key hex to interact with the contracts')
+  .action(async function (packages: PackageDefinition[], options, program) {
+    const { run } = await import('./commands/run');
 
-function configureRun(program: Command) {
-  return program
-    .description('Utility for instantly loading cannon packages in standalone contexts')
-    .usage('[global options] ...[<name>[:<semver>] ...[<key>=<value>]]')
-    .argument(
-      '<packageNames...>',
-      'List of packages to load, optionally with custom settings for each one',
-      parsePackagesArguments
-    )
-    .option('-p --port <number>', 'Port which the JSON-RPC server will be exposed', '8545')
-    .option('-f --fork <url>', 'Fork the network at the specified RPC url')
-    .option('--logs', 'Show RPC logs instead of an interactive prompt')
-    .option('--preset <name>', 'Load an alternate setting preset', 'main')
-    .option('--write-deployments <path>', 'Path to write the deployments data (address and ABIs), like "./deployments"')
-    .option('--project-directory <directory>', 'Path to a custom running environment directory')
-    .option('-d --cannon-directory <directory>', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
-    .option(
-      '--registry-ipfs-url <https://...>',
-      'URL of the JSON-RPC server used to query the registry',
-      DEFAULT_REGISTRY_IPFS_ENDPOINT
-    )
-    .option(
-      '--registry-ipfs-authorization-header <ipfsAuthorizationHeader>',
-      'Authorization header for requests to the IPFS endpoint'
-    )
-    .option(
-      '--registry-rpc-url <https://...>',
-      'Network endpoint for interacting with the registry',
-      DEFAULT_REGISTRY_ENDPOINT
-    )
-    .option('--registry-address <0x...>', 'Address of the registry contract', DEFAULT_REGISTRY_ADDRESS)
-    .option('--fund-addresses <fundAddresses...>', 'Pass a list of addresses to receive a balance of 10,000 ETH')
-    .option(
-      '--impersonate <address>',
-      'Impersonate all calls from the given signer instead of a real wallet. Only works with --fork',
-      '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
-    )
-    .option('--mnemonic <phrase>', 'Use the specified mnemonic to initialize a chain of signers while running')
-    .option('--private-key <0x...>', 'Use the specified private key hex to interact with the contracts')
-    .action(async function (packages: PackageDefinition[], options, program) {
-      const { run } = await import('./commands/run');
-
-      const node = await runRpc({
-        port: Number.parseInt(options.port) || 8545,
-        forkUrl: options.fork,
-      });
-
-      if (options.projectDirectory) {
-        options.projectDirectory = path.resolve(options.projectDirectory);
-      }
-
-      await run(packages, {
-        ...options,
-        node,
-        helpInformation: program.helpInformation(),
-      });
+    const node = await runRpc({
+      port: Number.parseInt(options.port) || 8545,
+      forkUrl: options.fork,
     });
-}
+
+    if (options.projectDirectory) {
+      options.projectDirectory = path.resolve(options.projectDirectory);
+    }
+
+    await run(packages, {
+      ...options,
+      node,
+      helpInformation: program.helpInformation(),
+    });
+  });
 
 program
   .command('build')
@@ -206,8 +203,8 @@ program
   .command('deploy')
   .description('Deploy a cannon package to a network')
   .argument('<packageWithSettings...>', 'Package to deploy, optionally with custom settings', parsePackageArguments)
-  .option('-p --private-key <privateKey>', 'Private key of the wallet to use for deployment')
-  .option('-n --network-rpc <networkRpc>', 'URL of a JSON-RPC server to use for deployment')
+  .requiredOption('-p --private-key <privateKey>', 'Private key of the wallet to use for deployment')
+  .requiredOption('-n --network-rpc <networkRpc>', 'URL of a JSON-RPC server to use for deployment')
   .option('-p --preset <preset>', 'Load an alternate setting preset', 'main')
   .option('-d --cannon-directory <directory>', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
   .option('--write-deployments <path>', 'Path to write the deployments data (address and ABIs), like "./deployments"')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -46,7 +46,6 @@ program
     await checkCannonVersion(pkg.version);
   });
 
-configureRun(program);
 configureRun(program.command('run'));
 
 function configureRun(program: Command) {
@@ -54,7 +53,7 @@ function configureRun(program: Command) {
     .description('Utility for instantly loading cannon packages in standalone contexts')
     .usage('[global options] ...[<name>[:<semver>] ...[<key>=<value>]]')
     .argument(
-      '[packageNames...]',
+      '<packageNames...>',
       'List of packages to load, optionally with custom settings for each one',
       parsePackagesArguments
     )
@@ -63,23 +62,23 @@ function configureRun(program: Command) {
     .option('--logs', 'Show RPC logs instead of an interactive prompt')
     .option('--preset <name>', 'Load an alternate setting preset', 'main')
     .option('--write-deployments <path>', 'Path to write the deployments data (address and ABIs), like "./deployments"')
-    .option('--project-directory [directory]', 'Path to a custom running environment directory')
-    .option('-d --cannon-directory [directory]', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
+    .option('--project-directory <directory>', 'Path to a custom running environment directory')
+    .option('-d --cannon-directory <directory>', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
     .option(
-      '--registry-ipfs-url [https://...]',
+      '--registry-ipfs-url <https://...>',
       'URL of the JSON-RPC server used to query the registry',
       DEFAULT_REGISTRY_IPFS_ENDPOINT
     )
     .option(
-      '--registry-ipfs-authorization-header [ipfsAuthorizationHeader]',
+      '--registry-ipfs-authorization-header <ipfsAuthorizationHeader>',
       'Authorization header for requests to the IPFS endpoint'
     )
     .option(
-      '--registry-rpc-url [https://...]',
+      '--registry-rpc-url <https://...>',
       'Network endpoint for interacting with the registry',
       DEFAULT_REGISTRY_ENDPOINT
     )
-    .option('--registry-address [0x...]', 'Address of the registry contract', DEFAULT_REGISTRY_ADDRESS)
+    .option('--registry-address <0x...>', 'Address of the registry contract', DEFAULT_REGISTRY_ADDRESS)
     .option('--fund-addresses <fundAddresses...>', 'Pass a list of addresses to receive a balance of 10,000 ETH')
     .option(
       '--impersonate <address>',
@@ -87,7 +86,7 @@ function configureRun(program: Command) {
       '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
     )
     .option('--mnemonic <phrase>', 'Use the specified mnemonic to initialize a chain of signers while running')
-    .option('--private-key <0xkey>', 'Use the specified private key hex to interact with the contracts')
+    .option('--private-key <0x...>', 'Use the specified private key hex to interact with the contracts')
     .action(async function (packages: PackageDefinition[], options, program) {
       const { run } = await import('./commands/run');
 
@@ -206,30 +205,30 @@ program
 program
   .command('deploy')
   .description('Deploy a cannon package to a network')
-  .argument('[packageWithSettings...]', 'Package to deploy, optionally with custom settings', parsePackageArguments)
-  .requiredOption('-n --network-rpc <networkRpc>', 'URL of a JSON-RPC server to use for deployment')
-  .requiredOption('-p --private-key <privateKey>', 'Private key of the wallet to use for deployment')
-  .option('-p --preset [preset]', 'Load an alternate setting preset', 'main')
-  .option('-d --cannon-directory [directory]', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
+  .argument('<packageWithSettings...>', 'Package to deploy, optionally with custom settings', parsePackageArguments)
+  .option('-p --private-key <privateKey>', 'Private key of the wallet to use for deployment')
+  .option('-n --network-rpc <networkRpc>', 'URL of a JSON-RPC server to use for deployment')
+  .option('-p --preset <preset>', 'Load an alternate setting preset', 'main')
+  .option('-d --cannon-directory <directory>', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
   .option('--write-deployments <path>', 'Path to write the deployments data (address and ABIs), like "./deployments"')
-  .option('--prefix [prefix]', 'Specify a prefix to apply to the deployment artifact outputs')
+  .option('--prefix <prefix>', 'Specify a prefix to apply to the deployment artifact outputs')
   .option('--dry-run', 'Simulate this deployment process without deploying the contracts to the specified network')
   .option('--wipe', 'Delete old, and do not attempt to download any from the repository')
   .option(
-    '--registry-ipfs-url [https://...]',
+    '--registry-ipfs-url <https://...>',
     'URL of the JSON-RPC server used to query the registry',
     DEFAULT_REGISTRY_IPFS_ENDPOINT
   )
   .option(
-    '--registry-ipfs-authorization-header [ipfsAuthorizationHeader]',
+    '--registry-ipfs-authorization-header <ipfsAuthorizationHeader>',
     'Authorization header for requests to the IPFS endpoint'
   )
   .option(
-    '--registry-rpc-url [https://...]',
+    '--registry-rpc-url <https://...>',
     'Network endpoint for interacting with the registry',
     DEFAULT_REGISTRY_ENDPOINT
   )
-  .option('--registry-address [0x...]', 'Address of the registry contract', DEFAULT_REGISTRY_ADDRESS)
+  .option('--registry-address <0x...>', 'Address of the registry contract', DEFAULT_REGISTRY_ADDRESS)
   .action(async function (packageDefinition, opts) {
     const { deploy } = await import('./commands/deploy');
 
@@ -242,7 +241,7 @@ program
 
     await deploy({
       packageDefinition,
-      cannonDirectory: opts.directory,
+      cannonDirectory: opts.cannonDirectory,
       projectDirectory,
       provider,
       mnemonic: opts.mnemonic,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -123,21 +123,21 @@ program
   .option('-a --artifacts-directory [artifacts]', 'Path to a directory with your artifact data', './out')
   .option('-d --cannon-directory [directory]', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
   .option(
-    '--registry-ipfs-url [https://...]',
+    '--registry-ipfs-url <https://...>',
     'URL of the JSON-RPC server used to query the registry',
     DEFAULT_REGISTRY_IPFS_ENDPOINT
   )
   .option(
-    '--registry-ipfs-authorization-header [ipfsAuthorizationHeader]',
+    '--registry-ipfs-authorization-header <ipfsAuthorizationHeader>',
     'Authorization header for requests to the IPFS endpoint'
   )
   .option(
-    '--registry-rpc-url [https://...]',
+    '--registry-rpc-url <https://...>',
     'Network endpoint for interacting with the registry',
     DEFAULT_REGISTRY_ENDPOINT
   )
+  .option('--registry-address <0x...>', 'Address of the registry contract', DEFAULT_REGISTRY_ADDRESS)
   .option('--write-deployments <path>', 'Path to write the deployments data (address and ABIs), like "./deployments"')
-  .option('--registry-address [0x...]', 'Address of the registry contract', DEFAULT_REGISTRY_ADDRESS)
   .showHelpAfterError('Use --help for more information.')
   .action(async function (cannonfile, settings, opts) {
     // If the first param is not a cannonfile, it should be parsed as settings
@@ -267,7 +267,7 @@ program
   .argument('<packageName>', 'Name and version of the Cannon package to verify')
   .option('-a --apiKey <apiKey>', 'Etherscan API key')
   .option('-n --network <network>', 'Network of deployment to verify', 'mainnet')
-  .option('-d --directory [directory]', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
+  .option('-d --directory <directory>', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
   .action(async function (packageName, options) {
     const { verify } = await import('./commands/verify');
     await verify(packageName, options.apiKey, options.network, options.directory);
@@ -286,7 +286,7 @@ program
   .command('inspect')
   .description('Inspect the details of a Cannon package')
   .argument('<packageName>', 'Name and version of the cannon package to inspect')
-  .option('-d --directory [directory]', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
+  .option('-d --directory <directory>', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
   .option('-j --json', 'Output as JSON')
   .action(async function (packageName, options) {
     const { inspect } = await import('./commands/inspect');
@@ -298,19 +298,30 @@ program
   .description('Publish a Cannon package to the registry')
   .argument('<packageName>', 'Name and version of the package to publish')
   .option('-p --private-key <privateKey>', 'Private key of the wallet to use when publishing')
-  .option('-d --directory [directory]', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
+  .option('-d --directory <directory>', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
   .option('-t --tags <tags>', 'Comma separated list of labels for your package', 'latest')
-  .option('-a --registryAddress <registryAddress>', 'Address for a custom package registry', DEFAULT_REGISTRY_ADDRESS)
-  .option('-r --registryEndpoint <registryEndpoint>', 'Address for RPC endpoint for the registry', DEFAULT_REGISTRY_ENDPOINT)
-  .option('-e --ipfsEndpoint <ipfsEndpoint>', 'Address for an IPFS endpoint')
-  .option('-h --ipfsAuthorizationHeader <ipfsAuthorizationHeader>', 'Authorization header for requests to the IPFS endpoint')
+  .option(
+    '--registry-ipfs-url <https://...>',
+    'URL of the JSON-RPC server used to query the registry',
+    DEFAULT_REGISTRY_IPFS_ENDPOINT
+  )
+  .option(
+    '--registry-ipfs-authorization-header <ipfsAuthorizationHeader>',
+    'Authorization header for requests to the IPFS endpoint'
+  )
+  .option(
+    '--registry-rpc-url <https://...>',
+    'Network endpoint for interacting with the registry',
+    DEFAULT_REGISTRY_ENDPOINT
+  )
+  .option('--registry-address <0x...>', 'Address of the registry contract', DEFAULT_REGISTRY_ADDRESS)
   .action(async function (packageName, options) {
     const { publish } = await import('./commands/publish');
 
     let registrationOptions: PublishRegistrationOptions | undefined = undefined;
 
-    if (options.registryEndpoint && options.privateKey) {
-      const provider = new ethers.providers.JsonRpcProvider(options.registryEndpoint);
+    if (options.registryRpcUrl && options.privateKey) {
+      const provider = new ethers.providers.JsonRpcProvider(options.registryRpcUrl);
       const wallet = new ethers.Wallet(options.privateKey, provider);
 
       registrationOptions = {
@@ -334,8 +345,8 @@ program
       options.directory,
       packageName,
       options.tags,
-      options.ipfsEndpoint,
-      options.ipfsAuthorizationHeader,
+      options.registryIpfsUrl,
+      options.registryIpfsAuthorizationHeader,
       registrationOptions
     );
   });
@@ -344,7 +355,7 @@ program
   .command('import')
   .description('Import a Cannon package from a zip archive')
   .argument('<importFile>', 'Relative path and filename to package archive')
-  .option('-d --directory [directory]', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
+  .option('-d --directory <directory>', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
   .action(async function (importFile, options) {
     const { importPackage } = await import('./commands/import');
     await importPackage(options.directory, importFile);
@@ -355,7 +366,7 @@ program
   .description('Export a Cannon package as a zip archive')
   .argument('<packageName>', 'Name and version of the cannon package to export')
   .argument('[outputFile]', 'Relative path and filename to export package archive')
-  .option('-d --directory [directory]', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
+  .option('-d --directory <directory>', 'Path to a custom package directory', DEFAULT_CANNON_DIRECTORY)
   .action(async function (packageName, outputFile, options) {
     const { exportPackage } = await import('./commands/export');
     await exportPackage(options.directory, outputFile, packageName);


### PR DESCRIPTION
This PR fixes several bugs that were on the CLI:

* There was a commands definition conflict having `npx cannon run` to be an alias when running only `npx cannon`. This caused to recognise other commands (e.g. `deploy`) as a param for `run`.
  * ❗ The simple solution for this was to just remove the alias.❗
* Several params that needed a value were defined using `[ ... ]` on commander. All of these were changed to `< ... >`
* Fixes the `--cannon-directory` param on `cannon deploy`