### PR TITLE
Fix usage of hardhat accounts during build when impersonating

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.0.8"
+  "version": "2.0.9-alpha.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "root",
+      "license": "GNU GPL V3.0",
       "devDependencies": {
         "@babel/core": "^7.17.5",
         "@babel/plugin-transform-runtime": "^7.17.0",

--- a/packages/hardhat-cannon/package-lock.json
+++ b/packages/hardhat-cannon/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-cannon",
-  "version": "2.0.8",
+  "version": "2.0.9-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/hardhat-cannon/package.json
+++ b/packages/hardhat-cannon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-cannon",
-  "version": "2.0.8",
+  "version": "2.0.9-alpha.1",
   "description": "Agnostic chain construction. Select the protocols and configuration you need to quickly and easily verify your project",
   "repository": "github:usecannon/cannon",
   "author": "Synthetix",

--- a/packages/hardhat-cannon/package.json
+++ b/packages/hardhat-cannon/package.json
@@ -2,7 +2,7 @@
   "name": "hardhat-cannon",
   "version": "2.0.8",
   "description": "Agnostic chain construction. Select the protocols and configuration you need to quickly and easily verify your project",
-  "repository": "github:Synthetixio/cannon",
+  "repository": "github:usecannon/cannon",
   "author": "Synthetix",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -53,6 +53,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
       console.log('using hardhat network provider');
       provider = new CannonWrapperGenericProvider({}, hre.ethers.provider, false);
     }
+
     if (dryRun || hre.network.name === 'cannon') {
       const opts: RpcOptions = { port: hre.config.networks.cannon.port };
 
@@ -65,17 +66,26 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
       provider = getProvider(node);
     }
 
-    let signers: ethers.Signer[] = [];
-    if (!impersonate) {
-      signers = getHardhatSigners(hre, provider);
-    }
+    const signers = getHardhatSigners(hre, provider);
+
+    const getSigner = async (addr: string) => {
+      addr = addr.toLowerCase();
+      for (const signer of signers) {
+        const signerAddr = await signer.getAddress();
+        if (addr === signerAddr.toLowerCase()) return signer.connect(provider);
+      }
+    };
 
     let defaultSigner: ethers.Signer | null = null;
     if (impersonate) {
       await provider.send('hardhat_impersonateAccount', [impersonate]);
       await provider.send('hardhat_setBalance', [impersonate, `0x${(1e22).toString(16)}`]);
-      defaultSigner = provider.getSigner(impersonate);
-      signers.push(defaultSigner);
+      defaultSigner = (await getSigner(impersonate)) || null;
+      // Add the impersonated signer if it is not part of the hardhat config
+      if (!defaultSigner) {
+        defaultSigner = provider.getSigner(impersonate);
+        signers.push(defaultSigner);
+      }
     } else if (hre.network.name !== CANNON_NETWORK_NAME) {
       defaultSigner = signers[0].connect(provider);
     }
@@ -102,11 +112,8 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
           return provider.getSigner(addr);
         } else {
           // return the actual signer with private key
-          for (const signer of signers) {
-            if (addr.toLowerCase() === (await signer.getAddress()).toLowerCase()) {
-              return signer.connect(provider);
-            }
-          }
+          const signer = await getSigner(addr);
+          if (signer) return signer;
 
           throw new Error(
             `the current step requests usage of the signer with address ${addr}, but this signer is not found. Please either supply the private key, or change the cannon configuration to use a different signer.`
@@ -125,8 +132,6 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
     } as const;
 
     const { outputs } = await build(params);
-
-    //const signers: ethers.Signer[] = [];
 
     augmentProvider(hre, outputs);
     provider.artifacts = outputs;

--- a/packages/registry/package-lock.json
+++ b/packages/registry/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cannon-registry",
-	"version": "2.0.8",
+	"version": "2.0.9-alpha.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cannon-registry",
-  "version": "2.0.8",
+  "version": "2.0.9-alpha.1",
   "private": true,
   "description": "Contract registry for Cannon images",
   "scripts": {
@@ -29,7 +29,7 @@
     "dotenv": "16.0.1",
     "ethers": "5.7.1",
     "hardhat": "^2.12.6",
-    "hardhat-cannon": "^2.0.8",
+    "hardhat-cannon": "^2.0.9-alpha.1",
     "hardhat-contract-sizer": "^2.7.0",
     "hardhat-gas-reporter": "^1.0.9",
     "mocha": "10.0.0",

--- a/packages/sample-hardhat-project/package-lock.json
+++ b/packages/sample-hardhat-project/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-hardhat-project",
-  "version": "2.0.8",
+  "version": "2.0.9-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/sample-hardhat-project/package.json
+++ b/packages/sample-hardhat-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-hardhat-project",
-  "version": "2.0.8",
+  "version": "2.0.9-alpha.1",
   "private": true,
   "scripts": {
     "test": "hardhat test"
@@ -17,7 +17,7 @@
     "dotenv": "^10.0.0",
     "ethers": "^5.7.1",
     "hardhat": "^2.9.1",
-    "hardhat-cannon": "^2.0.8",
+    "hardhat-cannon": "^2.0.9-alpha.1",
     "hardhat-gas-reporter": "^1.0.8",
     "hardhat-interact": "^0.2.0",
     "solidity-coverage": "^0.7.20",


### PR DESCRIPTION
This PR fixes a bug on the hardhat-cannon package, that caused during build using the `--impersonate` param to not return all the hardhat signers.