### PR TITLE
Run anvil on an available port instead of running in on 8545

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -168,7 +168,8 @@ async function doBuild(cannonfile: string, settings: string[], opts: any): Promi
   if (!opts.chainId && !opts.providerUrl) {
     // doing a local build, just create a anvil rpc
     node = await runRpc({
-      port: 8545,
+      // https://www.lifewire.com/port-0-in-tcp-and-udp-818145
+      port: 0,
     });
 
     provider = getProvider(node);
@@ -183,7 +184,8 @@ async function doBuild(cannonfile: string, settings: string[], opts: any): Promi
 
     if (opts.dryRun) {
       node = await runRpc({
-        port: 8545,
+        // https://www.lifewire.com/port-0-in-tcp-and-udp-818145
+        port: 0,
         forkProvider: p.provider.passThroughProvider as ethers.providers.JsonRpcProvider,
         chainId,
       });


### PR DESCRIPTION
related to #306

I have set **0** while building so it allocates the first free port to that
https://www.lifewire.com/port-0-in-tcp-and-udp-818145
As you see in the below pics I ran cannon in a tab and in another tab I wanted to build with cannon and I got error, but in this branch I did the same and it built successfully

* **before**
<img width="1920" alt="Screen Shot 1402-05-10 at 12 47 13" src="https://github.com/usecannon/cannon/assets/9850545/0e3a33fd-81c6-4d2b-be93-db8b74638b5d">

* **now**
<img width="1920" alt="Screen Shot 1402-05-10 at 12 46 28" src="https://github.com/usecannon/cannon/assets/9850545/72392b6e-a0d5-4a6c-bd2a-fff496a02003">

 