### PR TITLE
Add nested structures to write deployments

### DIFF
--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -25,19 +25,21 @@ export type ContractArtifact = {
   };
 };
 
+export type ContractData = {
+  address: string;
+  abi: JsonFragment[];
+  constructorArgs?: any[]; // only needed for etherscan verification
+  // only needed for etherscan verification,
+  // only should be supplied when generated solidity as a single file
+  sourceCode?: string;
+  deployTxnHash: string;
+  contractName: string;
+  sourceName: string;
+  deployedOn: string;
+};
+
 export type ContractMap = {
-  [label: string]: {
-    address: string;
-    abi: JsonFragment[];
-    constructorArgs?: any[]; // only needed for etherscan verification
-    // only needed for etherscan verification,
-    // only should be supplied when generated solidity as a single file
-    sourceCode?: string;
-    deployTxnHash: string;
-    contractName: string;
-    sourceName: string;
-    deployedOn: string;
-  };
+  [label: string]: ContractData;
 };
 
 export type TransactionMap = {


### PR DESCRIPTION
This PR adds all the nested contracts from the `imports` when writing deployments files. Creating a sub directory for each `provision.*` or `import.*` state.