### PR TITLE
Build and Run successfully when not connected to internet

### DIFF
--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -10,6 +10,7 @@ import { CANNON_CHAIN_ID, ChainDefinition, RawChainDefinition, ChainBuilderConte
 import { chains } from './chains';
 import { IChainData } from './types';
 import { resolveCliSettings } from './settings';
+import { isConnectedToInternet } from './util/is-connected-to-internet';
 
 export async function setupAnvil(): Promise<void> {
   // TODO Setup anvil using https://github.com/foundry-rs/hardhat/tree/develop/packages/easy-foundryup
@@ -76,6 +77,10 @@ export function execPromise(command: string): Promise<string> {
 }
 
 export async function checkCannonVersion(currentVersion: string): Promise<void> {
+  if (!(await isConnectedToInternet())) {
+    console.log('You are offline so we dont check the latest version of cannon');
+    return;
+  }
   const latestVersion = await execPromise('npm view @usecannon/cli version');
 
   if (currentVersion !== latestVersion) {

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -6,6 +6,7 @@ import { yellowBright } from 'chalk';
 
 import { CliSettings } from './settings';
 import { resolveRegistryProvider } from './util/provider';
+import { isConnectedToInternet } from './util/is-connected-to-internet';
 
 const debug = Debug('cannon:cli:registry');
 
@@ -106,8 +107,11 @@ export async function createDefaultReadRegistry(settings: CliSettings): Promise<
         result: string;
         registry: LocalRegistry;
       }) => {
+        if (!(await isConnectedToInternet())) {
+          // When not connected to the internet, we don't want to check the on-chain registry version to not throw an error
+          return;
+        }
         const onChainResult = await onChainRegistry.getUrl(packageRef, variant);
-
         if (registry instanceof LocalRegistry && onChainResult && onChainResult != result && !settings.quiet) {
           console.log(
             yellowBright(

--- a/packages/cli/src/util/is-connected-to-internet.ts
+++ b/packages/cli/src/util/is-connected-to-internet.ts
@@ -1,0 +1,13 @@
+import { resolve as dnsResolve } from 'dns';
+
+export async function isConnectedToInternet() {
+  return new Promise((resolve) => {
+    dnsResolve('www.google.com', (error) => {
+      if (error) {
+        resolve(false); // No connection
+      } else {
+        resolve(true); // Connected
+      }
+    });
+  });
+}


### PR DESCRIPTION
related to #315

We had two problems:
1. Checking `cannon` version before executing every command, so I changed it to just check `cannon` version if system is not offline
2. After gettingUrl in fallback registry we were calling `onChainRegistry.getUrl` and it throws when we are offline, so I changed it to not call it if system is offline ( it was just calling it to show the log, so not calling that in offline more has no side effects)

I tested  `build` and `run` commands and they are working fast and correct like when it's online

For testing this PR 
1. Go to project directory and enter this `npx lerna run build`
2. Go to `packages/sample-foundry-project` directory
3. Make your system offline (Turning off the wifi)
4. Enter `TRACE=true npx ts-node ../cli/bin/cannon.ts build`
5. Enter `TRACE=true npx ts-node ../cli/bin/cannon.ts run greeter-foundry:2.4.21`

<img width="1054" alt="Screen Shot 1402-05-09 at 18 44 43" src="https://github.com/usecannon/cannon/assets/9850545/9d6a3a5e-2e3e-43f6-b699-e1f2339f281a">
