### PR TITLE
Fix overrideCannonfile usage on deploy

### DIFF
--- a/packages/hardhat-cannon/src/tasks/deploy.ts
+++ b/packages/hardhat-cannon/src/tasks/deploy.ts
@@ -31,7 +31,12 @@ task(TASK_DEPLOY, 'Deploy a cannon package to a network')
       throw new Error(`cannot deploy to '${CANNON_NETWORK_NAME}'. Use cannon:build instead.`);
     }
 
+    const overrideCannonfilePath = opts.overrideManifest
+      ? path.resolve(hre.config.paths.root, opts.overrideManifest)
+      : undefined;
+
     const packageDefinition = await hre.run(SUBTASK_LOAD_PACKAGE_DEFINITION, {
+      cannonfile: overrideCannonfilePath,
       packageWithSettingsParams: opts.packageWithSettings,
     });
 
@@ -67,7 +72,7 @@ task(TASK_DEPLOY, 'Deploy a cannon package to a network')
 
     const { outputs } = await deploy({
       packageDefinition,
-      overrideCannonfilePath: opts.overrideManifest ? path.resolve(hre.config.paths.root, opts.overrideManifest) : undefined,
+      overrideCannonfilePath,
 
       // we have to wrap the provider here because of the third argument, prevent any reading-into for the hardhat-network
       provider,


### PR DESCRIPTION
This PR fixes the usage of the `overrideManifest` param on deploy. It wasn't working if it didn't exist a `cannonfile.toml` next to the custom cannonfile.