### PR TITLE
add `--upgrade-from` option

### DIFF
--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -170,7 +170,7 @@ export class CannonRegistry {
     } catch (err) {
       try {
         // try to delete the mess we created
-        await fs.rmdir(packageDir);
+        await fs.remove(packageDir);
       } catch (_) {
         // do nothing here
       }

--- a/packages/builder/src/storage.ts
+++ b/packages/builder/src/storage.ts
@@ -34,6 +34,12 @@ export async function getAllDeploymentInfos(packageDir: string): Promise<Deploym
   return (await fs.readJson(file)) as DeploymentManifest;
 }
 
+export async function patchDeploymentManifest(packageDir: string, updatedManifest: Partial<DeploymentManifest>) {
+  const manifest = await getAllDeploymentInfos(packageDir);
+  _.assign(manifest, updatedManifest);
+  await fs.writeFile(getDeploymentInfoFile(packageDir), JSON.stringify(manifest, null, DEPLOY_FILE_INDENTATION));
+}
+
 export async function getDeploymentInfo(packageDir: string, network: number, label: string): Promise<DeploymentInfo | null> {
   const deployInfo = await getAllDeploymentInfos(packageDir);
 

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -135,6 +135,9 @@ export type DeploymentManifest = {
   // npm style package.json for the project being uploaded
   npmPackage: any;
 
+  // tag of the package which was used as the base for this package
+  upgradeFrom?: string;
+
   // archive which contains miscellaneus dependencies ex. documentation pages, contracts, etc.
   misc: {
     ipfsHash: string;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -141,6 +141,7 @@ export async function run(packages: PackageDefinition[], options: RunOptions) {
         ...options,
         packageDefinition: pkg,
         node,
+        registry,
         preset: options.preset,
         persist: false,
         deploymentPath: options.writeDeployments ? resolve(options.writeDeployments) : undefined,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,7 @@ import { RegistrationOptions as PublishRegistrationOptions } from './commands/pu
 import prompts from 'prompts';
 import { interact } from './interact';
 import { getContractsRecursive } from './util/contracts-recursive';
+import createRegistry from './registry';
 
 // Can we avoid doing these exports here so only the necessary files are loaded when running a command?
 export { build } from './commands/build';
@@ -134,6 +135,10 @@ program
   .description('Build a package from a Cannonfile')
   .argument('[cannonfile]', 'Path to a cannonfile', 'cannonfile.toml')
   .argument('[settings...]', 'Custom settings for building the cannonfile')
+  .option(
+    '--upgrade-from [cannon-package:0.0.1]',
+    'Wipe the deployment files, and use the deployment files from another cannon package as base'
+  )
   .option('-p --preset <preset>', 'The preset label for storing the build with the given settings', 'main')
   .option(
     '-c --contracts-directory [contracts]',
@@ -203,6 +208,13 @@ program
     const { build } = await import('./commands/build');
     const { name, version } = loadCannonfile(cannonfilePath);
 
+    const registry = createRegistry({
+      registryAddress: opts.registryAddress,
+      registryRpc: opts.registryRpcUrl,
+      ipfsUrl: opts.registryIpfsUrl,
+      ipfsAuthorizationHeader: opts.registryIpfsAuthorizationHeader,
+    });
+
     await build({
       node,
       cannonfilePath,
@@ -214,11 +226,9 @@ program
       getArtifact,
       cannonDirectory: opts.cannonDirectory,
       projectDirectory,
+      upgradeFrom: opts.upgradeFrom,
       preset: opts.preset,
-      registryIpfsUrl: opts.registryIpfsUrl,
-      registryIpfsAuthorizationHeader: opts.registryIpfsAuthorizationHeader,
-      registryRpcUrl: opts.registryRpcUrl,
-      registryAddress: opts.registryAddress,
+      registry,
       deploymentPath,
     });
 

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { task } from 'hardhat/config';
 import { TASK_COMPILE } from 'hardhat/builtin-tasks/task-names';
+import { HttpNetworkConfig } from 'hardhat/types';
 import { ethers } from 'ethers';
 import { build, runRpc, parseSettings } from '@usecannon/cli';
 import { TASK_BUILD } from '../task-names';
@@ -8,15 +9,20 @@ import { CANNON_NETWORK_NAME } from '../constants';
 import { augmentProvider } from '../internal/augment-provider';
 import loadCannonfile from '../internal/load-cannonfile';
 import { getHardhatSigners } from '../internal/get-hardhat-signers';
+import { CannonRegistry } from '@usecannon/builder';
 
 task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can be used later')
   .addPositionalParam('cannonfile', 'Path to a cannonfile to build', 'cannonfile.toml')
   .addOptionalVariadicPositionalParam('settings', 'Custom settings for building the cannonfile', [])
+  .addOptionalParam(
+    'upgradeFrom',
+    'Wipe the deployment files, and use the deployment files from another cannon package as base'
+  )
   .addOptionalParam('preset', 'The preset label for storing the build with the given settings', 'main')
   .addOptionalParam('writeDeployments', 'Path to write the deployments data (address and ABIs), like "./deployments"')
   .addFlag('noCompile', 'Do not execute hardhat compile before build')
   .addFlag('wipe', 'Do not reuse any previously built artifacts')
-  .setAction(async ({ cannonfile, settings, preset, noCompile, wipe, writeDeployments }, hre) => {
+  .setAction(async ({ cannonfile, settings, upgradeFrom, preset, noCompile, wipe, writeDeployments }, hre) => {
     if (hre.network.name !== CANNON_NETWORK_NAME) {
       throw new Error(
         `cannot build cannon image with hardhat network '${hre.network.name}'. Switch network to '${CANNON_NETWORK_NAME}', or use cannon:deploy instead.`
@@ -41,6 +47,24 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
 
     const node = await runRpc({ port: hre.config.networks.cannon.port });
 
+    let registry: CannonRegistry;
+    if (hre.config.cannon.ipfsEndpoint) {
+      const ipfsOptions = {
+        url: hre.config.cannon.ipfsEndpoint,
+        headers: {
+          authorization: hre.config.cannon.ipfsAuthorizationHeader || '',
+        },
+      };
+
+      registry = new CannonRegistry({
+        ipfsOptions,
+        signerOrProvider: new ethers.providers.JsonRpcProvider((hre.config.networks.mainnet as HttpNetworkConfig)?.url),
+        address: hre.config.cannon.registryAddress,
+      });
+    } else {
+      throw new Error('cannot download package dependencies! please configure an IPFS registry.');
+    }
+
     const params = {
       cannonfilePath,
       node,
@@ -53,12 +77,10 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
       cannonDirectory: hre.config.paths.cannon,
       projectDirectory: hre.config.paths.root,
       preset,
+      upgradeFrom,
       wipe,
       deploymentPath: writeDeployments ? path.resolve(writeDeployments) : undefined,
-      registryIpfsUrl: hre.config.cannon.ipfsEndpoint,
-      registryIpfsAuthorizationHeader: hre.config.cannon.ipfsAuthorizationHeader,
-      registryRpcUrl: hre.config.cannon.registryEndpoint,
-      registryAddress: hre.config.cannon.registryAddress,
+      registry,
     } as const;
 
     const { outputs, provider } = await build(params);


### PR DESCRIPTION
for upgradable/proxy protocols, allow for generation of deployments using a previous deployment as a base.

cannon will automatically detect any changes and only run deployment steps for those changes.

the deployment manifest file will contain a `upgradeFrom` option, allowing for a user to step back through the upgrade history for a package, which is pretty cool!