### PR TITLE
Add npm modules compatibility on run steps

### DIFF
--- a/packages/builder/src/helpers/import-from.ts
+++ b/packages/builder/src/helpers/import-from.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+interface ErrorWithCode extends Error {
+  code: string;
+}
+
+/**
+ * Try to import a file relative to the given baseDir, if not present, try to
+ * get the relative NPM Module.
+ */
+export async function importFrom(baseDir: string, fileOrModule: string) {
+  try {
+    return await import(path.resolve(baseDir, fileOrModule));
+  } catch (e) {
+    const err = e as ErrorWithCode;
+    if (err.code === 'MODULE_NOT_FOUND') {
+      const localRequire = createRequire(baseDir);
+      return await import(localRequire.resolve(fileOrModule));
+    }
+    throw err;
+  }
+}

--- a/packages/builder/src/steps/run.ts
+++ b/packages/builder/src/steps/run.ts
@@ -1,8 +1,9 @@
+import path from 'node:path';
 import _ from 'lodash';
 import Debug from 'debug';
 import { JTDDataType } from 'ajv/dist/core';
-import { join } from 'path';
 
+import { importFrom } from '../helpers/import-from';
 import { ChainBuilderContext, ChainBuilderRuntime, ChainArtifacts } from '../types';
 import { hashFs } from '../util';
 
@@ -93,7 +94,7 @@ export default {
       );
     }
 
-    const runfile = await import(join(runtime.baseDir, config.exec));
+    const runfile = await importFrom(runtime.baseDir, config.exec);
 
     const outputs = (await runfile[config.func](runtime, ...(config.args || []))) as Omit<ChainArtifacts, 'deployedOn'>;
 


### PR DESCRIPTION
This PR adds the possibility of executing scripts on Run steps coming from an NPM dependency, e.g.:

```toml
[run.generate_router]
exec = "@synthetixio/core-router"
func = "generate"
args = ["contracts/routers/chain-<%= chainId %>/Router.sol:Router"]
```