### PR TITLE
add ability to finish build cleanly on interrupt

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -107,6 +107,10 @@ ${printChainDefinitionProblems(problems)}`);
     } else {
       debug('building individual');
       doActions: for (const n of topologicalActions) {
+        if (runtime.isCancelled()) {
+          break;
+        }
+
         ctx = _.cloneDeep(initialCtx);
 
         const artifacts: ChainArtifacts = {};

--- a/packages/builder/src/runtime.ts
+++ b/packages/builder/src/runtime.ts
@@ -68,6 +68,7 @@ export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRu
   readonly snapshots: boolean;
   readonly allowPartialDeploy: boolean;
   readonly publicSourceCode: boolean | undefined;
+  private cancelled = false;
 
   private cleanSnapshot: any;
 
@@ -110,6 +111,14 @@ export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRu
     this.publicSourceCode = info.publicSourceCode;
 
     this.misc = { artifacts: {} };
+  }
+
+  cancel() {
+    this.cancelled = true;
+  }
+
+  isCancelled() {
+    return this.cancelled;
   }
 
   async checkNetwork() {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -228,6 +228,21 @@ export async function build({
     }
   }
 
+  // attach control-c handler
+
+  if (persist) {
+    const handler = () => {
+      console.log('interrupt received, finishing current build step and cancelling...');
+      console.log('please be patient, or state loss may occur.');
+      partialDeploy = true;
+      runtime.cancel();
+    };
+
+    process.on('SIGINT', handler);
+    process.on('SIGTERM', handler);
+    process.on('SIGQUIT', handler);
+  }
+
   const newState = await cannonBuild(runtime, def, oldDeployData && !wipe ? oldDeployData.state : {}, initialCtx);
 
   const outputs = (await getOutputs(runtime, def, newState))!;


### PR DESCRIPTION
if user pushes "control-c" or the process is sent a termination signal or similar, the process will attempt to finish the currently running step before quitting.

to verify fix, run a real build of `greeter` package on goerli. Press control-c while the library contract is being deployed. Observe how the greeter contract deploy step is skipped and a partial build is generated.

fixes #224
![image](https://github.com/usecannon/cannon/assets/2107457/2feab94a-5351-468e-93c5-4c396951c25d)
