### PR TITLE
Dynamic build path

### DIFF
--- a/packages/cli/src/foundry.ts
+++ b/packages/cli/src/foundry.ts
@@ -35,17 +35,17 @@ export async function getFoundryArtifact(name: string, baseDir = ''): Promise<Co
 
     // append 'foundry.toml' to filepath
     const filePath = path.join(currentPath, markerFile);
-  
+
     // If filepath exists it means we're already at root of the project
     // so just return currentPath
     if (fs.existsSync(filePath)) {
       return currentPath;
     }
-  
+
     // Reached the filesystem root without finding the marker file
     const parentPath = path.dirname(currentPath);
     if (parentPath === currentPath) {
-      throw new Error(`Could not find foundry project, make sure your cannonfiles are stored within a foundry project`)
+      throw new Error('Could not find foundry project, make sure your cannonfiles are stored within a foundry project');
     }
 
     //Otherwise loop
@@ -53,7 +53,7 @@ export async function getFoundryArtifact(name: string, baseDir = ''): Promise<Co
   }
 
   baseDir = findProjectRoot(baseDir);
-  
+
   const artifactPath = path.join(path.join(baseDir, foundryOpts.out), `${name}.sol`, `${name}.json`);
   const artifactBuffer = await fs.readFile(artifactPath);
   const artifact = JSON.parse(artifactBuffer.toString()) as any;

--- a/packages/cli/src/foundry.ts
+++ b/packages/cli/src/foundry.ts
@@ -28,26 +28,27 @@ export async function getFoundryArtifact(name: string, baseDir = ''): Promise<Co
   // TODO: Theres a bug that if the file has a different name than the contract it would not work
   const foundryOpts = await getFoundryOpts();
 
-  // Finds root of the foundry project based on where the foundry.toml file is within the relative path
+  // Finds root of the foundry project based n owhere the foundry.toml file is within the relative path
+  // Linear time complexity O(n) where n is the depth of the directory structure from the initial currentPath to the project root.
   function findProjectRoot(currentPath: string): string {
     const markerFile = 'foundry.toml';
 
     // append 'foundry.toml' to filepath
     const filePath = path.join(currentPath, markerFile);
   
-    // If filepath exists its already root of the project
+    // If filepath exists it means we're already at root of the project
     // so just return currentPath
     if (fs.existsSync(filePath)) {
       return currentPath;
     }
   
-    const parentPath = path.dirname(currentPath);
-
     // Reached the filesystem root without finding the marker file
+    const parentPath = path.dirname(currentPath);
     if (parentPath === currentPath) {
-      throw new Error(`Could not find foundry project root in ${currentPath}, please run this command from the root of your foundry project`)
+      throw new Error(`Could not find foundry project, make sure your cannonfiles are stored within a foundry project`)
     }
-  
+
+    //Otherwise loop
     return findProjectRoot(parentPath);
   }
 

--- a/packages/cli/src/foundry.ts
+++ b/packages/cli/src/foundry.ts
@@ -45,7 +45,10 @@ export async function getFoundryArtifact(name: string, baseDir = ''): Promise<Co
     // Reached the filesystem root without finding the marker file
     const parentPath = path.dirname(currentPath);
     if (parentPath === currentPath) {
-      throw new Error('Could not find foundry project, make sure your cannonfiles are stored within a foundry project');
+      console.warn(
+        'Could not find foundry project, make sure your cannonfiles are stored within the root of a foundry project.'
+      );
+      return parentPath;
     }
 
     //Otherwise loop

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import fs from 'fs';
 import { spawn } from 'child_process';
 import { ethers } from 'ethers';
 import { Command } from 'commander';
@@ -137,7 +138,7 @@ async function doBuild(cannonfile: string, settings: string[], opts: any): Promi
   const parsedSettings = parseSettings(settings);
 
   const cannonfilePath = path.resolve(cannonfile);
-  const projectDirectory = path.resolve(process.cwd());
+  const projectDirectory = path.resolve(cannonfilePath);
 
   const cliSettings = resolveCliSettings(opts);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import fs from 'fs';
 import { spawn } from 'child_process';
 import { ethers } from 'ethers';
 import { Command } from 'commander';


### PR DESCRIPTION
Ref #286 

Before when running the build step using a path with cannonfiles in a subdirectory it would fail to find artifacts, on the contrary using a relative path would work. I implemented a fix by simply forcing the user to be in the project root directory when running the command so that it would always resolve the parent directory as the foundry project root (therefore being able to find the artifacts).  However this would break the use of relative paths when specifying a cannonfile like '../../packages/sample-foundry-project/cannonfile.toml', I implemented a fix that recursively checks for a 'foundry.toml' file to determine the foundry project root so getArtifacts always has context of the project root directory regardless of where the command is ran and/or where the cannonfiles are (whether in a subdirectory or not).

Before
![image](https://github.com/usecannon/cannon/assets/30664234/d1345ce8-154b-41dc-b8b0-04402773583f)

After
![image](https://github.com/usecannon/cannon/assets/30664234/0b7d4f7d-5d5b-45ac-9bac-12f8023e6dfe)


Before
![image](https://github.com/usecannon/cannon/assets/30664234/f5404bb4-50a6-4fc5-b456-2ac095d21426)
After
![image](https://github.com/usecannon/cannon/assets/30664234/124d9c0d-61fc-4610-9bf4-2226d8b15106)




The alternative to this is to simply force users to run this command within the project root and change the CLI to display a message to the user to rerun the command within the root.