### PR TITLE
fix default overrides on registry publish

### DIFF
--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -60,7 +60,7 @@ export class CannonRegistry {
     version: string,
     tags: string[],
     url: string,
-    overrides?: Overrides
+    overrides: Overrides = {}
   ): Promise<ethers.providers.TransactionReceipt> {
     if (!this.contract) {
       throw new Error('Contract not initialized');

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -56,7 +56,7 @@ export async function publish(
     splitTags = _.uniq(splitTags);
 
     if (!quiet) {
-      console.log(`Register package ${manifest.def.name}:${manifest.def.version} (tags:)...`);
+      console.log(`Register package ${manifest.def.name}:${manifest.def.version} (tags: ${splitTags.join(', ')})...`);
     }
 
     const txn = await registry.publish(


### PR DESCRIPTION
This PR fixes a bug when trying to publish a package without custom settings it wouldn't work, because ethers.js would think that the last `undefined` was an extra argument for the contract call.