### PR TITLE
add capability to write `extras` from invokes

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -284,10 +284,7 @@ previous txn deployed at: ${ctx.txns[txn].hash} in step ${'tbd'}`
       let newCtx = _.clone(ctx);
       for (const action of layer.actions) {
         debug('run action in layer', action);
-        newCtx = combineCtx([
-          newCtx, 
-          await this.runStep(action, _.clone(ctx))
-        ]);
+        newCtx = combineCtx([newCtx, await this.runStep(action, _.clone(ctx))]);
       }
 
       // after all contexts are built, save all of them at the same time

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -51,6 +51,7 @@ export enum Events {
   PostStepExecute = 'post-step-execute',
   DeployContract = 'deploy-contract',
   DeployTxn = 'deploy-txn',
+  DeployExtra = 'deploy-extra',
 }
 
 const DEFAULT_PRESET = 'main';
@@ -187,6 +188,18 @@ previous txn deployed at: ${ctx.txns[txn].hash} in step ${'tbd'}`
 
         ctx.txns[txn] = txns[txn];
         this.emit(Events.DeployTxn, n, txns[txn]);
+      }
+
+      for (const n in output.extras) {
+        if (ctx.extras[n]) {
+          // name reused
+          throw new Error(
+            `duplicate extra label ${n}. Please double check your cannonfile/scripts to ensure a txn name is used only once.`
+          );
+        }
+
+        ctx.extras[n] = output.extras[n];
+        this.emit(Events.DeployExtra, n, ctx.extras[n]);
       }
     }
 
@@ -483,6 +496,8 @@ ${printChainDefinitionProblems(problems)}`);
       txns: {},
 
       imports: {},
+
+      extras: {},
     };
   }
 

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -56,6 +56,7 @@ export async function downloadPackagesRecursive(
     contracts: {},
     txns: {},
     imports: {},
+    extras: {},
   });
 
   for (const dependency of dependencies) {

--- a/packages/builder/src/steps/invoke.ts
+++ b/packages/builder/src/steps/invoke.ts
@@ -33,7 +33,7 @@ const config = {
         properties: {
           event: { type: 'string' },
           arg: { type: 'int32' },
-        }
+        },
       },
     },
     factory: {
@@ -116,29 +116,24 @@ async function runTxn(
   return [receipt, txnEvents as EncodedTxnEvents];
 }
 
-function parseEventOutputs(
-  config: Config['extra'], 
-  txnEvents: EncodedTxnEvents[]
-): { [label: string]: string } {
+function parseEventOutputs(config: Config['extra'], txnEvents: EncodedTxnEvents[]): { [label: string]: string } {
   const vals: { [label: string]: string } = {};
 
   if (config) {
     for (const n in txnEvents) {
       for (const [name, extra] of Object.entries(config)) {
-  
         const events = _.entries(txnEvents[n][extra.event]);
         for (const [i, e] of events) {
-  
           let label = name;
-  
+
           if (txnEvents.length > 1) {
             label += '_' + n;
           }
-  
+
           if (events.length > 1) {
             label += '_' + i;
           }
-  
+
           vals[label] = e.args[extra.arg];
         }
       }
@@ -146,7 +141,6 @@ function parseEventOutputs(
   }
 
   return vals;
-
 }
 
 // ensure the specified contract is already deployed
@@ -307,7 +301,7 @@ ${getAllContractPaths(ctx).join('\n')}`);
     return {
       contracts,
       txns,
-      extras
+      extras,
     };
   },
 };

--- a/packages/builder/src/steps/keeper.ts
+++ b/packages/builder/src/steps/keeper.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { JTDDataType } from 'ajv/dist/core';
 
-import { ChainBuilderContext, ChainBuilderRuntime } from '../types';
+import { ChainArtifacts, ChainBuilderContext, ChainBuilderRuntime } from '../types';
 import { ChainDefinitionScriptSchema } from '../util';
 
 export type Config = JTDDataType<typeof ChainDefinitionScriptSchema>;
@@ -41,7 +41,7 @@ export default {
   },
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async exec(_runtime: ChainBuilderRuntime, _ctx: ChainBuilderContext, _config: Config): Promise<Outputs> {
+  async exec(_runtime: ChainBuilderRuntime, _ctx: ChainBuilderContext, _config: Config): Promise<ChainArtifacts> {
     return {};
   },
 };

--- a/packages/builder/src/steps/run.ts
+++ b/packages/builder/src/steps/run.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import _ from 'lodash';
 import Debug from 'debug';
 import { JTDDataType } from 'ajv/dist/core';

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -63,6 +63,8 @@ export interface ChainBuilderContext {
   txns: TransactionMap;
 
   imports: BundledChainBuilderOutputs;
+
+  extras: { [label: string]: string };
 }
 
 export type BuildOptions = { [val: string]: OptionTypesTs };
@@ -104,7 +106,7 @@ export interface BundledChainBuilderOutputs {
   [module: string]: ChainArtifacts;
 }
 
-export type ChainArtifacts = Partial<Pick<ChainBuilderContext, 'imports' | 'contracts' | 'txns'>>;
+export type ChainArtifacts = Partial<Pick<ChainBuilderContext, 'imports' | 'contracts' | 'txns' | 'extras'>>;
 
 export interface ChainBuilderOptions {
   [key: string]: OptionTypesTs;
@@ -160,6 +162,7 @@ export function combineCtx(ctxs: ChainBuilderContext[]): ChainBuilderContext {
     ctx.contracts = { ...ctx.contracts, ...additionalCtx.contracts };
     ctx.txns = { ...ctx.txns, ...additionalCtx.txns };
     ctx.imports = { ...ctx.imports, ...additionalCtx.imports };
+    ctx.extras = { ...ctx.extras, ...additionalCtx.extras };
   }
 
   return ctx;

--- a/packages/builder/src/util.test.ts
+++ b/packages/builder/src/util.test.ts
@@ -123,6 +123,7 @@ describe('util.ts', () => {
     chainId: 0,
     timestamp: '0',
     package: {},
+    extras: {}
   };
 
   describe('getContractFromPath()', () => {

--- a/packages/builder/src/util.test.ts
+++ b/packages/builder/src/util.test.ts
@@ -3,7 +3,6 @@ import { getContractFromPath, getMergedAbiFromContractPaths } from './util';
 import 'jest';
 import { ChainBuilderContext } from '.';
 import { JsonFragment } from '@ethersproject/abi';
-import { ethers } from 'ethers';
 
 describe('util.ts', () => {
   const fakeTransferFragment: JsonFragment = {
@@ -73,7 +72,7 @@ describe('util.ts', () => {
   const fakeCtx: ChainBuilderContext = {
     contracts: {
       FakeContract: {
-        address: "0x0000000000000000000000000000000000000000",
+        address: '0x0000000000000000000000000000000000000000',
         contractName: '',
         sourceName: '',
         deployTxnHash: '',
@@ -82,7 +81,7 @@ describe('util.ts', () => {
       },
 
       AnotherFake: {
-        address: "0x0000000000000000000000000000000000000001",
+        address: '0x0000000000000000000000000000000000000001',
         contractName: '',
         sourceName: '',
         deployTxnHash: '',
@@ -96,19 +95,19 @@ describe('util.ts', () => {
           SuperFake: {
             contracts: {
               TheFakest: {
-                address: "0x0000000000000000000000000000000000000002",
+                address: '0x0000000000000000000000000000000000000002',
                 contractName: '',
                 sourceName: '',
                 deployTxnHash: '',
                 deployedOn: '',
                 abi: [fakeTransferFragment, fakeReadFragment],
-              }
-            }
-          }
+              },
+            },
+          },
         },
         contracts: {
           AnotherFake: {
-            address: "0x0000000000000000000000000000000000000003",
+            address: '0x0000000000000000000000000000000000000003',
             contractName: '',
             sourceName: '',
             deployTxnHash: '',
@@ -123,23 +122,24 @@ describe('util.ts', () => {
     chainId: 0,
     timestamp: '0',
     package: {},
-    extras: {}
+    extras: {},
   };
 
   describe('getContractFromPath()', () => {
     it('works with no depth', async () => {
-      expect(getContractFromPath(fakeCtx, 'FakeContract')?.address)
-        .toEqual("0x0000000000000000000000000000000000000000");
+      expect(getContractFromPath(fakeCtx, 'FakeContract')?.address).toEqual('0x0000000000000000000000000000000000000000');
     });
 
     it('works with one layer of depth', async () => {
-      expect(getContractFromPath(fakeCtx, 'FakeImport.AnotherFake')?.address)
-      .toEqual("0x0000000000000000000000000000000000000003");
+      expect(getContractFromPath(fakeCtx, 'FakeImport.AnotherFake')?.address).toEqual(
+        '0x0000000000000000000000000000000000000003'
+      );
     });
 
     it('works with two layers of depth', async () => {
-      expect(getContractFromPath(fakeCtx, 'FakeImport.SuperFake.TheFakest')?.address)
-      .toEqual("0x0000000000000000000000000000000000000002");
+      expect(getContractFromPath(fakeCtx, 'FakeImport.SuperFake.TheFakest')?.address).toEqual(
+        '0x0000000000000000000000000000000000000002'
+      );
     });
   });
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -181,6 +181,7 @@ export async function build({
   builder.on(Events.PreStepExecute, (t, n) => console.log(`\nexec: ${t}.${n}`));
   builder.on(Events.DeployContract, (n, c) => console.log(`deployed contract ${n} (${c.address})`));
   builder.on(Events.DeployTxn, (n, t) => console.log(`ran txn ${n} (${t.hash})`));
+  builder.on(Events.DeployExtra, (n, v) => console.log(`extra data ${n} (${v})`));
 
   const outputs = await builder.build(packageDefinition.settings);
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -184,6 +184,7 @@ export async function deploy(options: DeployOptions) {
   builder.on(Events.PreStepExecute, (t, n) => console.log(`\nexec: ${t}.${n}`));
   builder.on(Events.DeployContract, (n, c) => console.log(`deployed contract ${n} (${c.address})`));
   builder.on(Events.DeployTxn, (n, t) => console.log(`ran txn ${n} (${t.hash})`));
+  builder.on(Events.DeployExtra, (n, v) => console.log(`extra data ${n} (${v})`));
 
   const outputs = await builder.build(options.packageDefinition.settings);
 

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -114,6 +114,7 @@ export function loadCannonfile(filepath: string) {
     contracts: {},
     txns: {},
     imports: {},
+    extras: {},
   };
 
   const name = def.getName(ctx);

--- a/packages/cli/src/interact.ts
+++ b/packages/cli/src/interact.ts
@@ -380,12 +380,12 @@ async function promptInputValue(input: Ethers.utils.ParamType): Promise<any> {
 }
 
 function parseInput(input: Ethers.utils.ParamType, rawValue: string): any {
-  const requiresBytes32Util = input.type.includes('bytes32');
+  const isBytes32 = input.type.includes('bytes32');
   const isArray = input.type.includes('[]');
   const isNumber = input.type.includes('int');
 
   let processed = isArray ? JSON.parse(rawValue) : rawValue;
-  if (requiresBytes32Util) {
+  if (isBytes32 && !ethers.utils.isBytesLike(processed)) {
     if (isArray) {
       processed = processed.map((item: string) => Ethers.utils.formatBytes32String(item));
     } else {

--- a/packages/cli/src/util/printer.ts
+++ b/packages/cli/src/util/printer.ts
@@ -21,4 +21,13 @@ export function printChainBuilderOutput(output: ChainBuilderContext) {
       console.log(table(formattedData));
     }
   }
+
+  if (output.extras) {
+    const formattedData = _.map(output.extras, (v, k) => [k, v]);
+
+    if (formattedData.length) {
+      console.log('EXTRA DATA:');
+      console.log(table(formattedData));
+    }
+  }
 }

--- a/packages/hardhat-cannon/src/internal/load-cannonfile.ts
+++ b/packages/hardhat-cannon/src/internal/load-cannonfile.ts
@@ -71,6 +71,7 @@ export default function loadCannonfile(hre: HardhatRuntimeEnvironment, filepath:
     contracts: {},
     txns: {},
     imports: {},
+    extras: {},
   };
 
   const name = def.getName(ctx);

--- a/packages/hardhat-cannon/src/subtasks/load-package-definition.ts
+++ b/packages/hardhat-cannon/src/subtasks/load-package-definition.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-import { HardhatPluginError } from 'hardhat/plugins';
 import { subtask } from 'hardhat/config';
 
 import { SUBTASK_LOAD_PACKAGE_DEFINITION } from '../task-names';

--- a/packages/hardhat-cannon/src/tasks/deploy.ts
+++ b/packages/hardhat-cannon/src/tasks/deploy.ts
@@ -1,11 +1,10 @@
 import { task } from 'hardhat/config';
-import { deploy, PackageDefinition, parsePackageArguments } from '@usecannon/cli';
+import { deploy } from '@usecannon/cli';
 import { SUBTASK_LOAD_PACKAGE_DEFINITION, TASK_DEPLOY } from '../task-names';
 import { ethers } from 'ethers';
 import { HttpNetworkConfig, HttpNetworkHDAccountsConfig } from 'hardhat/types';
 import { CANNON_NETWORK_NAME } from '../constants';
 import { augmentProvider } from '../internal/augment-provider';
-import loadCannonfile from '../internal/load-cannonfile';
 import { CannonWrapperGenericProvider } from '@usecannon/builder';
 import path from 'path';
 import { getHardhatSigners } from '../internal/get-hardhat-signers';


### PR DESCRIPTION
sometimes it is necessary to store values which are not addresses after executing an invoke statement.

a new data structure has been added to the cannon ctx to handle this called `extras`.

sorry if the name isn't great, I didn't want to say `outputs` or `misc` because both of those terms are used elsewhere, and in truth this functionality should be avoided unless it is really necessary for whatever cannon package you are building.