### PR TITLE
prevent printing of `object Object` on skipped step

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -114,7 +114,9 @@ export async function build({
   runtime.on(Events.PreStepExecute, (t, n, _c, d) => console.log(`${'  '.repeat(d)}exec: ${t}.${n}`));
   runtime.on(Events.SkipDeploy, (n, err, d) => {
     partialDeploy = true;
-    console.log(`${'  '.repeat(d)}  -> skip ${n} (${err.toString()})`);
+    console.log(
+      `${'  '.repeat(d)}  -> skip ${n} (${err.toString() === '[object Object]' ? JSON.stringify(err) : err.toString()})`
+    );
   });
 
   // Check for existing package

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -115,7 +115,7 @@ export async function build({
   runtime.on(Events.SkipDeploy, (n, err, d) => {
     partialDeploy = true;
     console.log(
-      `${'  '.repeat(d)}  -> skip ${n} (${err.toString() === '[object Object]' ? JSON.stringify(err) : err.toString()})`
+      `${'  '.repeat(d)}  -> skip ${n} (${(typeof err === 'object' && err.toString === Object.prototype.toString) ? JSON.stringify(err) : err.toString()})`
     );
   });
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -115,7 +115,9 @@ export async function build({
   runtime.on(Events.SkipDeploy, (n, err, d) => {
     partialDeploy = true;
     console.log(
-      `${'  '.repeat(d)}  -> skip ${n} (${(typeof err === 'object' && err.toString === Object.prototype.toString) ? JSON.stringify(err) : err.toString()})`
+      `${'  '.repeat(d)}  -> skip ${n} (${
+        typeof err === 'object' && err.toString === Object.prototype.toString ? JSON.stringify(err) : err.toString()
+      })`
     );
   });
 


### PR DESCRIPTION
if a step is skipped, it is critical we print out hte actual reason why the step failed.

the change here is simple, if the error is just going to be `[object Object]`, stringify the object instead

result:
![image](https://github.com/usecannon/cannon/assets/2107457/8c88d00a-ad07-4256-8f9f-6e75c7871396)
