### PR TITLE
use multicall on copy package publish

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,5 @@ jobs:
       - run: |
           npm ci
           npx lerna bootstrap
-          npm run lint
+      - run: npm run lint:js
+      - run: npm run lint:sol

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  registry:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,5 @@ jobs:
           npm ci
           npx lerna bootstrap
           npm run build
-          cd ./packages/registry
-          REPORT_GAS=1 npm test
+      - run: cd ./packages/builder && npm test
+      - run: cd ./packages/registry && REPORT_GAS=1 npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  registry:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/packages/builder/src/abis/CannonRegistry.ts
+++ b/packages/builder/src/abis/CannonRegistry.ts
@@ -1,559 +1,559 @@
 export default [
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "implementation",
-          "type": "address"
-        }
-      ],
-      "name": "ImplementationIsSterile",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "name",
-          "type": "bytes32"
-        }
-      ],
-      "name": "InvalidName",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "InvalidTags",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "url",
-          "type": "string"
-        }
-      ],
-      "name": "InvalidUrl",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "NoChange",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "contr",
-          "type": "address"
-        }
-      ],
-      "name": "NotAContract",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "addr",
-          "type": "address"
-        }
-      ],
-      "name": "NotNominated",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "PackageNotFound",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "addr",
-          "type": "address"
-        }
-      ],
-      "name": "Unauthorized",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "Unauthorized",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "UpgradeSimulationFailed",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "ZeroAddress",
-      "type": "error"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "oldOwner",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "OwnerChanged",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "OwnerNominated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "name",
-          "type": "bytes32"
-        },
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "tag",
-          "type": "bytes32"
-        },
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "variant",
-          "type": "bytes32"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "deployUrl",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "metaUrl",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "owner",
-          "type": "address"
-        }
-      ],
-      "name": "PackagePublish",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "name",
-          "type": "bytes32"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "verifier",
-          "type": "address"
-        }
-      ],
-      "name": "PackageUnverify",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "name",
-          "type": "bytes32"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "verifier",
-          "type": "address"
-        }
-      ],
-      "name": "PackageVerify",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "self",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "implementation",
-          "type": "address"
-        }
-      ],
-      "name": "Upgraded",
-      "type": "event"
-    },
-    {
-      "inputs": [],
-      "name": "MIN_PACKAGE_NAME_LENGTH",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "acceptOwnership",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_packageName",
-          "type": "bytes32"
-        }
-      ],
-      "name": "acceptPackageOwnership",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "getImplementation",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_packageName",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "_packageVersionName",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "_packageVariant",
-          "type": "bytes32"
-        }
-      ],
-      "name": "getPackageMeta",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_packageName",
-          "type": "bytes32"
-        }
-      ],
-      "name": "getPackageNominatedOwner",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_packageName",
-          "type": "bytes32"
-        }
-      ],
-      "name": "getPackageOwner",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_packageName",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "_packageVersionName",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "_packageVariant",
-          "type": "bytes32"
-        }
-      ],
-      "name": "getPackageUrl",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes[]",
-          "name": "data",
-          "type": "bytes[]"
-        }
-      ],
-      "name": "multicall",
-      "outputs": [
-        {
-          "internalType": "bytes[]",
-          "name": "results",
-          "type": "bytes[]"
-        }
-      ],
-      "stateMutability": "payable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "newNominatedOwner",
-          "type": "address"
-        }
-      ],
-      "name": "nominateNewOwner",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_packageName",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "address",
-          "name": "_newPackageOwner",
-          "type": "address"
-        }
-      ],
-      "name": "nominatePackageOwner",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "nominatedOwner",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "owner",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_packageName",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "_variant",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "bytes32[]",
-          "name": "_packageTags",
-          "type": "bytes32[]"
-        },
-        {
-          "internalType": "string",
-          "name": "_packageDeployUrl",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "_packageMetaUrl",
-          "type": "string"
-        }
-      ],
-      "name": "publish",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "renounceNomination",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "newImplementation",
-          "type": "address"
-        }
-      ],
-      "name": "simulateUpgradeTo",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_packageName",
-          "type": "bytes32"
-        }
-      ],
-      "name": "unverifyPackage",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_newImplementation",
-          "type": "address"
-        }
-      ],
-      "name": "upgradeTo",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_name",
-          "type": "bytes32"
-        }
-      ],
-      "name": "validatePackageName",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_packageName",
-          "type": "bytes32"
-        }
-      ],
-      "name": "verifyPackage",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    }
-  ]
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'implementation',
+        type: 'address',
+      },
+    ],
+    name: 'ImplementationIsSterile',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'name',
+        type: 'bytes32',
+      },
+    ],
+    name: 'InvalidName',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidTags',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'url',
+        type: 'string',
+      },
+    ],
+    name: 'InvalidUrl',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NoChange',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'contr',
+        type: 'address',
+      },
+    ],
+    name: 'NotAContract',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'addr',
+        type: 'address',
+      },
+    ],
+    name: 'NotNominated',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'PackageNotFound',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'addr',
+        type: 'address',
+      },
+    ],
+    name: 'Unauthorized',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'Unauthorized',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'UpgradeSimulationFailed',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ZeroAddress',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'oldOwner',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnerChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnerNominated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'name',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'tag',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'variant',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'string',
+        name: 'deployUrl',
+        type: 'string',
+      },
+      {
+        indexed: false,
+        internalType: 'string',
+        name: 'metaUrl',
+        type: 'string',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+    ],
+    name: 'PackagePublish',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'name',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'verifier',
+        type: 'address',
+      },
+    ],
+    name: 'PackageUnverify',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'name',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'verifier',
+        type: 'address',
+      },
+    ],
+    name: 'PackageVerify',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'self',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'implementation',
+        type: 'address',
+      },
+    ],
+    name: 'Upgraded',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'MIN_PACKAGE_NAME_LENGTH',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'acceptOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_packageName',
+        type: 'bytes32',
+      },
+    ],
+    name: 'acceptPackageOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getImplementation',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_packageName',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_packageVersionName',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_packageVariant',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getPackageMeta',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_packageName',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getPackageNominatedOwner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_packageName',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getPackageOwner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_packageName',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_packageVersionName',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_packageVariant',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getPackageUrl',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes[]',
+        name: 'data',
+        type: 'bytes[]',
+      },
+    ],
+    name: 'multicall',
+    outputs: [
+      {
+        internalType: 'bytes[]',
+        name: 'results',
+        type: 'bytes[]',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newNominatedOwner',
+        type: 'address',
+      },
+    ],
+    name: 'nominateNewOwner',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_packageName',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: '_newPackageOwner',
+        type: 'address',
+      },
+    ],
+    name: 'nominatePackageOwner',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'nominatedOwner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_packageName',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_variant',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32[]',
+        name: '_packageTags',
+        type: 'bytes32[]',
+      },
+      {
+        internalType: 'string',
+        name: '_packageDeployUrl',
+        type: 'string',
+      },
+      {
+        internalType: 'string',
+        name: '_packageMetaUrl',
+        type: 'string',
+      },
+    ],
+    name: 'publish',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'renounceNomination',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newImplementation',
+        type: 'address',
+      },
+    ],
+    name: 'simulateUpgradeTo',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_packageName',
+        type: 'bytes32',
+      },
+    ],
+    name: 'unverifyPackage',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_newImplementation',
+        type: 'address',
+      },
+    ],
+    name: 'upgradeTo',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_name',
+        type: 'bytes32',
+      },
+    ],
+    name: 'validatePackageName',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_packageName',
+        type: 'bytes32',
+      },
+    ],
+    name: 'verifyPackage',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];

--- a/packages/builder/src/abis/CannonRegistry.ts
+++ b/packages/builder/src/abis/CannonRegistry.ts
@@ -1,574 +1,559 @@
 export default [
-  {
-    inputs: [
-      {
-        internalType: 'address',
-        name: 'implementation',
-        type: 'address',
-      },
-    ],
-    name: 'ImplementationIsSterile',
-    type: 'error',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: 'name',
-        type: 'bytes32',
-      },
-    ],
-    name: 'InvalidName',
-    type: 'error',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'string',
-        name: 'url',
-        type: 'string',
-      },
-    ],
-    name: 'InvalidUrl',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'NoChange',
-    type: 'error',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address',
-      },
-    ],
-    name: 'NotAContract',
-    type: 'error',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'address',
-        name: 'addr',
-        type: 'address',
-      },
-    ],
-    name: 'NotNominated',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'OwnerNoChange',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'OwnerZeroAddress',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'PackageNotFound',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'TooManyTags',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'Unauthorized',
-    type: 'error',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address',
-      },
-    ],
-    name: 'Unauthorized',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'UpgradeSimulationFailed',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'ValueAlreadyInSet',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'ZeroAddress',
-    type: 'error',
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: false,
-        internalType: 'address',
-        name: 'oldOwner',
-        type: 'address',
-      },
-      {
-        indexed: false,
-        internalType: 'address',
-        name: 'newOwner',
-        type: 'address',
-      },
-    ],
-    name: 'OwnerChanged',
-    type: 'event',
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: false,
-        internalType: 'address',
-        name: 'newOwner',
-        type: 'address',
-      },
-    ],
-    name: 'OwnerNominated',
-    type: 'event',
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: 'bytes32',
-        name: 'name',
-        type: 'bytes32',
-      },
-      {
-        indexed: true,
-        internalType: 'bytes32[]',
-        name: 'tags',
-        type: 'bytes32[]',
-      },
-      {
-        indexed: false,
-        internalType: 'bytes32',
-        name: 'variant',
-        type: 'bytes32',
-      },
-      {
-        indexed: false,
-        internalType: 'string',
-        name: 'deployUrl',
-        type: 'string',
-      },
-      {
-        indexed: false,
-        internalType: 'string',
-        name: 'metaUrl',
-        type: 'string',
-      },
-      {
-        indexed: false,
-        internalType: 'address',
-        name: 'owner',
-        type: 'address',
-      },
-    ],
-    name: 'PackagePublish',
-    type: 'event',
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: 'bytes32',
-        name: 'name',
-        type: 'bytes32',
-      },
-      {
-        indexed: true,
-        internalType: 'address',
-        name: 'verifier',
-        type: 'address',
-      },
-    ],
-    name: 'PackageUnverify',
-    type: 'event',
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: 'bytes32',
-        name: 'name',
-        type: 'bytes32',
-      },
-      {
-        indexed: true,
-        internalType: 'address',
-        name: 'verifier',
-        type: 'address',
-      },
-    ],
-    name: 'PackageVerify',
-    type: 'event',
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: 'address',
-        name: 'self',
-        type: 'address',
-      },
-      {
-        indexed: false,
-        internalType: 'address',
-        name: 'implementation',
-        type: 'address',
-      },
-    ],
-    name: 'Upgraded',
-    type: 'event',
-  },
-  {
-    inputs: [],
-    name: 'MIN_PACKAGE_NAME_LENGTH',
-    outputs: [
-      {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [],
-    name: 'acceptOwnership',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: '_packageName',
-        type: 'bytes32',
-      },
-    ],
-    name: 'acceptPackageOwnership',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [],
-    name: 'getImplementation',
-    outputs: [
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: '_packageName',
-        type: 'bytes32',
-      },
-      {
-        internalType: 'bytes32',
-        name: '_packageVersionName',
-        type: 'bytes32',
-      },
-      {
-        internalType: 'bytes32',
-        name: '_packageVariant',
-        type: 'bytes32',
-      },
-    ],
-    name: 'getPackageMeta',
-    outputs: [
-      {
-        internalType: 'string',
-        name: '',
-        type: 'string',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: '_packageName',
-        type: 'bytes32',
-      },
-    ],
-    name: 'getPackageNominatedOwner',
-    outputs: [
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: '_packageName',
-        type: 'bytes32',
-      },
-    ],
-    name: 'getPackageOwner',
-    outputs: [
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: '_packageName',
-        type: 'bytes32',
-      },
-      {
-        internalType: 'bytes32',
-        name: '_packageVersionName',
-        type: 'bytes32',
-      },
-      {
-        internalType: 'bytes32',
-        name: '_packageVariant',
-        type: 'bytes32',
-      },
-    ],
-    name: 'getPackageUrl',
-    outputs: [
-      {
-        internalType: 'string',
-        name: '',
-        type: 'string',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: '_packageName',
-        type: 'bytes32',
-      },
-    ],
-    name: 'getPackageVersions',
-    outputs: [
-      {
-        internalType: 'bytes32[]',
-        name: '',
-        type: 'bytes32[]',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'address',
-        name: 'newNominatedOwner',
-        type: 'address',
-      },
-    ],
-    name: 'nominateNewOwner',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: '_packageName',
-        type: 'bytes32',
-      },
-      {
-        internalType: 'address',
-        name: '_newPackageOwner',
-        type: 'address',
-      },
-    ],
-    name: 'nominatePackageOwner',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [],
-    name: 'nominatedOwner',
-    outputs: [
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [],
-    name: 'owner',
-    outputs: [
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: '_packageName',
-        type: 'bytes32',
-      },
-      {
-        internalType: 'bytes32',
-        name: '_variant',
-        type: 'bytes32',
-      },
-      {
-        internalType: 'bytes32[]',
-        name: '_packageTags',
-        type: 'bytes32[]',
-      },
-      {
-        internalType: 'string',
-        name: '_packageVersionUrl',
-        type: 'string',
-      },
-      {
-        internalType: 'string',
-        name: '_packageMetaUrl',
-        type: 'string',
-      },
-    ],
-    name: 'publish',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [],
-    name: 'renounceNomination',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'address',
-        name: 'newImplementation',
-        type: 'address',
-      },
-    ],
-    name: 'simulateUpgradeTo',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: '_packageName',
-        type: 'bytes32',
-      },
-    ],
-    name: 'unverifyPackage',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'address',
-        name: '_newImplementation',
-        type: 'address',
-      },
-    ],
-    name: 'upgradeTo',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: '_name',
-        type: 'bytes32',
-      },
-    ],
-    name: 'validatePackageName',
-    outputs: [
-      {
-        internalType: 'bool',
-        name: '',
-        type: 'bool',
-      },
-    ],
-    stateMutability: 'pure',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        internalType: 'bytes32',
-        name: '_packageName',
-        type: 'bytes32',
-      },
-    ],
-    name: 'verifyPackage',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-];
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "implementation",
+          "type": "address"
+        }
+      ],
+      "name": "ImplementationIsSterile",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "name",
+          "type": "bytes32"
+        }
+      ],
+      "name": "InvalidName",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidTags",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "url",
+          "type": "string"
+        }
+      ],
+      "name": "InvalidUrl",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NoChange",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "contr",
+          "type": "address"
+        }
+      ],
+      "name": "NotAContract",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "NotNominated",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PackageNotFound",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "Unauthorized",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "Unauthorized",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "UpgradeSimulationFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroAddress",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "oldOwner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnerChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnerNominated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "name",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "tag",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "variant",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "deployUrl",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "metaUrl",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "PackagePublish",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "name",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "verifier",
+          "type": "address"
+        }
+      ],
+      "name": "PackageUnverify",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "name",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "verifier",
+          "type": "address"
+        }
+      ],
+      "name": "PackageVerify",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "self",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "implementation",
+          "type": "address"
+        }
+      ],
+      "name": "Upgraded",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "MIN_PACKAGE_NAME_LENGTH",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "acceptOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_packageName",
+          "type": "bytes32"
+        }
+      ],
+      "name": "acceptPackageOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getImplementation",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_packageName",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_packageVersionName",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_packageVariant",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getPackageMeta",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_packageName",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getPackageNominatedOwner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_packageName",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getPackageOwner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_packageName",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_packageVersionName",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_packageVariant",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getPackageUrl",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes[]",
+          "name": "data",
+          "type": "bytes[]"
+        }
+      ],
+      "name": "multicall",
+      "outputs": [
+        {
+          "internalType": "bytes[]",
+          "name": "results",
+          "type": "bytes[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newNominatedOwner",
+          "type": "address"
+        }
+      ],
+      "name": "nominateNewOwner",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_packageName",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "_newPackageOwner",
+          "type": "address"
+        }
+      ],
+      "name": "nominatePackageOwner",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nominatedOwner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_packageName",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_variant",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32[]",
+          "name": "_packageTags",
+          "type": "bytes32[]"
+        },
+        {
+          "internalType": "string",
+          "name": "_packageDeployUrl",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_packageMetaUrl",
+          "type": "string"
+        }
+      ],
+      "name": "publish",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceNomination",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newImplementation",
+          "type": "address"
+        }
+      ],
+      "name": "simulateUpgradeTo",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_packageName",
+          "type": "bytes32"
+        }
+      ],
+      "name": "unverifyPackage",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_newImplementation",
+          "type": "address"
+        }
+      ],
+      "name": "upgradeTo",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_name",
+          "type": "bytes32"
+        }
+      ],
+      "name": "validatePackageName",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_packageName",
+          "type": "bytes32"
+        }
+      ],
+      "name": "verifyPackage",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]

--- a/packages/builder/src/create2.ts
+++ b/packages/builder/src/create2.ts
@@ -9,7 +9,9 @@ import Debug from 'debug';
 
 const debug = Debug('cannon:builder:create2');
 
-const ARACHNID_DEPLOY_TXN =
+export const ARACHNID_DEPLOY_ADDR = '0x3fab184622dc19b6109349b94811493bf2a45362';
+
+export const ARACHNID_DEPLOY_TXN =
   '0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222';
 
 /**
@@ -26,7 +28,7 @@ export async function ensureArachnidCreate2Exists(runtime: ChainBuilderRuntimeIn
     // first "get" the signer (which will populate it for use and with enough eth for gas)
     // if signer doesn't exist then this isnt local testing network, and this txn will fail
     try {
-      await runtime.getSigner('0x3fab184622dc19b6109349b94811493bf2a45362');
+      await runtime.getSigner(ARACHNID_DEPLOY_ADDR);
     } catch (err) {
       debug('got arachnid signer error', err);
       throw new Error(

--- a/packages/builder/src/package.test.ts
+++ b/packages/builder/src/package.test.ts
@@ -89,7 +89,7 @@ describe('package.ts', () => {
       });
 
       await fromLoader.resolver.publish([testPkg], '1-main', 'https://usecannon.com', 'https://usecannon.com/meta');
-      await fromLoader.resolver.publish([nestedPkg], '1-main', 'https://usecannon.com/nested');
+      await fromLoader.resolver.publish([nestedPkg], '1-main', 'https://usecannon.com/nested', '');
     });
 
     it('fails when deployment info is not found', async () => {

--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -27,10 +27,10 @@ export async function copyIpfs({
   fromLoader,
   toLoader,
   recursive,
-}: CopyPackageOpts): Promise<{packagesNames: string[], variant: string, url: string, metaUrl: string }[]> {
+}: CopyPackageOpts): Promise<{ packagesNames: string[]; variant: string; url: string; metaUrl: string }[]> {
   debug(`copy package ${packageRef} (${fromLoader.getLabel()} -> ${toLoader.getLabel()})`);
 
-  const registrationCalls: {packagesNames: string[], variant: string, url: string, metaUrl: string }[] = [];
+  const registrationCalls: { packagesNames: string[]; variant: string; url: string; metaUrl: string }[] = [];
 
   const chainId = parseInt(variant.split('-')[0]);
   const preset = variant.substring(variant.indexOf('-') + 1);
@@ -88,7 +88,7 @@ export async function copyIpfs({
     packagesNames: [def.getVersion(preCtx), ...tags].map((t) => `${def.getName(preCtx)}:${t}`),
     variant,
     url,
-    metaUrl: metaUrl || ''
+    metaUrl: metaUrl || '',
   });
 
   return registrationCalls;

--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -5,24 +5,32 @@ import { ChainDefinition } from './definition';
 import { createInitialContext } from './builder';
 const debug = Debug('cannon:cli:publish');
 
-export async function copyPackage({
-  packageRef,
-  tags,
-  variant,
-  fromLoader,
-  toLoader,
-  recursive,
-}: {
+export type CopyPackageOpts = {
   packageRef: string;
   variant: string;
   tags: string[];
   fromLoader: CannonLoader;
   toLoader: CannonLoader;
   recursive?: boolean;
-}): Promise<string[]> {
+};
+
+export async function copyPackage(opts: CopyPackageOpts) {
+  const calls = await copyIpfs(opts);
+
+  return opts.toLoader.resolver.publishMany(calls);
+}
+
+export async function copyIpfs({
+  packageRef,
+  tags,
+  variant,
+  fromLoader,
+  toLoader,
+  recursive,
+}: CopyPackageOpts): Promise<{packagesNames: string[], variant: string, url: string, metaUrl: string }[]> {
   debug(`copy package ${packageRef} (${fromLoader.getLabel()} -> ${toLoader.getLabel()})`);
 
-  const registrationReceipts: string[] = [];
+  const registrationCalls: {packagesNames: string[], variant: string, url: string, metaUrl: string }[] = [];
 
   const chainId = parseInt(variant.split('-')[0]);
   const preset = variant.substring(variant.indexOf('-') + 1);
@@ -45,8 +53,8 @@ export async function copyPackage({
           const nestedDeployInfo: DeploymentInfo = await fromLoader.readMisc(importArtifact[1].url);
           const nestedDef = new ChainDefinition(nestedDeployInfo.def);
           const preCtx = await createInitialContext(nestedDef, nestedDeployInfo.meta, 0, nestedDeployInfo.options);
-          registrationReceipts.push(
-            ...(await copyPackage({
+          registrationCalls.push(
+            ...(await copyIpfs({
               packageRef: `${nestedDef.getName(preCtx)}:${nestedDef.getVersion(preCtx)}`,
               variant: `${chainId}-${def.getConfig(stepState[0], preCtx).targetPreset}`,
               tags: importArtifact[1].tags || [],
@@ -76,14 +84,12 @@ export async function copyPackage({
 
   const preCtx = await createInitialContext(def, deployData.meta, 0, deployData.options);
 
-  registrationReceipts.push(
-    ...(await toLoader.resolver.publish(
-      [def.getVersion(preCtx), ...tags].map((t) => `${def.getName(preCtx)}:${t}`),
-      variant,
-      url,
-      metaUrl || ''
-    ))
-  );
+  registrationCalls.push({
+    packagesNames: [def.getVersion(preCtx), ...tags].map((t) => `${def.getName(preCtx)}:${t}`),
+    variant,
+    url,
+    metaUrl: metaUrl || ''
+  });
 
-  return registrationReceipts;
+  return registrationCalls;
 }

--- a/packages/builder/src/registry.test.ts
+++ b/packages/builder/src/registry.test.ts
@@ -1,6 +1,5 @@
 import { ethers } from 'ethers';
 import { CannonRegistry, OnChainRegistry } from './registry';
-import { TransactionReceipt } from '@ethersproject/abstract-provider';
 import { CannonWrapperGenericProvider } from './error/provider';
 
 jest.mock('./error/provider');
@@ -110,12 +109,8 @@ describe('registry.ts', () => {
 
         const retValue = await registry.publish(['dummyPackage:0.0.1', 'anotherPkg:1.2.3'], '1-main', 'ipfs://Qmsomething');
 
-        jest
-          .mocked(provider.waitForTransaction)
-          .mockResolvedValueOnce({ transactionHash: '0x1234' } as TransactionReceipt)
-          .mockResolvedValueOnce({ transactionHash: '0x5678' } as TransactionReceipt);
-
-        expect(retValue).toStrictEqual(['0x1234', '0x5678']);
+        // should only return the first receipt because its a multicall
+        expect(retValue).toStrictEqual(['0x1234']);
 
         // TODO: check the transaction which was sent (its hard to do here because it comes in as the signed txn)
       });

--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -11,7 +11,9 @@ const debug = Debug('cannon:builder:registry');
 export abstract class CannonRegistry {
   abstract publish(packagesNames: string[], variant: string, url: string, metaUrl: string): Promise<string[]>;
 
-  async publishMany(toPublish: {packagesNames: string[], variant: string, url: string, metaUrl: string }[]): Promise<string[]> {
+  async publishMany(
+    toPublish: { packagesNames: string[]; variant: string; url: string; metaUrl: string }[]
+  ): Promise<string[]> {
     const receipts: string[] = [];
     for (const pub of toPublish) {
       await this.publish(pub.packagesNames, pub.variant, pub.url, pub.metaUrl);
@@ -138,7 +140,9 @@ export class FallbackRegistry extends EventEmitter implements CannonRegistry {
     return _.first(this.registries).publish(packagesNames, variant, url, metaUrl);
   }
 
-  async publishMany(toPublish: {packagesNames: string[], variant: string, url: string, metaUrl: string }[]): Promise<string[]> {
+  async publishMany(
+    toPublish: { packagesNames: string[]; variant: string; url: string; metaUrl: string }[]
+  ): Promise<string[]> {
     const receipts: string[] = [];
     for (const pub of toPublish) {
       await this.publish(pub.packagesNames, pub.variant, pub.url, pub.metaUrl);
@@ -196,7 +200,13 @@ export class OnChainRegistry extends CannonRegistry {
     }
   }
 
-  private generatePublishTransactionData(packagesName: string, packageTags: string[], variant: string, url: string, metaUrl?: string) {
+  private generatePublishTransactionData(
+    packagesName: string,
+    packageTags: string[],
+    variant: string,
+    url: string,
+    metaUrl?: string
+  ) {
     return this.contract.interface.encodeFunctionData('publish', [
       ethers.utils.formatBytes32String(packagesName),
       ethers.utils.formatBytes32String(variant),
@@ -205,11 +215,11 @@ export class OnChainRegistry extends CannonRegistry {
       metaUrl || '',
     ]);
   }
-  
+
   private async doMulticall(datas: string[]): Promise<string> {
     const tx = await this.contract.connect(this.signer!).multicall(datas, this.overrides);
     const receipt = await tx.wait();
-    
+
     return receipt.transactionHash;
   }
 
@@ -228,7 +238,7 @@ export class OnChainRegistry extends CannonRegistry {
         registerPackages.map((p) => ethers.utils.formatBytes32String(p[1])),
         variant,
         url,
-        metaUrl,
+        metaUrl
       );
 
       datas.push(tx);
@@ -237,7 +247,9 @@ export class OnChainRegistry extends CannonRegistry {
     return [await this.doMulticall(datas)];
   }
 
-  async publishMany(toPublish: { packagesNames: string[]; variant: string; url: string; metaUrl: string; }[]): Promise<string[]> {
+  async publishMany(
+    toPublish: { packagesNames: string[]; variant: string; url: string; metaUrl: string }[]
+  ): Promise<string[]> {
     await this.checkSigner();
 
     const datas: string[] = [];
@@ -253,9 +265,9 @@ export class OnChainRegistry extends CannonRegistry {
           registerPackages.map((p) => ethers.utils.formatBytes32String(p[1])),
           pub.variant,
           pub.url,
-          pub.metaUrl,
+          pub.metaUrl
         );
-  
+
         datas.push(tx);
       }
     }

--- a/packages/builder/src/steps/import.ts
+++ b/packages/builder/src/steps/import.ts
@@ -40,7 +40,7 @@ export default {
     const preset = config.preset ?? 'main';
     const chainId = config.chainId ?? runtime.chainId;
 
-    console.log(cfg.source, `${chainId}-${preset}`);
+    debug('resolved pkg', cfg.source, `${chainId}-${preset}`);
     const url = await runtime.loader.resolver.getUrl(cfg.source, `${chainId}-${preset}`);
 
     return {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,7 +33,7 @@ import Debug from 'debug';
 import { writeModuleDeployments } from './util/write-deployments';
 import { getIpfsLoader } from './util/loader';
 import { getFoundryArtifact } from './foundry';
-import { resolveWriteProvider } from './util/provider';
+import { resolveRegistryProvider, resolveWriteProvider } from './util/provider';
 
 const debug = Debug('cannon:cli');
 
@@ -284,6 +284,7 @@ program
   .description('Publish a Cannon package to the registry')
   .argument('<packageName>', 'Name and version of the package to publish')
   .option('-n --registry-provider-url [url]', 'RPC endpoint to publish to')
+  .option('--private-key <key>', 'Private key to use for publishing the registry package')
   .option('--chain-id <number>', 'The chain ID of the package to publish')
   .option('--preset <preset>', 'The preset of the packages to publish')
   .option('-t --tags <tags>', 'Comma separated list of labels for your package', 'latest')
@@ -302,7 +303,7 @@ program
     const { publish } = await import('./commands/publish');
 
     const cliSettings = resolveCliSettings(options);
-    const p = await resolveWriteProvider(cliSettings, cliSettings.registryChainId);
+    const p = await resolveRegistryProvider(cliSettings);
 
     const overrides: ethers.Overrides = {};
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -284,7 +284,8 @@ program
   .description('Publish a Cannon package to the registry')
   .argument('<packageName>', 'Name and version of the package to publish')
   .option('-n --registry-provider-url [url]', 'RPC endpoint to publish to')
-  .option('--preset <preset>', 'The preset of the packages that are deployed', 'main')
+  .option('--chain-id <number>', 'The chain ID of the package to publish')
+  .option('--preset <preset>', 'The preset of the packages to publish')
   .option('-t --tags <tags>', 'Comma separated list of labels for your package', 'latest')
   .option('--gas-limit <gasLimit>', 'The maximum units of gas spent for the registration transaction')
   .option(
@@ -317,7 +318,16 @@ program
       overrides.gasLimit = options.gasLimit;
     }
 
-    await publish(packageName, options.tags, options.preset, p.signers[0], overrides, options.quiet, options.force);
+    await publish(
+      packageName,
+      options.tags,
+      p.signers[0],
+      options.chainId,
+      options.preset,
+      overrides,
+      options.quiet,
+      options.force
+    );
   });
 
 program

--- a/packages/cli/src/util/provider.ts
+++ b/packages/cli/src/util/provider.ts
@@ -11,7 +11,7 @@ const debug = Debug('cannon:cli:provider');
 export async function resolveWriteProvider(settings: CliSettings, chainId: number | string) {
   return resolveProviderAndSigners({
     chainId,
-    checkProviders: settings.providerUrl!.split(','),
+    checkProviders: settings.providerUrl?.split(',') || [],
     privateKey: settings.privateKey,
   });
 }


### PR DESCRIPTION
recently more and more I have been finding that publish transactions tend to be very numerous, which is both expensive and arduous. It would be better if package publish calls were the minimum number possible.

Add a `publishMany` function to the CannonRegistry (which defaults to just calling `publish` in a loop. This function is overridden by OnChainRegistry, which will combine all the calls into a single multicall transaction