### PR TITLE
Removed hardcoded default preset name from import step error message

### DIFF
--- a/packages/builder/src/steps/import.ts
+++ b/packages/builder/src/steps/import.ts
@@ -76,7 +76,7 @@ export default {
 
     if (!deployInfo) {
       throw new Error(
-        `deployment not found: ${packageRef}. please make sure it exists for the cannon network and main preset.`
+        `deployment not found: ${packageRef}. please make sure it exists for the cannon network and ${preset} preset.`
       );
     }
 


### PR DESCRIPTION
If deployment info isnt present, the import step outputs a log that says the deployment info was not found but it does not dynamically display the preset specified in the cannonfile (if there is one) and instead just defaults to referencing the 'main' preset