### PR TITLE
Subdirectory build fail

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -137,7 +137,7 @@ async function doBuild(cannonfile: string, settings: string[], opts: any): Promi
   const parsedSettings = parseSettings(settings);
 
   const cannonfilePath = path.resolve(cannonfile);
-  const projectDirectory = path.dirname(cannonfilePath);
+  const projectDirectory = path.resolve(process.cwd());
 
   const cliSettings = resolveCliSettings(opts);
 
@@ -202,6 +202,8 @@ async function doBuild(cannonfile: string, settings: string[], opts: any): Promi
 
   const { build } = await import('./commands/build');
   const { name, version } = await loadCannonfile(cannonfilePath);
+
+  console.log("PROJECT DIRECTORY ====>", projectDirectory)
 
   const { outputs } = await build({
     provider,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -203,8 +203,6 @@ async function doBuild(cannonfile: string, settings: string[], opts: any): Promi
   const { build } = await import('./commands/build');
   const { name, version } = await loadCannonfile(cannonfilePath);
 
-  console.log("PROJECT DIRECTORY ====>", projectDirectory)
-
   const { outputs } = await build({
     provider,
     cannonfilePath,


### PR DESCRIPTION
When using a subdirectory to store your cannonfiles, if the build command was run from the project root directory then cannon would try to fetch artifacts using the subdirectory as the root-directory.

![image](https://github.com/usecannon/cannon/assets/30664234/70985e82-35b3-4661-ac2a-9af01939e818)

![image](https://github.com/usecannon/cannon/assets/30664234/2d7a7910-1d3b-4938-8d44-1ea4700e24a5)

By using the process.cwd() [Node function](https://nodejs.org/api/process.html#processcwd) we can set the project directory to be relative to where the process is run. 

Here's a successful run after making the change and rebuilding:

![image](https://github.com/usecannon/cannon/assets/30664234/1f637d32-857d-421f-b113-d3d55b6c0153)

