### PR TITLE
Fix cannon executable

### DIFF
--- a/packages/cli/bin/cannon.js
+++ b/packages/cli/bin/cannon.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import cli from '../src/index';
-import { red } from 'chalk';
+const { red } = require('chalk');
+const cli = require('../dist');
 
 cli
   .parseAsync()


### PR DESCRIPTION
1. Bin file must have executable flag `chmod +x`
2. Bin file must not be generated (as when it is generated it will not have executable flag)