### PR TITLE
Fixed issue with custom build path

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -137,7 +137,7 @@ async function doBuild(cannonfile: string, settings: string[], opts: any): Promi
   const parsedSettings = parseSettings(settings);
 
   const cannonfilePath = path.resolve(cannonfile);
-  const projectDirectory = path.resolve(process.cwd());
+  const projectDirectory = path.dirname(cannonfilePath);
 
   const cliSettings = resolveCliSettings(opts);
 


### PR DESCRIPTION
@FuzzB0t Did you have any intention for changing that line? that change causes an issue in building with custom path like `cannon build ../../packages/sample-foundry-project/cannonfile.toml`
