### PR TITLE
fix topology edge case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "root",
+      "license": "GNU GPL V3.0",
       "devDependencies": {
         "@babel/core": "^7.17.5",
         "@babel/plugin-transform-runtime": "^7.17.0",

--- a/packages/builder/jest.config.ts
+++ b/packages/builder/jest.config.ts
@@ -159,9 +159,9 @@ export default {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: [
+     "/dist/"
+  ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/packages/builder/src/create2.test.ts
+++ b/packages/builder/src/create2.test.ts
@@ -2,7 +2,7 @@ import { ARACHNID_CREATE2_PROXY } from './constants';
 import { makeArachnidCreate2Txn } from './create2';
 
 describe('util.ts', () => {
-  describe('deployArachnidCreate2()', async () => {
+  describe('deployArachnidCreate2()', () => {
     // todo when we have mock/dummy runtime
   });
 

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -401,6 +401,11 @@ export class ChainDefinition {
           layers[dependingLayer].actions.push(...layers[attachingLayer].actions);
           layers[dependingLayer].depends = _.uniq([...layers[dependingLayer].depends, ...layers[attachingLayer].depends]);
 
+          // ensure the other nodes are now pointing to this structure
+          for (const a of layers[attachingLayer].actions) {
+            layers[a] = layers[dependingLayer];
+          }
+
           attachingLayer = dependingLayer;
         } else if (layers[attachingLayer].depends.indexOf(depLayer) === -1) {
           // "extend" this layer to encapsulate this


### PR DESCRIPTION
while building the uniswap pkg found this exciting error that occurs when layers are merged twice. Some of the old dependencies get detached, and you end up with this extra "island" of incomplete dependencies