### PR TITLE
run forge build when using cli

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -220,6 +220,8 @@ program
   .option('-a --artifacts-directory [artifacts]', 'Path to a directory with your artifact data', './out')
   .showHelpAfterError('Use --help for more information.')
   .action(async (cannonfile, settings, opts) => {
+    await spawn('forge', ['build']);
+
     const [node] = await doBuild(cannonfile, settings, opts);
 
     await node?.kill();


### PR DESCRIPTION
Untested. We do hardhat compile with the plug-in so I think it makes sense to add this here?