### PR TITLE
Add error throw when trying to use hardhat network with --dry-run

### DIFF
--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -48,6 +48,10 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
     let provider = new CannonWrapperGenericProvider({}, new ethers.providers.JsonRpcProvider(providerUrl));
 
     if (hre.network.name === 'hardhat') {
+      if (dryRun) {
+        throw new Error('You cannot use --dry-run param when using the "hardhat" network');
+      }
+
       // hardhat network is "special" in that it looks like its a jsonrpc provider,
       // but really you can't use it like that.
       console.log('using hardhat network provider');


### PR DESCRIPTION
It does not make sense to configure --dry-run when using the `hardhat` network. If you would need to use create a fork using the hardhat network, it can be done on hardhat's config: https://hardhat.org/hardhat-network/docs/guides/forking-other-networks#forking-from-mainnet