### PR TITLE
CLI build non-local cannon file support

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -53,7 +53,6 @@ export async function build({
   getArtifact,
   getSigner,
   getDefaultSigner,
-  projectDirectory,
   preset = 'main',
   overrideResolver,
   wipe = false,
@@ -97,7 +96,6 @@ export async function build({
 
     getDefaultSigner,
 
-    baseDir: projectDirectory || null,
     snapshots: chainId === CANNON_CHAIN_ID,
     allowPartialDeploy: chainId !== CANNON_CHAIN_ID && persist,
     publicSourceCode,

--- a/packages/website/content/docs-technical.md
+++ b/packages/website/content/docs-technical.md
@@ -43,8 +43,6 @@ The `build` command will attempt to build a specified blockchain into the state 
 - `--private-key` - Specify a private key which may be needed to sign a transaction.
 - `--wipe` - Clear the existing deployment state and start this deploy from scratch.
 - `--upgrade-from` - Specify a package to use as a new base for the deployment.
-- `--contracts-directory` - Contracts source directory which will be built using Foundry and saved to the path specified with --artifacts (_Default: "./src"_)
-- `--artifacts-directory` - Path to a directory with your artifact data (_Default: "./out"_)
 
 ### verify
 


### PR DESCRIPTION
Made cli build to support cannon file in another path
Removed misleading contracts-directory and artifacts-directory options from cli build command 
Removed unused variables
Ref #203