### PR TITLE
bump build version, check anvil version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
       }
     ],
     "indent": "off",
-    "quotes": ["error", "single"],
+    "quotes": ["error", "single", { "avoidEscape": true }],
     "import/no-unresolved": "off", // messed up by lerna hoisting
     "no-undef": "error",
     "prefer-const": "error",

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -126,8 +126,12 @@ ${printChainDefinitionProblems(problems)}`);
 
         addOutputsToContext(ctx, artifacts);
 
-        // also add self artifacts here so that we can self-reference from inside the step
         if (state[n]) {
+          if (state[n].version > BUILD_VERSION) {
+            throw new Error('incompatible (newer) build version. please update cannon.');
+          }
+
+          // also add self artifacts here so that we can self-reference from inside the step
           debug('adding self artifacts to context', state[n].artifacts);
           addOutputsToContext(ctx, state[n].artifacts);
         }
@@ -223,8 +227,12 @@ export async function buildLayer(
 
     addOutputsToContext(ctx, depArtifacts);
 
-    // also add self artifacts here so that we can self-reference from inside the step
     if (state[action] && state[action].artifacts) {
+      if (state[action].version > BUILD_VERSION) {
+        throw new Error('incompatible (newer) build version. please update cannon.');
+      }
+
+      // also add self artifacts here so that we can self-reference from inside the step
       addOutputsToContext(ctx, state[action].artifacts);
     }
 

--- a/packages/builder/src/constants.ts
+++ b/packages/builder/src/constants.ts
@@ -1,4 +1,4 @@
 export const CANNON_CHAIN_ID = 13370;
-export const BUILD_VERSION = 5;
+export const BUILD_VERSION = 6;
 
 export const ARACHNID_CREATE2_PROXY = '0x4e59b44847b379578588920ca78fbf26c0b4956c';

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -30,8 +30,10 @@ let anvilProvider: CannonWrapperGenericProvider | null = null;
 export const versionCheck = _.once(async () => {
   const anvilVersionInfo = await execPromise('anvil --version');
 
-  if (anvilVersionInfo.match(/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/)![0] < '2023-06-04') {
-    throw new Error(`anvil version too old. please run 'foundryup' to get the latest version`);
+  if (
+    anvilVersionInfo.match(/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/)![0] < '2023-06-04'
+  ) {
+    throw new Error("anvil version too old. please run 'foundryup' to get the latest version");
   }
 });
 

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -8,6 +8,8 @@ import { spawn, ChildProcess } from 'child_process';
 
 import Debug from 'debug';
 import { CANNON_CHAIN_ID, CannonWrapperGenericProvider } from '@usecannon/builder';
+import { execPromise } from './helpers';
+import _ from 'lodash';
 
 const debug = Debug('cannon:cli:rpc');
 
@@ -25,7 +27,17 @@ export type CannonRpcNode = ChildProcess & RpcOptions;
 let anvilInstance: CannonRpcNode | null = null;
 let anvilProvider: CannonWrapperGenericProvider | null = null;
 
+export const versionCheck = _.once(async () => {
+  const anvilVersionInfo = await execPromise('anvil --version');
+
+  if (anvilVersionInfo.match(/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/)![0] < '2023-06-04') {
+    throw new Error(`anvil version too old. please run 'foundryup' to get the latest version`);
+  }
+});
+
 export async function runRpc({ port, forkProvider, chainId = CANNON_CHAIN_ID }: RpcOptions): Promise<CannonRpcNode> {
+  await versionCheck();
+
   if (anvilInstance && anvilInstance.exitCode === null) {
     console.log('shutting down existing anvil subprocess', anvilInstance.pid);
 


### PR DESCRIPTION
to prevent issues with people using older versions of anvil, or trying to load newer build versions of packages:
* bump build version to ensure older versions of cannon will be force updated before loading an incompatible package
* check version of anvil to ensure its new enough to use compressed state dumps, and reccomend foundryup if not.

(note: this does nothing for existing versions of cannon that didnt have the build version check. shhh.)

![image](https://github.com/usecannon/cannon/assets/2107457/c6d3ea35-0022-4979-97c8-e19a5fceb303)

doesnt actually fix 201 but we put part of the issue in this pr so yea.
