### PR TITLE
fix infinite loop issue with layer compute

### DIFF
--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -405,7 +405,6 @@ export class ChainDefinition {
       // first. filter any deps which are extraneous. This is a dependency which is a subdepenendency of an assigned layer for a dependency.
       // @note this is the slowest part of cannon atm. Improvements here would be most important.
       for (const dep of deps) {
-        console.log('checking dep', dep, layers[dep], n);
         for (const depdep of layers[dep].depends) {
           const depTree = this.getLayerDependencyTree(depdep, layers);
           deps = deps.filter((d) => depTree.indexOf(d) === -1);


### PR DESCRIPTION
the problem is that the layer resolution system did not just depend on having topological dependencies. As an additional requirement, steps should be arranged based on the *layer* that they appear on to prevent cases where a subdependency shared by two steps ends up being merged together on a lower layer, creating a internal dependency cycle.

thankfully, it is fairly easy to mitigate this issue. if, while scanning deep dependencies, we also return the `maxDepth` (which is the effective depth of the dependency that was just scanned) and recursively compute that, we can assign a layer depth to every action reasonably cheaply. After this, it is possible to sort all nodes by depth (nodes with higher depth are mathematically guarenteed to have all dependencies included over nodes with a lower depth). This also gives us the guarentee we need in order to properly build the merged layer tree, required for local builds.