### PR TITLE
fix isolated skip context not carried over

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -337,7 +337,17 @@ ${printChainDefinitionProblems(problems)}`);
             await this.dumpAction(newCtx, n);
           }
         } else {
-          completed.set(n, thisStepCtx);
+          debug('skip isolated', n);
+          // even if this step has already been completed, there is a possibility that prior steps were executed and had unrelated changes
+          // since context is only able to add context, its safe to apply properties to downstream
+
+          const newCtx = { ...thisStepCtx, ...ctx };
+
+          completed.set(n, newCtx);
+
+          if (this.writeMode !== 'none') {
+            await this.dumpAction(newCtx, n);
+          }
         }
       }
     }


### PR DESCRIPTION
during package upgrades, if a step has no changes in the check hash, the step will be skipped even if dependencies had changed. This is desirable behavior. However, if the context of a upstream dependency has changed, it is important for that change to be carried over to subsequent contexts.

We can accomplish this by simply overriding the previous context onto the new context. This is acceptable since context can only extended by subsequent steps (aka, not upgraded).