### PR TITLE
some issues with upgrades resolved

### DIFF
--- a/packages/builder/src/actions.ts
+++ b/packages/builder/src/actions.ts
@@ -13,7 +13,7 @@ import { ChainArtifacts, ChainBuilderContext, ChainBuilderContextWithHelpers } f
 export interface Action {
   configInject: (ctx: ChainBuilderContextWithHelpers, config: any) => any;
 
-  getState: (runtime: ChainBuilderRuntime, ctx: ChainBuilderContextWithHelpers, config: any) => any;
+  getState: (runtime: ChainBuilderRuntime, ctx: ChainBuilderContextWithHelpers, config: any, currentLabel?: string) => any;
 
   exec: (
     runtime: ChainBuilderRuntime,

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -94,7 +94,7 @@ ${printChainDefinitionProblems(problems)}`);
   } else {
     debug('building individual');
     doActions: for (const n of topologicalActions) {
-      const ctx = _.clone(initialCtx);
+      const ctx = _.cloneDeep(initialCtx);
 
       const artifacts: ChainArtifacts = {};
 
@@ -115,6 +115,7 @@ ${printChainDefinitionProblems(problems)}`);
 
       // also add self artifacts here so that we can self-reference from inside the step
       if (state[n]) {
+        debug('adding self artifacts to context', state[n].artifacts);
         addOutputsToContext(ctx, state[n].artifacts);
       }
 
@@ -246,6 +247,7 @@ async function buildLayer(
 
       // also add self artifacts here so that we can self-reference from inside the step
       if (state[action] && state[action].artifacts) {
+        debug('adding self artifacts to context', state[action].artifacts);
         addOutputsToContext(ctx, state[action].artifacts);
       }
 

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -133,7 +133,8 @@ export class ChainDefinition {
     const obj = await ActionKinds[kind].getState(
       runtime,
       { ...ctx, ...ethers.utils, ...ethers.constants },
-      this.getConfig(n, ctx) as any
+      this.getConfig(n, ctx) as any,
+      n
     );
 
     if (!obj) {


### PR DESCRIPTION
while upgrading synthetix today we ran into some probs:

* its possible for some bad state to be carried over steps through `_.clone` instead of `_.cloneDeep`
* provision of partial deployments will not be run unless we actually check the status of the deployment

both these issues have been resolved with this PR, and tested against the observed cases to verify.

test commands:

```
npx cannon build omnibus-goerli.toml --upgrade-from synthetix-omnibus:3.0.0-alpha.8 --network https://goerli.infura.io/v3/$INFURA_KEY --dry-run
npx cannon build omnibus-optimism-goerli.toml --upgrade-from synthetix-omnibus:3.0.0-alpha.10 --network https://optimism-goerli.infura.io/v3/$INFURA_KEY --dry-run
npx cannon build omnibus-goerli.toml --upgrade-from synthetix-omnibus:3.0.0-alpha.10 --network https://goerli.infura.io/v3/$INFURA_KEY --dry-run
```