### PR TITLE
add capability to grant additional deployers

### DIFF
--- a/packages/registry/contracts/CannonRegistry.sol
+++ b/packages/registry/contracts/CannonRegistry.sol
@@ -82,7 +82,7 @@ contract CannonRegistry is Storage, EfficientStorage, OwnedUpgradable {
     if (owner != address(0) && owner != msg.sender) {
       uint additionalDeployersLength = _p.additionalDeployersLength;
       bool foundAdditionalDeployer = false;
-      for (uint i = 0;i < additionalDeployersLength;i++) {
+      for (uint i = 0; i < additionalDeployersLength; i++) {
         foundAdditionalDeployer = foundAdditionalDeployer || _p.additionalDeployers[i] == msg.sender;
       }
 

--- a/packages/registry/contracts/EfficientStorage.sol
+++ b/packages/registry/contracts/EfficientStorage.sol
@@ -16,6 +16,8 @@ contract EfficientStorage {
     mapping(bytes32 => mapping(bytes32 => CannonDeployInfo)) deployments;
     address owner;
     address nominatedOwner;
+    uint additionalDeployersLength;
+    mapping(uint => address) additionalDeployers;
   }
 
   struct CannonDeployInfo {


### PR DESCRIPTION
the owner of a package may grant a list of additional deployers. these deployers can publish to a package as if they are the owner.

this is useful if you want to have multiple parties deploying a package, and want to lower the security level of publishing a package (since deployers do not have permission to nominate a new owner)