### PR TITLE
dont build package by default on run command

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,6 +1,13 @@
 import { greenBright, green, bold, gray, yellow } from 'chalk';
 import { ethers } from 'ethers';
-import { ChainArtifacts, ContractArtifact } from '@usecannon/builder';
+import {
+  CANNON_CHAIN_ID,
+  ChainArtifacts,
+  ChainBuilderRuntime,
+  ChainDefinition,
+  ContractArtifact,
+  getOutputs,
+} from '@usecannon/builder';
 import { PackageSpecification } from '../types';
 import { CannonRpcNode, getProvider } from '../rpc';
 import { interact } from '../interact';
@@ -10,6 +17,7 @@ import { getContractsRecursive } from '../util/contracts-recursive';
 import { createDefaultReadRegistry } from '../registry';
 import { resolveCliSettings } from '../settings';
 import { setupAnvil } from '../helpers';
+import { getMainLoader } from '../loader';
 
 export interface RunOptions {
   node: CannonRpcNode;
@@ -23,6 +31,7 @@ export interface RunOptions {
   getArtifact?: (name: string) => Promise<ContractArtifact>;
   fundAddresses?: string[];
   helpInformation?: string;
+  build?: boolean;
 }
 
 const INITIAL_INSTRUCTIONS = green(`Press ${bold('h')} to see help information for this command.`);
@@ -47,7 +56,9 @@ export async function run(packages: PackageSpecification[], options: RunOptions)
     }
   }
 
-  const resolver = await createDefaultReadRegistry(resolveCliSettings(), false);
+  const cliSettings = resolveCliSettings();
+
+  const resolver = await createDefaultReadRegistry(cliSettings, false);
 
   const buildOutputs: { pkg: PackageSpecification; outputs: ChainArtifacts }[] = [];
 
@@ -60,20 +71,57 @@ export async function run(packages: PackageSpecification[], options: RunOptions)
     signers = [provider.getSigner(addr)];
   }
 
+  const chainId = (await provider.getNetwork()).chainId;
+
+  const basicRuntime = new ChainBuilderRuntime(
+    {
+      provider: provider,
+      chainId,
+      async getSigner(addr: string) {
+        // on test network any user can be conjured
+        await provider.send('hardhat_impersonateAccount', [addr]);
+        await provider.send('hardhat_setBalance', [addr, `0x${(1e22).toString(16)}`]);
+        return provider.getSigner(addr);
+      },
+      snapshots: chainId === CANNON_CHAIN_ID,
+      allowPartialDeploy: false,
+    },
+    resolver,
+    getMainLoader(cliSettings)
+  );
+
   for (const pkg of packages) {
     const { name, version } = pkg;
+    if (options.build || Object.keys(pkg.settings).length) {
+      const { outputs } = await build({
+        ...options,
+        packageDefinition: pkg,
+        provider,
+        overrideResolver: resolver,
+        preset: options.preset,
+        upgradeFrom: options.upgradeFrom,
+        persist: false,
+      });
 
-    const { outputs } = await build({
-      ...options,
-      packageDefinition: pkg,
-      provider,
-      overrideResolver: resolver,
-      preset: options.preset,
-      upgradeFrom: options.upgradeFrom,
-      persist: false,
-    });
+      buildOutputs.push({ pkg, outputs });
+    } else {
+      // just get outputs
+      const deployData = await basicRuntime.readDeploy(`${pkg.name}:${pkg.version}`, 'main', basicRuntime.chainId);
 
-    buildOutputs.push({ pkg, outputs });
+      if (!deployData) {
+        throw new Error(
+          `deployment not found: ${name}:${version}. please make sure it exists for the main preset and network ${basicRuntime.chainId}`
+        );
+      }
+
+      const outputs = await getOutputs(basicRuntime, new ChainDefinition(deployData.def), deployData.state);
+
+      if (!outputs) {
+        throw new Error(`no cannon build found for chain ${basicRuntime.chainId}/main. Did you mean to run instead?`);
+      }
+
+      buildOutputs.push({ pkg, outputs });
+    }
 
     console.log(
       greenBright(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -80,6 +80,7 @@ function configureRun(program: Command) {
     .option('-p --port <number>', 'Port which the JSON-RPC server will be exposed', '8545')
     .option('-n --provider-url [url]', 'RPC endpoint to fork off of')
     .option('-c --chain-id <number>', 'The chain id to run against')
+    .option('--build', 'Specify to rebuild generated artifacts with latest, even if no changed settings have been defined.')
     .option('--upgrade-from [cannon-package:0.0.1]', 'Specify a package to use as a new base for the deployment.')
     .option('--preset <name>', 'Load an alternate setting preset', 'main')
     .option('--logs', 'Show RPC logs instead of an interactive prompt')


### PR DESCRIPTION
unless the user specifies otherwise (either by including custom settings, or by including the `--build` flag), do not rebuild package on `cannon run`. instead rely entirely on existing snapshots of the top layers without checking if any steps need to be rebuilt.

This has a few benefits:
* much faster `run` command execution when not build
* avoid unexpected issues where package cannot be loaded for run due to local changes (ex. `synthetix-sandbox`). Package always runs as intended.
* eliminates need for plugins unless changing a package
* no significant change to command behavior otherwise

some behavior changes:
* list of contracts/transactions not printed out by default. I think this output is more useful overall, and if user wants a contract address they can find it in the interact cli