### PR TITLE
default `targetPreset` to a different context

### DIFF
--- a/packages/builder/src/actions.test.ts
+++ b/packages/builder/src/actions.test.ts
@@ -10,7 +10,7 @@ const FakeAction: Action = {
   },
 
   async getState(_runtime: ChainBuilderRuntimeInfo, ctx: ChainBuilderContextWithHelpers, config: Record<string, unknown>) {
-    return this.configInject(ctx, config);
+    return this.configInject(ctx, config, { name: '', version: '', currentLabel: '' });
   },
 
   configInject(ctx: ChainBuilderContext, config: Record<string, unknown>) {

--- a/packages/builder/src/actions.ts
+++ b/packages/builder/src/actions.ts
@@ -8,18 +8,18 @@ import importSpec from './steps/import';
 import invokeSpec from './steps/invoke';
 import keeperSpec from './steps/keeper';
 import provisionSpec from './steps/provision';
-import { ChainArtifacts, ChainBuilderContext, ChainBuilderContextWithHelpers } from './types';
+import { ChainArtifacts, ChainBuilderContext, ChainBuilderContextWithHelpers, PackageState } from './types';
 
 export interface Action {
-  configInject: (ctx: ChainBuilderContextWithHelpers, config: any) => any;
+  configInject: (ctx: ChainBuilderContextWithHelpers, config: any, packageState: PackageState) => any;
 
-  getState: (runtime: ChainBuilderRuntime, ctx: ChainBuilderContextWithHelpers, config: any, currentLabel?: string) => any;
+  getState: (runtime: ChainBuilderRuntime, ctx: ChainBuilderContextWithHelpers, config: any, packageState: PackageState) => any;
 
   exec: (
     runtime: ChainBuilderRuntime,
     ctx: ChainBuilderContext,
     config: any,
-    currentLabel: string
+    packageState: PackageState,
   ) => Promise<ChainArtifacts>;
 
   validate: {

--- a/packages/builder/src/builder.test.ts
+++ b/packages/builder/src/builder.test.ts
@@ -258,7 +258,7 @@ describe('builder.ts', () => {
       const handler = jest.fn();
       runtime.on(Events.PreStepExecute, handler);
       runtime.on(Events.PostStepExecute, handler);
-      const stepData = await runStep(runtime, 'contract.Yoop', (fakeDefinition as any).contract.Yoop, initialCtx);
+      const stepData = await runStep(runtime, { name: fakeDefinition.name, version: fakeDefinition.version, currentLabel: 'contract.Yoop' }, (fakeDefinition as any).contract.Yoop, initialCtx);
 
       expect(stepData).toStrictEqual(expectedStateOut['contract.Yoop'].artifacts);
     });

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -100,7 +100,12 @@ export class ChainDefinition {
 
     return ActionKinds[n.split('.')[0] as keyof typeof ActionKinds].configInject(
       { ...ctx, ...ethers.utils, ...ethers.constants },
-      _.get(this.raw, n)
+      _.get(this.raw, n),
+      { 
+        name: this.getName(ctx),
+        version: this.getVersion(ctx),
+        currentLabel: n
+      }
     )!;
   }
 
@@ -134,7 +139,11 @@ export class ChainDefinition {
       runtime,
       { ...ctx, ...ethers.utils, ...ethers.constants },
       this.getConfig(n, ctx) as any,
-      n
+      { 
+        name: this.getName(ctx),
+        version: this.getVersion(ctx),
+        currentLabel: n
+      }
     );
 
     if (!obj) {

--- a/packages/builder/src/steps/contract.ts
+++ b/packages/builder/src/steps/contract.ts
@@ -12,6 +12,7 @@ import {
   ChainArtifacts,
   ChainBuilderContextWithHelpers,
   ContractArtifact,
+  PackageState,
 } from '../types';
 import { getContractDefinitionFromPath, getMergedAbiFromContractPaths } from '../util';
 import { ensureArachnidCreate2Exists, makeArachnidCreate2Txn } from '../create2';
@@ -145,7 +146,7 @@ export default {
     runtime: ChainBuilderRuntimeInfo,
     ctx: ChainBuilderContext,
     config: Config,
-    currentLabel: string
+    packageState: PackageState
   ): Promise<ChainArtifacts> {
     debug('exec', config);
 
@@ -249,7 +250,7 @@ export default {
 
     return {
       contracts: {
-        [currentLabel?.split('.')[1] || '']: {
+        [packageState.currentLabel.split('.')[1] || '']: {
           address: contractAddress,
           abi,
           constructorArgs: config.args || [],
@@ -257,7 +258,7 @@ export default {
           deployTxnHash: transactionHash,
           sourceName: artifactData.sourceName,
           contractName: artifactData.contractName,
-          deployedOn: currentLabel!,
+          deployedOn: packageState.currentLabel!,
         },
       },
     };

--- a/packages/builder/src/steps/import.ts
+++ b/packages/builder/src/steps/import.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import Debug from 'debug';
 import { JTDDataType } from 'ajv/dist/core';
 
-import { ChainBuilderContext, ChainArtifacts, ChainBuilderContextWithHelpers } from '../types';
+import { ChainBuilderContext, ChainArtifacts, ChainBuilderContextWithHelpers, PackageState } from '../types';
 import { getOutputs } from '../builder';
 import { ChainDefinition } from '../definition';
 import { ChainBuilderRuntime } from '../runtime';
@@ -58,9 +58,9 @@ export default {
     runtime: ChainBuilderRuntime,
     ctx: ChainBuilderContext,
     config: Config,
-    currentLabel: string
+    packageState: PackageState
   ): Promise<ChainArtifacts> {
-    const importLabel = currentLabel?.split('.')[1] || '';
+    const importLabel = packageState.currentLabel?.split('.')[1] || '';
     debug('exec', config);
 
     const packageRef = config.source.includes(':') ? config.source : `${config.source}:latest`;

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -113,6 +113,12 @@ export interface ChainBuilderRuntimeInfo {
   publicSourceCode?: boolean;
 }
 
+export interface PackageState {
+  name: string;
+  version: string;
+  currentLabel: string;
+}
+
 export interface BundledChainBuilderOutputs {
   [module: string]: { url: string } & ChainArtifacts;
 }

--- a/packages/cli/src/custom-steps/run.ts
+++ b/packages/cli/src/custom-steps/run.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import Debug from 'debug';
 import { JTDDataType } from 'ajv/dist/core';
 
-import { ChainBuilderContext, ChainBuilderRuntimeInfo, ChainArtifacts, registerAction } from '@usecannon/builder';
+import { ChainBuilderContext, ChainBuilderRuntimeInfo, ChainArtifacts, registerAction, PackageState } from '@usecannon/builder';
 
 import crypto from 'crypto';
 import fs from 'fs-extra';
@@ -130,7 +130,7 @@ const runAction = {
     runtime: ChainBuilderRuntimeInfo,
     ctx: ChainBuilderContext,
     config: Config,
-    currentLabel: string
+    packageState: PackageState
   ): Promise<ChainArtifacts> {
     debug('exec', config);
 
@@ -146,12 +146,12 @@ const runAction = {
 
     outputs.contracts = _.mapValues(outputs.contracts, (c) => ({
       ...c,
-      deployedOn: currentLabel,
+      deployedOn: packageState.currentLabel,
     }));
 
     outputs.txns = _.mapValues(outputs.txns, (t) => ({
       ...t,
-      deployedOn: currentLabel,
+      deployedOn: packageState.currentLabel,
     }));
 
     return outputs;


### PR DESCRIPTION
changes the default `targetPreset` from `main` (which causes problems and overwrites package versions and etc) to `with-${packageName}`, where `${packageName}` is the name of the currently being built package.

unfortunately, we currently have no way to know what package is currently being built, so the `currentLabel` which is ususally passed into actions has been augmented to support both the package name and version as well. The builder will automatically handle any organization of this.