### PR TITLE
prevent stalled steps by implementing a basic timeout system

### DIFF
--- a/packages/builder/src/actions.ts
+++ b/packages/builder/src/actions.ts
@@ -34,6 +34,8 @@ export interface CannonAction {
     optionalProperties?: Record<string, SomeJTDSchemaType>;
     additionalProperties?: boolean;
   };
+
+  timeout?: number;
 }
 
 /**

--- a/packages/builder/src/steps/provision.ts
+++ b/packages/builder/src/steps/provision.ts
@@ -210,4 +210,6 @@ export default {
       },
     };
   },
+
+  timeout: 3600000,
 };


### PR DESCRIPTION
on rare occasion jsonrpc APIs will just send a transaction and then it never advances/gets picked up, but cannon still thinks it was successfully submitted.

when this occurs, it can cause cannon to be stuck indefinitely, and the user eventaully has to control-c to cancel the build. this is very bad, since control-c will lead to a loss of state and could impact future builds.

to prevent this, a global step timeout system is implemented. if a step exceeds its given time limit, its promise is immediately suspended and the step is marked as incomplete with `timeout without error`. the user can just retry after the build is complete if it really is just a dumb timeout issue with the api.