### PR TITLE
Refactor loader

### DIFF
--- a/packages/builder/src/builder.test.ts
+++ b/packages/builder/src/builder.test.ts
@@ -13,13 +13,14 @@ import { ChainBuilderContext, ContractArtifact, DeploymentState } from './types'
 
 import contractStep from './steps/contract';
 import invokeStep from './steps/invoke';
+import { InMemoryRegistry } from './registry';
 
 jest.mock('./error/provider');
 jest.mock('./steps/contract');
 jest.mock('./steps/invoke');
 
 describe('builder.ts', () => {
-  const loader = new IPFSLoader('', null as any, {});
+  const loader = new IPFSLoader('', null as any);
 
   const getSigner = jest.fn(async () => {
     return ethers.Wallet.createRandom();
@@ -60,7 +61,8 @@ describe('builder.ts', () => {
       getDefaultSigner,
       getArtifact,
     },
-    loader
+    new InMemoryRegistry(),
+    { ipfs: loader }
   );
 
   const fakeDefinition: RawChainDefinition = {

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -9,6 +9,7 @@ import { ActionKinds, getChainDefinitionValidator, RawChainDefinition } from './
 import { ChainBuilderRuntime } from './runtime';
 
 const debug = Debug('cannon:builder:definition');
+const debugVerbose = Debug('cannon:verbose:builder:definition');
 
 export type ChainDefinitionProblems = {
   invalidSchema: any;
@@ -149,7 +150,9 @@ export class ChainDefinition {
     if (!obj) {
       return null;
     } else {
-      return crypto.createHash('md5').update(JSON.stringify(obj)).digest('hex');
+      const rawState = JSON.stringify(obj);
+      debugVerbose('creating hash of', rawState);
+      return crypto.createHash('md5').update(rawState).digest('hex');
     }
   }
 

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -2,7 +2,7 @@ export { createInitialContext, build, getOutputs } from './builder';
 export { registerAction, CannonAction } from './actions';
 export type { RawChainDefinition } from './actions';
 export { ChainDefinition } from './definition';
-export { ChainBuilderRuntime, Events } from './runtime';
+export { ChainBuilderRuntime, CannonStorage, Events } from './runtime';
 export { CannonLoader, IPFSLoader } from './loader';
 
 export * from './util';

--- a/packages/builder/src/loader.test.ts
+++ b/packages/builder/src/loader.test.ts
@@ -1,5 +1,4 @@
 import { IPFSLoader } from './loader';
-import { ethers } from 'ethers';
 
 import { OnChainRegistry } from './registry';
 import { readIpfs, writeIpfs } from './ipfs';
@@ -11,57 +10,21 @@ describe('loader.ts', () => {
   describe('IPFSLoader', () => {
     jest.mocked(OnChainRegistry);
 
-    let registry: OnChainRegistry;
     let loader: IPFSLoader;
     beforeAll(() => {
-      registry = new OnChainRegistry({
-        address: ethers.constants.AddressZero,
-        signerOrProvider: ethers.Wallet.createRandom(),
-      });
-      loader = new IPFSLoader('hello', registry);
+      loader = new IPFSLoader('hello');
     });
 
     describe('constructor', () => {
       it('sets props', () => {
         expect(loader.ipfsUrl).toEqual('hello');
-        expect(loader.resolver).toBe(registry);
-      });
-    });
-
-    describe('readDeploy()', () => {
-      it('returns null when deployment is not found', async () => {
-        const deploy = await loader.readDeploy('foobar:1', 'main', 5);
-        expect(deploy).toBeNull();
-      });
-
-      it('calls readIpfs with correct url', async () => {
-        jest.mocked(registry.getUrl).mockResolvedValue('ipfs://Qmfoobar');
-        jest.mocked(readIpfs).mockResolvedValue({ hello: 'world' });
-        const deploy = await loader.readDeploy('foobar:1', 'main', 5);
-        expect(deploy).toEqual({ hello: 'world' });
-        expect(readIpfs).toBeCalledWith('hello', 'Qmfoobar', {});
-      });
-    });
-
-    describe('putDeploy()', () => {
-      it('calls ipfs write and returns the resulting ipfs Qmhash', async () => {
-        const fakeDeployDefinition = {
-          def: { name: 'funny', version: 'woot' },
-          state: {},
-          meta: '',
-          miscUrl: '',
-          options: {},
-        };
-        jest.mocked(writeIpfs).mockResolvedValue('Qmfun');
-        expect(await loader.putDeploy(fakeDeployDefinition)).toEqual('ipfs://Qmfun');
-        expect(writeIpfs).toBeCalledWith('hello', fakeDeployDefinition, {});
       });
     });
 
     describe('putMisc()', () => {
       it('calls ipfs write and returns the resulting ipfs Qmhash', async () => {
         jest.mocked(writeIpfs).mockResolvedValue('Qmfun');
-        expect(await loader.putMisc({ hello: 'fun' })).toEqual('ipfs://Qmfun');
+        expect(await loader.put({ hello: 'fun' })).toEqual('ipfs://Qmfun');
         expect(writeIpfs).toBeCalledWith('hello', { hello: 'fun' }, {});
       });
     });
@@ -69,7 +32,7 @@ describe('loader.ts', () => {
     describe('readMisc()', () => {
       it('calls readIpfs', async () => {
         jest.mocked(readIpfs).mockResolvedValue({ hello: 'world' });
-        const deploy = await loader.readMisc('ipfs://Qmfoobar');
+        const deploy = await loader.read('ipfs://Qmfoobar');
         expect(deploy).toEqual({ hello: 'world' });
       });
     });

--- a/packages/builder/src/loader.ts
+++ b/packages/builder/src/loader.ts
@@ -7,60 +7,40 @@ import Debug from 'debug';
 const debug = Debug('cannon:builder:loader');
 
 export interface CannonLoader {
-  resolver: CannonRegistry;
   getLabel(): string;
-  readDeploy(packageName: string, preset: string, chainId: number): Promise<DeploymentInfo | null>;
-  putDeploy(deployInfo: DeploymentInfo): Promise<string | null>;
-  readMisc(url: string): Promise<any | null>;
-  putMisc(misc: any): Promise<string | null>;
+  read(url: string): Promise<any | null>;
+  put(misc: any): Promise<string | null>;
 }
 
 export class IPFSLoader implements CannonLoader {
   ipfsUrl: string;
-  resolver: CannonRegistry;
   customHeaders: Headers = {};
 
   static PREFIX = 'ipfs://';
 
-  constructor(ipfsUrl: string, resolver: CannonRegistry, customHeaders: Headers = {}) {
+  constructor(ipfsUrl: string, customHeaders: Headers = {}) {
     this.ipfsUrl = ipfsUrl;
-    this.resolver = resolver;
     this.customHeaders = customHeaders;
   }
 
   getLabel() {
-    return `ipfs ${this.ipfsUrl} + ${this.resolver.getLabel()}`;
-  }
-
-  async readDeploy(packageName: string, preset: string, chainId: number): Promise<DeploymentInfo | null> {
-    const uri = await this.resolver.getUrl(packageName, `${chainId}-${preset}`);
-
-    if (!uri) return null;
-
-    const deployInfo: DeploymentInfo = await readIpfs(this.ipfsUrl, uri.replace(IPFSLoader.PREFIX, ''), this.customHeaders);
-
-    return deployInfo;
-  }
-
-  async putDeploy(deployInfo: DeploymentInfo): Promise<string | null> {
-    const deployHash = await writeIpfs(this.ipfsUrl, deployInfo, this.customHeaders);
-    return deployHash ? IPFSLoader.PREFIX + deployHash : deployHash;
+    return `ipfs ${this.ipfsUrl}`;
   }
 
   protected async readMiscInternal(url: string) {
     return await readIpfs(this.ipfsUrl, url.split(IPFSLoader.PREFIX)[1], this.customHeaders);
   }
 
-  async putMisc(misc: any): Promise<string | null> {
-    debug('record misc');
+  async put(misc: any): Promise<string | null> {
+    debug('ipfs put');
 
     const hash = await writeIpfs(this.ipfsUrl, misc, this.customHeaders);
 
     return hash ? IPFSLoader.PREFIX + hash : hash;
   }
 
-  async readMisc(url: string) {
-    debug('restore misc');
+  async read(url: string) {
+    debug('ipfs read', url);
 
     return await readIpfs(this.ipfsUrl, url.replace(IPFSLoader.PREFIX, ''), this.customHeaders);
   }

--- a/packages/builder/src/loader.ts
+++ b/packages/builder/src/loader.ts
@@ -1,6 +1,4 @@
 import { Headers, readIpfs, writeIpfs } from './ipfs';
-import { CannonRegistry } from './registry';
-import { DeploymentInfo } from './types';
 
 import Debug from 'debug';
 

--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -1,9 +1,7 @@
 import Debug from 'debug';
 import { DeploymentInfo, StepState } from './types';
-import { CannonLoader } from './loader';
 import { ChainDefinition } from './definition';
 import { createInitialContext } from './builder';
-import { CannonRegistry } from './registry';
 import { CannonStorage } from './runtime';
 const debug = Debug('cannon:cli:publish');
 
@@ -36,7 +34,7 @@ export async function forPackageTree<T>(
     for (const importArtifact of Object.entries((stepState[1] as StepState).artifacts.imports || {})) {
       if (!onlyProvisioned || importArtifact[1].tags) {
         const nestedDeployInfo = await store.readBlob(importArtifact[1].url);
-        results.push(...await forPackageTree(store, nestedDeployInfo, action, onlyProvisioned));
+        results.push(...(await forPackageTree(store, nestedDeployInfo, action, onlyProvisioned)));
       }
     }
   }

--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -3,93 +3,101 @@ import { DeploymentInfo, StepState } from './types';
 import { CannonLoader } from './loader';
 import { ChainDefinition } from './definition';
 import { createInitialContext } from './builder';
+import { CannonRegistry } from './registry';
+import { CannonStorage } from './runtime';
 const debug = Debug('cannon:cli:publish');
 
 export type CopyPackageOpts = {
   packageRef: string;
   variant: string;
   tags: string[];
-  fromLoader: CannonLoader;
-  toLoader: CannonLoader;
+  fromStorage: CannonStorage;
+  toStorage: CannonStorage;
   recursive?: boolean;
 };
 
-export async function copyPackage(opts: CopyPackageOpts) {
-  const calls = await copyIpfs(opts);
+/**
+ * Iterate Depth-First-Search over the given DeploymentInfo and its dependencies, and execute the given `action` function. Postfix execution (aka, `action` is only executed after dependants are completed).
+ * Each package executes one at a time. No paralellization.
+ * @param loader The loader to use for downloading sub-packages
+ * @param deployInfo The head node of the tree, which will be executed on `action` last
+ * @param action The action to execute
+ * @param onlyProvisioned Skip over sub-packages which are not provisioned within the parent
+ */
+export async function forPackageTree<T>(
+  store: CannonStorage,
+  deployInfo: DeploymentInfo,
+  action: (deployInfo: DeploymentInfo) => Promise<T>,
+  onlyProvisioned = true
+): Promise<T[]> {
+  const results: T[] = [];
 
-  return opts.toLoader.resolver.publishMany(calls);
+  for (const stepState of Object.entries(deployInfo.state || {})) {
+    for (const importArtifact of Object.entries((stepState[1] as StepState).artifacts.imports || {})) {
+      if (!onlyProvisioned || importArtifact[1].tags) {
+        const nestedDeployInfo = await store.readBlob(importArtifact[1].url);
+        results.push(...await forPackageTree(store, nestedDeployInfo, action, onlyProvisioned));
+      }
+    }
+  }
+
+  results.push(await action(deployInfo));
+
+  return results;
 }
 
-export async function copyIpfs({
-  packageRef,
-  tags,
-  variant,
-  fromLoader,
-  toLoader,
-  recursive,
-}: CopyPackageOpts): Promise<{ packagesNames: string[]; variant: string; url: string; metaUrl: string }[]> {
-  debug(`copy package ${packageRef} (${fromLoader.getLabel()} -> ${toLoader.getLabel()})`);
+export async function copyPackage({ packageRef, tags, variant, fromStorage, toStorage, recursive }: CopyPackageOpts) {
+  debug(`copy package ${packageRef} (${fromStorage.registry.getLabel()} -> ${toStorage.registry.getLabel()})`);
+  // this internal function will copy one package's ipfs records and return a publish call, without recursing
+  const copyIpfs = async (deployInfo: DeploymentInfo) => {
+    const newMiscUrl = await toStorage.putBlob(await fromStorage.readBlob(deployInfo!.miscUrl));
 
-  const registrationCalls: { packagesNames: string[]; variant: string; url: string; metaUrl: string }[] = [];
+    const metaUrl = await fromStorage.registry.getMetaUrl(packageRef, variant);
+    let newMetaUrl = metaUrl;
+
+    if (metaUrl) {
+      newMetaUrl = await toStorage.putBlob(await fromStorage.readBlob(metaUrl));
+
+      if (!newMetaUrl) {
+        throw new Error('error while writing new misc blob');
+      }
+    }
+
+    deployInfo.miscUrl = newMiscUrl || '';
+
+    const url = await toStorage.putBlob(deployInfo!);
+
+    if (!url) {
+      throw new Error('uploaded url is invalid');
+    }
+
+    const def = new ChainDefinition(deployInfo.def);
+
+    const preCtx = await createInitialContext(def, deployInfo.meta, 0, deployInfo.options);
+
+    return {
+      packagesNames: [def.getVersion(preCtx), ...tags].map((t) => `${def.getName(preCtx)}:${t}`),
+      variant,
+      url,
+      metaUrl: newMetaUrl || '',
+    };
+  };
 
   const chainId = parseInt(variant.split('-')[0]);
   const preset = variant.substring(variant.indexOf('-') + 1);
 
-  const deployData = await fromLoader.readDeploy(packageRef, preset, chainId);
+  const deployData = await fromStorage.readDeploy(packageRef, preset, chainId);
 
   if (!deployData) {
     throw new Error('ipfs could not find deployment artifact. please double check your settings, and rebuild your package.');
   }
 
-  const def = new ChainDefinition(deployData.def);
-
   if (recursive) {
-    for (const stepState of Object.entries(deployData.state || {})) {
-      for (const importArtifact of Object.entries((stepState[1] as StepState).artifacts.imports || {})) {
-        // if there are any tags defined (even an empty array), then we assume that a publish should be done.
-        // otherwise, its a non-provisioned import and we shouldn't do anything
-        if (importArtifact[1].tags) {
-          // copy package nested
-          const nestedDeployInfo: DeploymentInfo = await fromLoader.readMisc(importArtifact[1].url);
-          const nestedDef = new ChainDefinition(nestedDeployInfo.def);
-          const preCtx = await createInitialContext(nestedDef, nestedDeployInfo.meta, 0, nestedDeployInfo.options);
-          registrationCalls.push(
-            ...(await copyIpfs({
-              packageRef: `${nestedDef.getName(preCtx)}:${nestedDef.getVersion(preCtx)}`,
-              variant: `${chainId}-${def.getConfig(stepState[0], preCtx).targetPreset}`,
-              tags: importArtifact[1].tags || [],
-              fromLoader,
-              toLoader,
-              recursive,
-            }))
-          );
-        }
-      }
-    }
+    const calls = await forPackageTree(fromStorage, deployData, copyIpfs);
+    return toStorage.registry.publishMany(calls);
+  } else {
+    const call = await copyIpfs(deployData);
+
+    return toStorage.registry.publish(call.packagesNames, call.variant, call.url, call.metaUrl);
   }
-
-  const miscUrl = await toLoader.putMisc(await fromLoader.readMisc(deployData!.miscUrl));
-
-  const metaUrl = await fromLoader.resolver.getMetaUrl(packageRef, variant);
-  let newMetaUrl = metaUrl;
-
-  if (metaUrl) {
-    newMetaUrl = await toLoader.putMisc(await fromLoader.readMisc(metaUrl));
-  }
-  const url = await toLoader.putDeploy(deployData!);
-
-  if (!url || /*url !== toPublishUrl || */ newMetaUrl !== metaUrl || miscUrl !== deployData.miscUrl) {
-    throw new Error('re-deployed urls do not match up');
-  }
-
-  const preCtx = await createInitialContext(def, deployData.meta, 0, deployData.options);
-
-  registrationCalls.push({
-    packagesNames: [def.getVersion(preCtx), ...tags].map((t) => `${def.getName(preCtx)}:${t}`),
-    variant,
-    url,
-    metaUrl: metaUrl || '',
-  });
-
-  return registrationCalls;
 }

--- a/packages/builder/src/runtime.ts
+++ b/packages/builder/src/runtime.ts
@@ -2,11 +2,12 @@ import _ from 'lodash';
 import { ethers } from 'ethers';
 import { EventEmitter } from 'events';
 import { CannonWrapperGenericProvider } from './error/provider';
-import { ChainBuilderRuntimeInfo, ContractArtifact } from './types';
+import { ChainBuilderRuntimeInfo, ContractArtifact, DeploymentInfo } from './types';
 
 import Debug from 'debug';
 import { getExecutionSigner } from './util';
 import { CannonLoader } from './loader';
+import { CannonRegistry } from './registry';
 
 const debug = Debug('cannon:builder:runtime');
 
@@ -19,7 +20,42 @@ export enum Events {
   SkipDeploy = 'skip-deploy', // step name, error causing skip
 }
 
-export class ChainBuilderRuntime extends EventEmitter implements ChainBuilderRuntimeInfo {
+export class CannonStorage extends EventEmitter {
+  readonly registry: CannonRegistry;
+  readonly defaultLoaderScheme: string;
+  readonly loaders: {[scheme: string]: CannonLoader};
+
+  constructor(registry: CannonRegistry, loaders: {[scheme: string]: CannonLoader}, defaultLoaderScheme = 'ipfs') {
+    super();
+    this.registry = registry;
+    this.defaultLoaderScheme = defaultLoaderScheme;
+    this.loaders = loaders;
+  }
+
+  readBlob(url: string) {
+    return this.loaders[url.split(':')[0]].read(url);
+  }
+
+  putBlob(data: any) {
+    return this.loaders[this.defaultLoaderScheme].put(data)
+  }
+
+  async readDeploy(packageName: string, preset: string, chainId: number): Promise<DeploymentInfo | null> {
+    const uri = await this.registry.getUrl(packageName, `${chainId}-${preset}`);
+
+    if (!uri) return null;
+
+    const deployInfo: DeploymentInfo = await this.readBlob(uri);
+
+    return deployInfo;
+  }
+
+  async putDeploy(deployInfo: DeploymentInfo): Promise<string | null> {
+    return this.putBlob(deployInfo);
+  }
+}
+
+export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRuntimeInfo {
   readonly provider: CannonWrapperGenericProvider;
   readonly chainId: number;
   readonly getSigner: (addr: string) => Promise<ethers.Signer>;
@@ -31,17 +67,17 @@ export class ChainBuilderRuntime extends EventEmitter implements ChainBuilderRun
 
   private cleanSnapshot: any;
 
-  readonly loader: CannonLoader;
-
   private loadedMisc: string | null = null;
   misc: {
     artifacts: { [label: string]: any };
   };
 
-  constructor(info: ChainBuilderRuntimeInfo, loader: CannonLoader) {
-    super();
+  constructor(info: ChainBuilderRuntimeInfo, registry: CannonRegistry, loaders: {[scheme: string]: CannonLoader}, defaultLoaderScheme = 'ipfs') {
+    super(registry, loaders, defaultLoaderScheme);
 
-    this.loader = loader;
+    if (!loaders[defaultLoaderScheme]) {
+      throw new Error('default loader scheme not provided as a loader');
+    }
 
     this.provider = info.provider;
     this.chainId = info.chainId;
@@ -109,7 +145,7 @@ export class ChainBuilderRuntime extends EventEmitter implements ChainBuilderRun
   }
 
   async recordMisc() {
-    return await this.loader.putMisc(this.misc);
+    return await this.loaders[this.defaultLoaderScheme].put(this.misc);
   }
 
   async restoreMisc(url: string) {
@@ -117,7 +153,7 @@ export class ChainBuilderRuntime extends EventEmitter implements ChainBuilderRun
       return;
     }
 
-    this.misc = await this.loader.readMisc(url);
+    this.misc = await this.readBlob(url);
 
     this.loadedMisc = url;
   }
@@ -133,7 +169,7 @@ export class ChainBuilderRuntime extends EventEmitter implements ChainBuilderRun
   }
 
   derive(overrides: Partial<ChainBuilderRuntimeInfo>): ChainBuilderRuntime {
-    const newRuntime = new ChainBuilderRuntime({ ...this, ...overrides }, this.loader);
+    const newRuntime = new ChainBuilderRuntime({ ...this, ...overrides }, this.registry, this.loaders, this.defaultLoaderScheme);
 
     // forward any events which come from our child
     newRuntime.on(Events.PreStepExecute, (t, n, c, d) => this.emit(Events.PreStepExecute, t, n, c, d + 1));

--- a/packages/builder/src/runtime.ts
+++ b/packages/builder/src/runtime.ts
@@ -23,9 +23,9 @@ export enum Events {
 export class CannonStorage extends EventEmitter {
   readonly registry: CannonRegistry;
   readonly defaultLoaderScheme: string;
-  readonly loaders: {[scheme: string]: CannonLoader};
+  readonly loaders: { [scheme: string]: CannonLoader };
 
-  constructor(registry: CannonRegistry, loaders: {[scheme: string]: CannonLoader}, defaultLoaderScheme = 'ipfs') {
+  constructor(registry: CannonRegistry, loaders: { [scheme: string]: CannonLoader }, defaultLoaderScheme = 'ipfs') {
     super();
     this.registry = registry;
     this.defaultLoaderScheme = defaultLoaderScheme;
@@ -33,7 +33,6 @@ export class CannonStorage extends EventEmitter {
   }
 
   readBlob(url: string) {
-
     if (!url) {
       throw new Error('url not defined');
     }
@@ -42,7 +41,7 @@ export class CannonStorage extends EventEmitter {
   }
 
   putBlob(data: any) {
-    return this.loaders[this.defaultLoaderScheme].put(data)
+    return this.loaders[this.defaultLoaderScheme].put(data);
   }
 
   async readDeploy(packageName: string, preset: string, chainId: number): Promise<DeploymentInfo | null> {
@@ -77,7 +76,12 @@ export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRu
     artifacts: { [label: string]: any };
   };
 
-  constructor(info: ChainBuilderRuntimeInfo, registry: CannonRegistry, loaders: {[scheme: string]: CannonLoader}, defaultLoaderScheme = 'ipfs') {
+  constructor(
+    info: ChainBuilderRuntimeInfo,
+    registry: CannonRegistry,
+    loaders: { [scheme: string]: CannonLoader },
+    defaultLoaderScheme = 'ipfs'
+  ) {
     super(registry, loaders, defaultLoaderScheme);
 
     if (!loaders[defaultLoaderScheme]) {
@@ -174,7 +178,12 @@ export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRu
   }
 
   derive(overrides: Partial<ChainBuilderRuntimeInfo>): ChainBuilderRuntime {
-    const newRuntime = new ChainBuilderRuntime({ ...this, ...overrides }, this.registry, this.loaders, this.defaultLoaderScheme);
+    const newRuntime = new ChainBuilderRuntime(
+      { ...this, ...overrides },
+      this.registry,
+      this.loaders,
+      this.defaultLoaderScheme
+    );
 
     // forward any events which come from our child
     newRuntime.on(Events.PreStepExecute, (t, n, c, d) => this.emit(Events.PreStepExecute, t, n, c, d + 1));

--- a/packages/builder/src/runtime.ts
+++ b/packages/builder/src/runtime.ts
@@ -33,6 +33,11 @@ export class CannonStorage extends EventEmitter {
   }
 
   readBlob(url: string) {
+
+    if (!url) {
+      throw new Error('url not defined');
+    }
+
     return this.loaders[url.split(':')[0]].read(url);
   }
 

--- a/packages/builder/src/steps/import.test.ts
+++ b/packages/builder/src/steps/import.test.ts
@@ -1,6 +1,5 @@
 import '../actions';
 import { BUILD_VERSION } from '../constants';
-import { IPFSLoader } from '../loader';
 import { InMemoryRegistry } from '../registry';
 import action from './import';
 import { fakeCtx, fakeRuntime } from './testUtils';
@@ -11,8 +10,7 @@ describe('steps/import.ts', () => {
   const registry = new InMemoryRegistry();
 
   beforeAll(async () => {
-    (fakeRuntime.loader as any) = new IPFSLoader('', registry);
-    fakeRuntime.loader.resolver = registry;
+    (fakeRuntime.registry as any) = registry;
     (fakeRuntime.chainId as any) = 1234;
   });
 
@@ -61,7 +59,7 @@ describe('steps/import.ts', () => {
     it('works properly', async () => {
       await registry.publish(['hello:1.0.0'], '1234-main', 'https://something.com', '');
 
-      jest.mocked(fakeRuntime.loader.readDeploy).mockResolvedValue({
+      jest.mocked(fakeRuntime.readDeploy).mockResolvedValue({
         state: {
           'contract.Woot': {
             version: BUILD_VERSION,

--- a/packages/builder/src/steps/import.ts
+++ b/packages/builder/src/steps/import.ts
@@ -41,7 +41,7 @@ export default {
     const chainId = config.chainId ?? runtime.chainId;
 
     debug('resolved pkg', cfg.source, `${chainId}-${preset}`);
-    const url = await runtime.loader.resolver.getUrl(cfg.source, `${chainId}-${preset}`);
+    const url = await runtime.registry.getUrl(cfg.source, `${chainId}-${preset}`);
 
     return {
       url,
@@ -72,7 +72,7 @@ export default {
 
     // try to load the chain definition specific to this chain
     // otherwise, load the top level definition
-    const deployInfo = await runtime.loader.readDeploy(packageRef, preset, chainId);
+    const deployInfo = await runtime.readDeploy(packageRef, preset, chainId);
 
     if (!deployInfo) {
       throw new Error(
@@ -89,7 +89,7 @@ export default {
     return {
       imports: {
         [importLabel]: {
-          url: (await runtime.loader.resolver.getUrl(packageRef, `${chainId}-${preset}`))!, // todo: duplication
+          url: (await runtime.registry.getUrl(packageRef, `${chainId}-${preset}`))!, // todo: duplication
           ...(await getOutputs(runtime, new ChainDefinition(deployInfo.def), deployInfo.state))!,
         },
       },

--- a/packages/builder/src/steps/provision.test.ts
+++ b/packages/builder/src/steps/provision.test.ts
@@ -1,6 +1,5 @@
 import '../actions';
 import { BUILD_VERSION } from '../constants';
-import { IPFSLoader } from '../loader';
 import { InMemoryRegistry } from '../registry';
 import action from './provision';
 import { fakeCtx, fakeRuntime } from './testUtils';
@@ -15,8 +14,7 @@ describe('setps/provision.ts', () => {
   const registry = new InMemoryRegistry();
 
   beforeAll(async () => {
-    (fakeRuntime.loader as any) = new IPFSLoader('', registry);
-    fakeRuntime.loader.resolver = registry;
+    (fakeRuntime.registry as any) = registry;
     (fakeRuntime.chainId as any) = 1234;
 
     jest.mocked(fakeRuntime.derive).mockReturnThis();
@@ -104,7 +102,7 @@ describe('setps/provision.ts', () => {
     it('works properly', async () => {
       await registry.publish(['hello:1.0.0'], '1234-main', 'https://something.com', '');
 
-      jest.mocked(fakeRuntime.loader.readDeploy).mockResolvedValue({
+      jest.mocked(fakeRuntime.readDeploy).mockResolvedValue({
         state: {
           'contract.Woot': {
             version: BUILD_VERSION,
@@ -135,7 +133,7 @@ describe('setps/provision.ts', () => {
         miscUrl: 'https://something.com',
       });
 
-      jest.mocked(fakeRuntime.loader.putDeploy).mockResolvedValue('ipfs://Qmsomething');
+      jest.mocked(fakeRuntime.putDeploy).mockResolvedValue('ipfs://Qmsomething');
 
       const result = await action.exec(
         fakeRuntime,
@@ -148,6 +146,7 @@ describe('setps/provision.ts', () => {
         imports: {
           something: {
             url: 'ipfs://Qmsomething',
+            preset: 'main',
             tags: ['latest'],
             contracts: {
               Woot: {

--- a/packages/builder/src/steps/provision.ts
+++ b/packages/builder/src/steps/provision.ts
@@ -61,14 +61,14 @@ export default {
     if (ctx.imports[importLabel]?.url) {
       const prevUrl = ctx.imports[importLabel].url!;
 
-      if ((await runtime.loader.readMisc(prevUrl))!.status === 'partial') {
+      if ((await runtime.readBlob(prevUrl))!.status === 'partial') {
         // partial build always need to be re-evaluated
         debug('forcing rebuild because deployment is partial');
         return 'REBUILD PARTIAL DEPLOYMENT ' + Math.random();
       }
     }
 
-    const srcUrl = await runtime.loader.resolver.getUrl(cfg.source, `${chainId}-${sourcePreset}`);
+    const srcUrl = await runtime.registry.getUrl(cfg.source, `${chainId}-${sourcePreset}`);
 
     return {
       url: srcUrl,
@@ -111,7 +111,7 @@ export default {
     const chainId = config.chainId ?? CANNON_CHAIN_ID;
 
     // try to read the chain definition we are going to use
-    const deployInfo = await runtime.loader.readDeploy(config.source, sourcePreset, chainId);
+    const deployInfo = await runtime.readDeploy(config.source, sourcePreset, chainId);
     if (!deployInfo) {
       throw new Error(
         `deployment not found: ${config.source}. please make sure it exists for preset ${sourcePreset} and network ${chainId}.`
@@ -131,13 +131,13 @@ export default {
     if (ctx.imports[importLabel]?.url) {
       const prevUrl = ctx.imports[importLabel].url!;
       debug(`using state from previous deploy: ${prevUrl}`);
-      const prevDeployInfo = await runtime.loader.readMisc(prevUrl);
+      const prevDeployInfo = await runtime.readBlob(prevUrl);
       prevState = prevDeployInfo!.state;
       prevMiscUrl = prevDeployInfo!.miscUrl;
     } else {
       // sanity: there shouldn't already be a build in our way
       // if there is, we need to overwrite it. print out a warning.
-      if (await runtime.loader.readDeploy(config.source, targetPreset, runtime.chainId)) {
+      if (await runtime.readDeploy(config.source, targetPreset, runtime.chainId)) {
         console.warn(
           'warn: there is a preexisting deployment for this preset/chainId. this build will overwrite. did you mean `import`?'
         );
@@ -152,7 +152,7 @@ export default {
     // use separate runtime to ensure everything is clear
     // we override `getArtifact` to use a simple loader from the upstream misc data to ensure that any contract upgrades are captured as expected
     // but if any other misc changes are generated they will still be preserved through the new separate context misc
-    const upstreamMisc = await runtime.loader.readMisc(deployInfo.miscUrl);
+    const upstreamMisc = await runtime.readBlob(deployInfo.miscUrl);
     const importRuntime = runtime.derive({
       getArtifact: (n) => {
         return upstreamMisc.artifacts[n];
@@ -179,7 +179,7 @@ export default {
     debug('new misc:', newMiscUrl);
 
     // need to save state to IPFS now so we can access it in future builds
-    const newSubDeployUrl = await runtime.loader.putDeploy({
+    const newSubDeployUrl = await runtime.putDeploy({
       def: def.toJson(),
       miscUrl: newMiscUrl || '',
       options: importPkgOptions,
@@ -191,11 +191,11 @@ export default {
     if (!newSubDeployUrl) {
       console.warn('warn: cannot record built state for import nested state');
     } else {
-      await runtime.loader.resolver.publish(
-        [config.source, ...(config.tags || ['latest']).map((t) => config.source.split(':')[1] + ':' + t)],
+      await runtime.registry.publish(
+        [config.source, ...(config.tags || ['latest']).map((t) => config.source.split(':')[0] + ':' + t)],
         `${runtime.chainId}-${targetPreset}`,
         newSubDeployUrl,
-        (await runtime.loader.resolver.getMetaUrl(config.source, `${chainId}-${config.sourcePreset}`)) || ''
+        (await runtime.registry.getMetaUrl(config.source, `${chainId}-${config.sourcePreset}`)) || ''
       );
     }
 

--- a/packages/builder/src/steps/provision.ts
+++ b/packages/builder/src/steps/provision.ts
@@ -204,6 +204,7 @@ export default {
         [importLabel]: {
           url: newSubDeployUrl || '',
           tags: config.tags || ['latest'],
+          preset: targetPreset,
           ...(await getOutputs(importRuntime, def, builtState))!,
         },
       },

--- a/packages/builder/src/steps/testUtils.ts
+++ b/packages/builder/src/steps/testUtils.ts
@@ -23,7 +23,7 @@ export const fakeCtx = {
   timestamp: '1234123412',
 } as unknown as ChainBuilderContextWithHelpers;
 
-export const fakeRuntime = new ChainBuilderRuntime({} as any, null as any);
+export const fakeRuntime = new ChainBuilderRuntime({} as any, null as any, {});
 
 (fakeRuntime as any).provider = new CannonWrapperGenericProvider({}, null as any);
 

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -119,8 +119,10 @@ export interface PackageState {
   currentLabel: string;
 }
 
+export type BundledOutput = { url: string; tags?: string[]; preset?: string } & ChainArtifacts;
+
 export interface BundledChainBuilderOutputs {
-  [module: string]: { url: string; tags?: string[] } & ChainArtifacts;
+  [module: string]: BundledOutput;
 }
 
 export type ChainArtifacts = Partial<Pick<ChainBuilderContext, 'imports' | 'contracts' | 'txns' | 'extras'>>;

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -22,7 +22,7 @@ import { resolveCliSettings } from '../settings';
 import { createDefaultReadRegistry } from '../registry';
 
 import { listInstalledPlugins, loadPlugin } from '../plugins';
-import { getIpfsLoader } from '../util/loader';
+import { getMainLoader } from '../loader';
 
 interface Params {
   provider: CannonWrapperGenericProvider;
@@ -118,7 +118,7 @@ export async function build({
 
   const resolver = overrideResolver || (await createDefaultReadRegistry(cliSettings));
 
-  const runtime = new ChainBuilderRuntime(runtimeOptions, getIpfsLoader(cliSettings.ipfsUrl, resolver));
+  const runtime = new ChainBuilderRuntime(runtimeOptions, resolver, getMainLoader(cliSettings), cliSettings.ipfsUrl ? 'ipfs' : 'file');
 
   let partialDeploy = false;
   runtime.on(Events.PreStepExecute, (t, n, _c, d) => console.log(`${'  '.repeat(d)}exec: ${t}.${n}`));
@@ -132,7 +132,7 @@ export async function build({
   const prevPkg = upgradeFrom || `${packageDefinition.name}:${packageDefinition.version}`;
 
   console.log(bold(`Checking IPFS for package ${prevPkg}...`));
-  oldDeployData = await runtime.loader.readDeploy(prevPkg, preset || 'main', runtime.chainId);
+  oldDeployData = await runtime.readDeploy(prevPkg, preset || 'main', runtime.chainId);
 
   // Update pkgInfo (package.json) with information from existing package, if present
   if (oldDeployData) {
@@ -242,7 +242,7 @@ export async function build({
   const miscUrl = await runtime.recordMisc();
 
   if (miscUrl) {
-    const deployUrl = await runtime.loader.putDeploy({
+    const deployUrl = await runtime.putDeploy({
       def: def.toJson(),
       state: newState,
       options: resolvedSettings,
@@ -251,7 +251,7 @@ export async function build({
       miscUrl: miscUrl,
     });
 
-    const metaUrl = await runtime.loader.putMisc(await readMetadataCache(`${pkgName}:${pkgVersion}`));
+    const metaUrl = await runtime.putBlob(await readMetadataCache(`${pkgName}:${pkgVersion}`));
 
     if (persist) {
       await resolver.publish(

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -118,7 +118,12 @@ export async function build({
 
   const resolver = overrideResolver || (await createDefaultReadRegistry(cliSettings));
 
-  const runtime = new ChainBuilderRuntime(runtimeOptions, resolver, getMainLoader(cliSettings), cliSettings.ipfsUrl ? 'ipfs' : 'file');
+  const runtime = new ChainBuilderRuntime(
+    runtimeOptions,
+    resolver,
+    getMainLoader(cliSettings),
+    cliSettings.ipfsUrl ? 'ipfs' : 'file'
+  );
 
   let partialDeploy = false;
   runtime.on(Events.PreStepExecute, (t, n, _c, d) => console.log(`${'  '.repeat(d)}exec: ${t}.${n}`));

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -135,7 +135,7 @@ export async function build({
   oldDeployData = await runtime.readDeploy(prevPkg, preset || 'main', runtime.chainId);
 
   // Update pkgInfo (package.json) with information from existing package, if present
-  if (oldDeployData) {
+  if (oldDeployData && !wipe) {
     console.log('Existing package found.');
     await runtime.restoreMisc(oldDeployData.miscUrl);
 

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -24,12 +24,10 @@ export async function inspect(packageRef: string, chainId: number, preset: strin
     );
   }
 
-  const deployData = await loader[deployUrl.split(':')[0] as 'ipfs'|'file'].read(deployUrl);
+  const deployData = await loader[deployUrl.split(':')[0] as 'ipfs' | 'file'].read(deployUrl);
 
   if (!deployData) {
-    throw new Error(
-      `deployment data could not be downloaded for ${deployUrl} from ${`${name}:${version}`}.`
-    );
+    throw new Error(`deployment data could not be downloaded for ${deployUrl} from ${`${name}:${version}`}.`);
   }
 
   const chainDefinition = new ChainDefinition(deployData.def);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,8 +1,9 @@
-import { IPFSLoader, OnChainRegistry, copyPackage } from '@usecannon/builder';
+import { IPFSLoader, OnChainRegistry, CannonStorage, copyPackage } from '@usecannon/builder';
 import { blueBright } from 'chalk';
 import { ethers } from 'ethers';
 import { LocalRegistry } from '../registry';
 import { resolveCliSettings } from '../settings';
+import { getMainLoader } from '../loader';
 
 export async function publish(
   packageRef: string,
@@ -38,14 +39,18 @@ export async function publish(
     console.log('Found deployment networks:', deploys.map((d) => d.variant).join(', '));
   }
 
+  if (!cliSettings.ipfsUrl && !cliSettings.publishIpfsUrl) {
+    throw new Error(`in order to publish, a IPFS URL must be set in your cannon configuration. use '${process.argv[0]} setup' to configure`)
+  }
+
   const onChainRegistry = new OnChainRegistry({
     signerOrProvider: signer,
     address: cliSettings.registryAddress,
     overrides,
   });
 
-  const fromLoader = new IPFSLoader(cliSettings.ipfsUrl, localRegistry);
-  const toLoader = new IPFSLoader(cliSettings.publishIpfsUrl || cliSettings.ipfsUrl, onChainRegistry);
+  const fromStorage = new CannonStorage(localRegistry, getMainLoader(cliSettings));
+  const toStorage = new CannonStorage(onChainRegistry, { ipfs: new IPFSLoader(cliSettings.publishIpfsUrl || cliSettings.ipfsUrl!) });
 
   const registrationReceipts = [];
 
@@ -53,8 +58,8 @@ export async function publish(
     const newReceipts = await copyPackage({
       packageRef: deploy.name,
       variant: deploy.variant,
-      fromLoader,
-      toLoader,
+      fromStorage,
+      toStorage,
       recursive,
       tags: tags.split(','),
     });

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -40,7 +40,9 @@ export async function publish(
   }
 
   if (!cliSettings.ipfsUrl && !cliSettings.publishIpfsUrl) {
-    throw new Error(`in order to publish, a IPFS URL must be set in your cannon configuration. use '${process.argv[0]} setup' to configure`)
+    throw new Error(
+      `in order to publish, a IPFS URL must be set in your cannon configuration. use '${process.argv[0]} setup' to configure`
+    );
   }
 
   const onChainRegistry = new OnChainRegistry({
@@ -50,7 +52,9 @@ export async function publish(
   });
 
   const fromStorage = new CannonStorage(localRegistry, getMainLoader(cliSettings));
-  const toStorage = new CannonStorage(onChainRegistry, { ipfs: new IPFSLoader(cliSettings.publishIpfsUrl || cliSettings.ipfsUrl!) });
+  const toStorage = new CannonStorage(onChainRegistry, {
+    ipfs: new IPFSLoader(cliSettings.publishIpfsUrl || cliSettings.ipfsUrl!),
+  });
 
   const registrationReceipts = [];
 

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,4 +1,4 @@
-import { ChainDefinition, getOutputs, ChainBuilderRuntime } from '@usecannon/builder';
+import { ChainDefinition, getOutputs, ChainBuilderRuntime, DeploymentInfo } from '@usecannon/builder';
 import { ethers } from 'ethers';
 import axios from 'axios';
 import { getChainDataFromId, setupAnvil } from '../helpers';
@@ -6,7 +6,8 @@ import { createDefaultReadRegistry } from '../registry';
 import { getProvider, runRpc } from '../rpc';
 import { resolveCliSettings } from '../settings';
 import Debug from 'debug';
-import { getIpfsLoader } from '../util/loader';
+import { forPackageTree } from '@usecannon/builder/dist/package';
+import { getMainLoader } from '../loader';
 
 const debug = Debug('cannon:cli:verify');
 
@@ -37,26 +38,9 @@ export async function verify(packageRef: string, apiKey: string, preset: string,
       snapshots: false,
       allowPartialDeploy: false,
     },
-    getIpfsLoader(settings.ipfsUrl, resolver)
+    resolver,
+    getMainLoader(settings)
   );
-
-  const deployData = await runtime.loader.readDeploy(packageRef, preset, chainId);
-
-  if (!deployData) {
-    throw new Error(
-      `deployment not found: ${packageRef}. please make sure it exists for the given preset and current network.`
-    );
-  }
-
-  const miscData = await runtime.loader.readMisc(deployData.miscUrl);
-
-  debug('misc data', miscData);
-
-  const outputs = await getOutputs(runtime, new ChainDefinition(deployData.def), deployData.state);
-
-  if (!outputs) {
-    throw new Error('No chain outputs found. Has the requested chain already been built?');
-  }
 
   const etherscanApi = settings.etherscanApiUrl || getChainDataFromId(chainId)?.etherscanApi;
   //const etherscanUrl = getChainDataFromId(chainId)?.etherscanUrl; // in case we need it later
@@ -75,60 +59,85 @@ export async function verify(packageRef: string, apiKey: string, preset: string,
 
   const guids: { [c: string]: string } = {};
 
-  for (const c in outputs.contracts) {
-    const contractInfo = outputs.contracts[c];
+  const verifyPackage = async (deployData: DeploymentInfo) => {
+    const miscData = await runtime.readBlob(deployData.miscUrl);
 
-    // contracts can either be imported by just their name, or by a full path.
-    // technically it may be more correct to just load by the actual name of the `artifact` property used, but that is complicated
-    debug('finding contract:', contractInfo.sourceName, contractInfo.contractName);
-    const contractArtifact =
-      miscData.artifacts[contractInfo.contractName] ||
-      miscData.artifacts[`${contractInfo.sourceName}:${contractInfo.contractName}`];
+    debug('misc data', miscData);
 
-    if (!contractArtifact) {
-      console.log(`${c}: cannot verify: no contract artifact found`);
-      continue;
+    const outputs = await getOutputs(runtime, new ChainDefinition(deployData.def), deployData.state);
+
+    if (!outputs) {
+      throw new Error('No chain outputs found. Has the requested chain already been built?');
     }
 
-    if (!contractArtifact.source) {
-      console.log(`${c}: cannot verify: no source code recorded in deploy data`);
-      continue;
+    for (const c in outputs.contracts) {
+      const contractInfo = outputs.contracts[c];
+
+      // contracts can either be imported by just their name, or by a full path.
+      // technically it may be more correct to just load by the actual name of the `artifact` property used, but that is complicated
+      debug('finding contract:', contractInfo.sourceName, contractInfo.contractName);
+      const contractArtifact =
+        miscData.artifacts[contractInfo.contractName] ||
+        miscData.artifacts[`${contractInfo.sourceName}:${contractInfo.contractName}`];
+
+      if (!contractArtifact) {
+        console.log(`${c}: cannot verify: no contract artifact found`);
+        continue;
+      }
+
+      if (!contractArtifact.source) {
+        console.log(`${c}: cannot verify: no source code recorded in deploy data`);
+        continue;
+      }
+
+      // supply any linked libraries within the inputs since those are calculated at runtime
+      const inputData = JSON.parse(contractArtifact.source.input);
+      inputData.settings.libraries = contractInfo.linkedLibraries;
+
+      const reqData: { [k: string]: string } = {
+        apikey: apiKey,
+        module: 'contract',
+        action: 'verifysourcecode',
+        contractaddress: contractInfo.address,
+        // need to parse to get the inner structure, then stringify again
+        sourceCode: JSON.stringify(inputData),
+        codeformat: 'solidity-standard-json-input',
+        contractname: `${contractInfo.sourceName}:${contractInfo.contractName}`,
+        compilerversion: 'v' + contractArtifact.source.solcVersion,
+
+        // NOTE: below: yes, the etherscan api is misspelling
+        constructorArguements: new ethers.utils.Interface(contractArtifact.abi)
+          .encodeDeploy(contractInfo.constructorArgs)
+          .slice(2),
+      };
+
+      debug('verification request', reqData);
+
+      const res = await axios.post(etherscanApi, reqData, {
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      if (res.data.status === '0') {
+        console.log(`${c}:\tcannot verify:`, res.data.result);
+      } else {
+        console.log(`${c}:\tsubmitted verification (${contractInfo.address})`);
+        guids[c] = res.data.result;
+      }
     }
+  };
 
-    // supply any linked libraries within the inputs since those are calculated at runtime
-    const inputData = JSON.parse(contractArtifact.source.input);
-    inputData.settings.libraries = contractInfo.linkedLibraries;
+  const deployData = await runtime.readDeploy(packageRef, preset, chainId);
 
-    const reqData: { [k: string]: string } = {
-      apikey: apiKey,
-      module: 'contract',
-      action: 'verifysourcecode',
-      contractaddress: contractInfo.address,
-      // need to parse to get the inner structure, then stringify again
-      sourceCode: JSON.stringify(inputData),
-      codeformat: 'solidity-standard-json-input',
-      contractname: `${contractInfo.sourceName}:${contractInfo.contractName}`,
-      compilerversion: 'v' + contractArtifact.source.solcVersion,
-
-      // NOTE: below: yes, the etherscan api is misspelling
-      constructorArguements: new ethers.utils.Interface(contractArtifact.abi)
-        .encodeDeploy(contractInfo.constructorArgs)
-        .slice(2),
-    };
-
-    debug('verification request', reqData);
-
-    const res = await axios.post(etherscanApi, reqData, {
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    });
-
-    if (res.data.status === '0') {
-      console.log(`${c}:\tcannot verify:`, res.data.result);
-    } else {
-      console.log(`${c}:\tsubmitted verification (${contractInfo.address})`);
-      guids[c] = res.data.result;
-    }
+  if (!deployData) {
+    throw new Error(
+      `deployment not found: ${packageRef}. please make sure it exists for the given preset and current network.`
+    );
   }
+
+  // go through all the packages and sub packages and make sure all contracts are being verified
+  await forPackageTree(runtime, deployData, verifyPackage);
+
+  // at this point, all contracts should have been submitted for verification. so we are just printing status.
   for (const c in guids) {
     for (;;) {
       const res = await axios.post(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,9 +31,9 @@ import { resolveCliSettings } from './settings';
 import { installPlugin, removePlugin } from './plugins';
 import Debug from 'debug';
 import { writeModuleDeployments } from './util/write-deployments';
-import { getIpfsLoader } from './util/loader';
 import { getFoundryArtifact } from './foundry';
 import { resolveRegistryProvider, resolveWriteProvider } from './util/provider';
+import { getMainLoader } from './loader';
 
 const debug = Debug('cannon:cli');
 
@@ -414,10 +414,11 @@ program
         snapshots: false,
         allowPartialDeploy: false,
       },
-      getIpfsLoader(cliSettings.ipfsUrl, resolver)
+      resolver,
+      getMainLoader(cliSettings)
     );
 
-    const deployData = await runtime.loader.readDeploy(
+    const deployData = await runtime.readDeploy(
       `${packageDefinition.name}:${packageDefinition.version}`,
       opts.preset || 'main',
       runtime.chainId

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -1,0 +1,42 @@
+import { CannonLoader, IPFSLoader } from "@usecannon/builder";
+
+import path from 'path';
+import fs from 'fs-extra';
+import crypto from 'crypto';
+import { CliSettings } from "./settings";
+import { DEFAULT_REGISTRY_IPFS_ENDPOINT } from "./constants";
+
+export class LocalLoader implements CannonLoader {
+  dir: string;
+
+  constructor(dir: string) {
+    this.dir = dir;
+  }
+
+  getLabel(): string {
+    return `local (${this.dir})`;
+  }
+
+
+  read(url: string): Promise<any> {
+
+    if (!url.startsWith('file://')) {
+      throw new Error('incorrect url type');
+    }
+
+    return fs.readFile(path.join(this.dir, `${url.slice(7)}`))
+  }
+
+  async put(misc: any): Promise<string | null> {
+    const dataToSave = JSON.stringify(misc);
+    const hash = crypto.createHash('md5').update(dataToSave).digest('hex');
+
+    await fs.writeFile(path.join(this.dir, `${hash}.json`), dataToSave);
+
+    return `file://${hash}.json`;
+  }  
+}
+
+export function getMainLoader(cliSettings: CliSettings) {
+  return { ipfs: new IPFSLoader(cliSettings.ipfsUrl || DEFAULT_REGISTRY_IPFS_ENDPOINT), file: new LocalLoader(path.join(cliSettings.cannonDirectory, 'blobs')) };
+}

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -1,10 +1,10 @@
-import { CannonLoader, IPFSLoader } from "@usecannon/builder";
+import { CannonLoader, IPFSLoader } from '@usecannon/builder';
 
 import path from 'path';
 import fs from 'fs-extra';
 import crypto from 'crypto';
-import { CliSettings } from "./settings";
-import { DEFAULT_REGISTRY_IPFS_ENDPOINT } from "./constants";
+import { CliSettings } from './settings';
+import { DEFAULT_REGISTRY_IPFS_ENDPOINT } from './constants';
 
 export class LocalLoader implements CannonLoader {
   dir: string;
@@ -17,14 +17,12 @@ export class LocalLoader implements CannonLoader {
     return `local (${this.dir})`;
   }
 
-
   read(url: string): Promise<any> {
-
     if (!url.startsWith('file://')) {
       throw new Error('incorrect url type');
     }
 
-    return fs.readJson(path.join(this.dir, `${url.slice(7)}`))
+    return fs.readJson(path.join(this.dir, `${url.slice(7)}`));
   }
 
   async put(misc: any): Promise<string | null> {
@@ -35,9 +33,12 @@ export class LocalLoader implements CannonLoader {
     await fs.writeFile(path.join(this.dir, `${hash}.json`), dataToSave);
 
     return `file://${hash}.json`;
-  }  
+  }
 }
 
 export function getMainLoader(cliSettings: CliSettings) {
-  return { ipfs: new IPFSLoader(cliSettings.ipfsUrl || DEFAULT_REGISTRY_IPFS_ENDPOINT), file: new LocalLoader(path.join(cliSettings.cannonDirectory, 'blobs')) };
+  return {
+    ipfs: new IPFSLoader(cliSettings.ipfsUrl || DEFAULT_REGISTRY_IPFS_ENDPOINT),
+    file: new LocalLoader(path.join(cliSettings.cannonDirectory, 'blobs')),
+  };
 }

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -24,13 +24,14 @@ export class LocalLoader implements CannonLoader {
       throw new Error('incorrect url type');
     }
 
-    return fs.readFile(path.join(this.dir, `${url.slice(7)}`))
+    return fs.readJson(path.join(this.dir, `${url.slice(7)}`))
   }
 
   async put(misc: any): Promise<string | null> {
     const dataToSave = JSON.stringify(misc);
     const hash = crypto.createHash('md5').update(dataToSave).digest('hex');
 
+    await fs.mkdirp(this.dir);
     await fs.writeFile(path.join(this.dir, `${hash}.json`), dataToSave);
 
     return `file://${hash}.json`;

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -22,7 +22,7 @@ export type CliSettings = {
   privateKey?: string;
 
   /// the url of the IPFS endpoint to use as a storage base. defaults to localhost IPFS
-  ipfsUrl: string;
+  ipfsUrl?: string;
 
   /// the IPFS url to use when publishing. If you have an IPFS cluster, or a pinning service, this is a good place to put its IPFS Proxy publish endpoint. If not specified, your packages wont be uploaded to remote ipfs.
   publishIpfsUrl?: string;
@@ -71,7 +71,7 @@ function _resolveCliSettings(overrides: Partial<CliSettings> = {}): CliSettings 
       cannonDirectory: untildify(process.env.CANNON_DIRECTORY || DEFAULT_CANNON_DIRECTORY),
       providerUrl: process.env.CANNON_PROVIDER_URL || fileSettings.providerUrl || 'frame,direct',
       privateKey: (process.env.CANNON_PRIVATE_KEY || fileSettings.privateKey) as string,
-      ipfsUrl: process.env.CANNON_IPFS_URL || fileSettings.ipfsUrl || DEFAULT_REGISTRY_IPFS_ENDPOINT,
+      ipfsUrl: process.env.CANNON_IPFS_URL || fileSettings.ipfsUrl,
       publishIpfsUrl: process.env.CANNON_PUBLISH_IPFS_URL || fileSettings.publishIpfsUrl,
       registryProviderUrl:
         process.env.CANNON_REGISTRY_PROVIDER_URL ||

--- a/packages/cli/src/util/loader.ts
+++ b/packages/cli/src/util/loader.ts
@@ -1,5 +1,0 @@
-import { CannonRegistry, IPFSLoader } from '@usecannon/builder';
-
-export function getIpfsLoader(ipfsUrl: string, resolver: CannonRegistry) {
-  return new IPFSLoader(ipfsUrl, resolver);
-}

--- a/packages/registry/hardhat.config.ts
+++ b/packages/registry/hardhat.config.ts
@@ -44,6 +44,9 @@ const config: HardhatUserConfig = {
     coinmarketcap: process.env.REPORT_GAS_API_KEY || '',
     gasPriceApi: process.env.ETHERSCAN_API_KEY || '',
   },
+  cannon: {
+    publicSourceCode: true,
+  },
 } as any;
 
 export default config;


### PR DESCRIPTION
much needed. switches the structure of loading chain artifacts from the loader to be in a new class called `CannonStorage`, which is inherited by `ChainBuilderRuntime`. This has shown a lot of benefits in terms of code clarity and maintainability.

includes changes from https://github.com/usecannon/cannon/pull/178