### PR TITLE
fix wipe

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -234,7 +234,7 @@ export async function build({
     }
   }
 
-  const newState = await cannonBuild(runtime, def, oldDeployData ? oldDeployData.state : {}, initialCtx);
+  const newState = await cannonBuild(runtime, def, oldDeployData && !wipe ? oldDeployData.state : {}, initialCtx);
 
   const outputs = (await getOutputs(runtime, def, newState))!;
 


### PR DESCRIPTION
wipe has not been working because the old state is getting passed into the builder without reading the `wipe` option passed in (despite the logging printing out the appropriate output)