### PR TITLE
support for recursive verify

### DIFF
--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -1,9 +1,7 @@
-import Debug from 'debug';
 import { DeploymentInfo, StepState } from './types';
 import { CannonLoader } from './loader';
 import { ChainDefinition } from './definition';
 import { createInitialContext } from './builder';
-const debug = Debug('cannon:cli:publish');
 
 export type CopyPackageOpts = {
   packageRef: string;
@@ -22,14 +20,18 @@ export type CopyPackageOpts = {
  * @param action The action to execute
  * @param onlyProvisioned Skip over sub-packages which are not provisioned within the parent
  */
-export async function forPackageTree<T>(loader: CannonLoader, deployInfo: DeploymentInfo, action: (deployInfo: DeploymentInfo) => Promise<T>, onlyProvisioned = true): Promise<T[]> {
+export async function forPackageTree<T>(
+  loader: CannonLoader,
+  deployInfo: DeploymentInfo,
+  action: (deployInfo: DeploymentInfo) => Promise<T>,
+  onlyProvisioned = true
+): Promise<T[]> {
   const results: T[] = [];
 
   for (const stepState of Object.entries(deployInfo.state || {})) {
     for (const importArtifact of Object.entries((stepState[1] as StepState).artifacts.imports || {})) {
       const nestedDeployInfo = await loader.readMisc(importArtifact[1].url);
       await forPackageTree(loader, nestedDeployInfo, action, onlyProvisioned);
-
     }
   }
 
@@ -38,15 +40,7 @@ export async function forPackageTree<T>(loader: CannonLoader, deployInfo: Deploy
   return results;
 }
 
-export async function copyPackage({
-  packageRef,
-  tags,
-  variant,
-  fromLoader,
-  toLoader,
-  recursive,
-}: CopyPackageOpts) {
-
+export async function copyPackage({ packageRef, tags, variant, fromLoader, toLoader, recursive }: CopyPackageOpts) {
   // this internal function will copy one package's ipfs records and return a publish call, without recursing
   const copyIpfs = async (deployInfo: DeploymentInfo) => {
     const miscUrl = await toLoader.putMisc(await fromLoader.readMisc(deployData!.miscUrl));
@@ -73,7 +67,7 @@ export async function copyPackage({
       url,
       metaUrl: metaUrl || '',
     };
-  }
+  };
 
   const chainId = parseInt(variant.split('-')[0]);
   const preset = variant.substring(variant.indexOf('-') + 1);

--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -14,23 +14,66 @@ export type CopyPackageOpts = {
   recursive?: boolean;
 };
 
-export async function copyPackage(opts: CopyPackageOpts) {
-  const calls = await copyIpfs(opts);
+/**
+ * Iterate Depth-First-Search over the given DeploymentInfo and its dependencies, and execute the given `action` function. Postfix execution (aka, `action` is only executed after dependants are completed).
+ * Each package executes one at a time. No paralellization.
+ * @param loader The loader to use for downloading sub-packages
+ * @param deployInfo The head node of the tree, which will be executed on `action` last
+ * @param action The action to execute
+ * @param onlyProvisioned Skip over sub-packages which are not provisioned within the parent
+ */
+export async function forPackageTree<T>(loader: CannonLoader, deployInfo: DeploymentInfo, action: (deployInfo: DeploymentInfo) => Promise<T>, onlyProvisioned = true): Promise<T[]> {
+  const results: T[] = [];
 
-  return opts.toLoader.resolver.publishMany(calls);
+  for (const stepState of Object.entries(deployInfo.state || {})) {
+    for (const importArtifact of Object.entries((stepState[1] as StepState).artifacts.imports || {})) {
+      const nestedDeployInfo = await loader.readMisc(importArtifact[1].url);
+      await forPackageTree(loader, nestedDeployInfo, action, onlyProvisioned);
+
+    }
+  }
+
+  results.push(await action(deployInfo));
+
+  return results;
 }
 
-export async function copyIpfs({
+export async function copyPackage({
   packageRef,
   tags,
   variant,
   fromLoader,
   toLoader,
   recursive,
-}: CopyPackageOpts): Promise<{ packagesNames: string[]; variant: string; url: string; metaUrl: string }[]> {
-  debug(`copy package ${packageRef} (${fromLoader.getLabel()} -> ${toLoader.getLabel()})`);
+}: CopyPackageOpts) {
 
-  const registrationCalls: { packagesNames: string[]; variant: string; url: string; metaUrl: string }[] = [];
+  // this internal function will copy one package's ipfs records and return a publish call, without recursing
+  const copyIpfs = async (deployInfo: DeploymentInfo) => {
+    const miscUrl = await toLoader.putMisc(await fromLoader.readMisc(deployData!.miscUrl));
+
+    const metaUrl = await fromLoader.resolver.getMetaUrl(packageRef, variant);
+    let newMetaUrl = metaUrl;
+
+    if (metaUrl) {
+      newMetaUrl = await toLoader.putMisc(await fromLoader.readMisc(metaUrl));
+    }
+    const url = await toLoader.putDeploy(deployData!);
+
+    if (!url || /*url !== toPublishUrl || */ newMetaUrl !== metaUrl || miscUrl !== deployInfo.miscUrl) {
+      throw new Error('re-deployed urls do not match up');
+    }
+
+    const def = new ChainDefinition(deployInfo.def);
+
+    const preCtx = await createInitialContext(def, deployInfo.meta, 0, deployInfo.options);
+
+    return {
+      packagesNames: [def.getVersion(preCtx), ...tags].map((t) => `${def.getName(preCtx)}:${t}`),
+      variant,
+      url,
+      metaUrl: metaUrl || '',
+    };
+  }
 
   const chainId = parseInt(variant.split('-')[0]);
   const preset = variant.substring(variant.indexOf('-') + 1);
@@ -41,55 +84,12 @@ export async function copyIpfs({
     throw new Error('ipfs could not find deployment artifact. please double check your settings, and rebuild your package.');
   }
 
-  const def = new ChainDefinition(deployData.def);
-
   if (recursive) {
-    for (const stepState of Object.entries(deployData.state || {})) {
-      for (const importArtifact of Object.entries((stepState[1] as StepState).artifacts.imports || {})) {
-        // if there are any tags defined (even an empty array), then we assume that a publish should be done.
-        // otherwise, its a non-provisioned import and we shouldn't do anything
-        if (importArtifact[1].tags) {
-          // copy package nested
-          const nestedDeployInfo: DeploymentInfo = await fromLoader.readMisc(importArtifact[1].url);
-          const nestedDef = new ChainDefinition(nestedDeployInfo.def);
-          const preCtx = await createInitialContext(nestedDef, nestedDeployInfo.meta, 0, nestedDeployInfo.options);
-          registrationCalls.push(
-            ...(await copyIpfs({
-              packageRef: `${nestedDef.getName(preCtx)}:${nestedDef.getVersion(preCtx)}`,
-              variant: `${chainId}-${def.getConfig(stepState[0], preCtx).targetPreset}`,
-              tags: importArtifact[1].tags || [],
-              fromLoader,
-              toLoader,
-              recursive,
-            }))
-          );
-        }
-      }
-    }
+    const calls = await forPackageTree(fromLoader, deployData, copyIpfs);
+    return toLoader.resolver.publishMany(calls);
+  } else {
+    const call = await copyIpfs(deployData);
+
+    return toLoader.resolver.publish(call.packagesNames, call.variant, call.url, call.metaUrl);
   }
-
-  const miscUrl = await toLoader.putMisc(await fromLoader.readMisc(deployData!.miscUrl));
-
-  const metaUrl = await fromLoader.resolver.getMetaUrl(packageRef, variant);
-  let newMetaUrl = metaUrl;
-
-  if (metaUrl) {
-    newMetaUrl = await toLoader.putMisc(await fromLoader.readMisc(metaUrl));
-  }
-  const url = await toLoader.putDeploy(deployData!);
-
-  if (!url || /*url !== toPublishUrl || */ newMetaUrl !== metaUrl || miscUrl !== deployData.miscUrl) {
-    throw new Error('re-deployed urls do not match up');
-  }
-
-  const preCtx = await createInitialContext(def, deployData.meta, 0, deployData.options);
-
-  registrationCalls.push({
-    packagesNames: [def.getVersion(preCtx), ...tags].map((t) => `${def.getName(preCtx)}:${t}`),
-    variant,
-    url,
-    metaUrl: metaUrl || '',
-  });
-
-  return registrationCalls;
 }

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,4 +1,4 @@
-import { ChainDefinition, getOutputs, ChainBuilderRuntime } from '@usecannon/builder';
+import { ChainDefinition, getOutputs, ChainBuilderRuntime, DeploymentInfo } from '@usecannon/builder';
 import { ethers } from 'ethers';
 import axios from 'axios';
 import { getChainDataFromId, setupAnvil } from '../helpers';
@@ -7,6 +7,7 @@ import { getProvider, runRpc } from '../rpc';
 import { resolveCliSettings } from '../settings';
 import Debug from 'debug';
 import { getIpfsLoader } from '../util/loader';
+import { forPackageTree } from '@usecannon/builder/dist/package';
 
 const debug = Debug('cannon:cli:verify');
 
@@ -40,24 +41,6 @@ export async function verify(packageRef: string, apiKey: string, preset: string,
     getIpfsLoader(settings.ipfsUrl, resolver)
   );
 
-  const deployData = await runtime.loader.readDeploy(packageRef, preset, chainId);
-
-  if (!deployData) {
-    throw new Error(
-      `deployment not found: ${packageRef}. please make sure it exists for the given preset and current network.`
-    );
-  }
-
-  const miscData = await runtime.loader.readMisc(deployData.miscUrl);
-
-  debug('misc data', miscData);
-
-  const outputs = await getOutputs(runtime, new ChainDefinition(deployData.def), deployData.state);
-
-  if (!outputs) {
-    throw new Error('No chain outputs found. Has the requested chain already been built?');
-  }
-
   const etherscanApi = settings.etherscanApiUrl || getChainDataFromId(chainId)?.etherscanApi;
   //const etherscanUrl = getChainDataFromId(chainId)?.etherscanUrl; // in case we need it later
 
@@ -75,60 +58,85 @@ export async function verify(packageRef: string, apiKey: string, preset: string,
 
   const guids: { [c: string]: string } = {};
 
-  for (const c in outputs.contracts) {
-    const contractInfo = outputs.contracts[c];
+  const verifyPackage = async (deployData: DeploymentInfo) => {
+    const miscData = await runtime.loader.readMisc(deployData.miscUrl);
 
-    // contracts can either be imported by just their name, or by a full path.
-    // technically it may be more correct to just load by the actual name of the `artifact` property used, but that is complicated
-    debug('finding contract:', contractInfo.sourceName, contractInfo.contractName);
-    const contractArtifact =
-      miscData.artifacts[contractInfo.contractName] ||
-      miscData.artifacts[`${contractInfo.sourceName}:${contractInfo.contractName}`];
-
-    if (!contractArtifact) {
-      console.log(`${c}: cannot verify: no contract artifact found`);
-      continue;
+    debug('misc data', miscData);
+  
+    const outputs = await getOutputs(runtime, new ChainDefinition(deployData.def), deployData.state);
+  
+    if (!outputs) {
+      throw new Error('No chain outputs found. Has the requested chain already been built?');
     }
 
-    if (!contractArtifact.source) {
-      console.log(`${c}: cannot verify: no source code recorded in deploy data`);
-      continue;
-    }
-
-    // supply any linked libraries within the inputs since those are calculated at runtime
-    const inputData = JSON.parse(contractArtifact.source.input);
-    inputData.settings.libraries = contractInfo.linkedLibraries;
-
-    const reqData: { [k: string]: string } = {
-      apikey: apiKey,
-      module: 'contract',
-      action: 'verifysourcecode',
-      contractaddress: contractInfo.address,
-      // need to parse to get the inner structure, then stringify again
-      sourceCode: JSON.stringify(inputData),
-      codeformat: 'solidity-standard-json-input',
-      contractname: `${contractInfo.sourceName}:${contractInfo.contractName}`,
-      compilerversion: 'v' + contractArtifact.source.solcVersion,
-
-      // NOTE: below: yes, the etherscan api is misspelling
-      constructorArguements: new ethers.utils.Interface(contractArtifact.abi)
-        .encodeDeploy(contractInfo.constructorArgs)
-        .slice(2),
-    };
-
-    debug('verification request', reqData);
-
-    const res = await axios.post(etherscanApi, reqData, {
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    });
-
-    if (res.data.status === '0') {
-      console.log(`${c}:\tcannot verify:`, res.data.result);
-    } else {
-      console.log(`${c}:\tsubmitted verification (${contractInfo.address})`);
-      guids[c] = res.data.result;
+    for (const c in outputs.contracts) {
+      const contractInfo = outputs.contracts[c];
+  
+      // contracts can either be imported by just their name, or by a full path.
+      // technically it may be more correct to just load by the actual name of the `artifact` property used, but that is complicated
+      debug('finding contract:', contractInfo.sourceName, contractInfo.contractName);
+      const contractArtifact =
+        miscData.artifacts[contractInfo.contractName] ||
+        miscData.artifacts[`${contractInfo.sourceName}:${contractInfo.contractName}`];
+  
+      if (!contractArtifact) {
+        console.log(`${c}: cannot verify: no contract artifact found`);
+        continue;
+      }
+  
+      if (!contractArtifact.source) {
+        console.log(`${c}: cannot verify: no source code recorded in deploy data`);
+        continue;
+      }
+  
+      // supply any linked libraries within the inputs since those are calculated at runtime
+      const inputData = JSON.parse(contractArtifact.source.input);
+      inputData.settings.libraries = contractInfo.linkedLibraries;
+  
+      const reqData: { [k: string]: string } = {
+        apikey: apiKey,
+        module: 'contract',
+        action: 'verifysourcecode',
+        contractaddress: contractInfo.address,
+        // need to parse to get the inner structure, then stringify again
+        sourceCode: JSON.stringify(inputData),
+        codeformat: 'solidity-standard-json-input',
+        contractname: `${contractInfo.sourceName}:${contractInfo.contractName}`,
+        compilerversion: 'v' + contractArtifact.source.solcVersion,
+  
+        // NOTE: below: yes, the etherscan api is misspelling
+        constructorArguements: new ethers.utils.Interface(contractArtifact.abi)
+          .encodeDeploy(contractInfo.constructorArgs)
+          .slice(2),
+      };
+  
+      debug('verification request', reqData);
+  
+      const res = await axios.post(etherscanApi, reqData, {
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+  
+      if (res.data.status === '0') {
+        console.log(`${c}:\tcannot verify:`, res.data.result);
+      } else {
+        console.log(`${c}:\tsubmitted verification (${contractInfo.address})`);
+        guids[c] = res.data.result;
+      }
     }
   }
+
+  const deployData = await runtime.loader.readDeploy(packageRef, preset, chainId);
+
+  if (!deployData) {
+    throw new Error(
+      `deployment not found: ${packageRef}. please make sure it exists for the given preset and current network.`
+    );
+  }
+
+  // go through all the packages and sub packages and make sure all contracts are being verified
+  await forPackageTree(runtime.loader, deployData, verifyPackage);
+
+  // at this point, all contracts should have been submitted for verification. so we are just printing status.
   for (const c in guids) {
     for (;;) {
       const res = await axios.post(
@@ -147,7 +155,7 @@ export async function verify(packageRef: string, apiKey: string, preset: string,
           await sleep(1000);
         } else {
           console.log(`❌ ${c}`, res.data.result);
-          console.log(res.data);
+          debug(res.data);
           break;
         }
       } else {


### PR DESCRIPTION
now all provisioned packages will be eligible for publish upon call to `cannon verify`.

This is achieved with a new function `forPackageTree` which basically executes an action for a given `DeploymentInfo` object recursively, one at a time.

We could also use this function to do all kinds of other things to do with subpackages.