### PR TITLE
prevent cli from exiting before forge test is run

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -408,10 +408,12 @@ program
       process.stderr.write(data);
     });
 
-    forgeCmd.on('close', (code: number) => {
-      console.log(`forge exited with code ${code}`);
-      node?.kill();
-      process.exit(code);
+    await new Promise((resolve) => {
+      forgeCmd.on('close', (code: number) => {
+        console.log(`forge exited with code ${code}`);
+        node?.kill();
+        resolve({});
+      });
     });
   });
 


### PR DESCRIPTION
on `cannon test` command, the forge cmd needs to be wrapped in a promise or else the command will exit early