### PR TITLE
fix: bugs on `--registry-priority` argument

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-config-prettier": "^8.4.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-prettier": "^4.0.0",
-        "lerna": "^7.1.0",
+        "lerna": "^7.2.0",
         "npm-run-parallel": "^0.6.0",
         "nx-cloud": "^16.0.5",
         "prettier": "^2.5.1",
@@ -6703,9 +6703,9 @@
       "integrity": "sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A=="
     },
     "node_modules/@lerna/child-process": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-7.1.5.tgz",
-      "integrity": "sha512-YXmxzxXTP3u9HQpSXvK8qqoAm7VWQIFria3FVMQKkOSkWkph1TNnvt3Q1JvKT7/Jgd1HfTc3QrK09a2FND9+8A==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-7.2.0.tgz",
+      "integrity": "sha512-8cRsYYX8rGZTXL1KcLBv0RHD9PMvphWZay8yg4qf2giX6x86dQyTetSU4SplG2LBGVClilmNHJa/CQwvPQNUFA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -6747,12 +6747,12 @@
       }
     },
     "node_modules/@lerna/create": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-7.1.5.tgz",
-      "integrity": "sha512-/CDI/cvXJbycgSDzWXzP7DBuJ10qL/uYEouFt3/mxi9+hSfM885fu6lbVPV7QOf8A0otXcTs7PN2dVyMrnWQeg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-7.2.0.tgz",
+      "integrity": "sha512-bBypNfwqOQNcfR2nXJ3mWUeIAIoSFpXg8MjuFSf87PzIiyeTEKa3Z57vAa3bDbHQtcB7x6f0rWysK1eQZSH15Q==",
       "dev": true,
       "dependencies": {
-        "@lerna/child-process": "7.1.5",
+        "@lerna/child-process": "7.2.0",
         "@npmcli/run-script": "6.0.2",
         "@nx/devkit": ">=16.5.1 < 17",
         "@octokit/plugin-enterprise-rest": "6.0.1",
@@ -6777,6 +6777,7 @@
         "ini": "^1.3.8",
         "init-package-json": "5.0.0",
         "inquirer": "^8.2.4",
+        "is-ci": "3.0.1",
         "is-stream": "2.0.0",
         "js-yaml": "4.1.0",
         "libnpmpublish": "7.3.0",
@@ -26124,13 +26125,13 @@
       }
     },
     "node_modules/lerna": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-7.1.5.tgz",
-      "integrity": "sha512-5bvfmoIH4Czk5mdoLaRPYkM3M63Ei6+TOuXs3MgXmvqD8vs+vQpHuBVmiYFp5Mwsck3FkidJ+eTxfucltA2Lmw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-7.2.0.tgz",
+      "integrity": "sha512-E13iAY4Tdo+86m4ClAe0j0bP7f8QG2neJReglILPOe+gAOoX17TGqEWanmkDELlUXOrTTwnte0ewc6I6/NOqpg==",
       "dev": true,
       "dependencies": {
-        "@lerna/child-process": "7.1.5",
-        "@lerna/create": "7.1.5",
+        "@lerna/child-process": "7.2.0",
+        "@lerna/create": "7.2.0",
         "@npmcli/run-script": "6.0.2",
         "@nx/devkit": ">=16.5.1 < 17",
         "@octokit/plugin-enterprise-rest": "6.0.1",
@@ -33291,9 +33292,9 @@
       }
     },
     "node_modules/read-package-json/node_modules/glob": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
-      "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
+      "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -40099,7 +40100,7 @@
     },
     "packages/builder": {
       "name": "@usecannon/builder",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.2.2",
@@ -40136,12 +40137,12 @@
     },
     "packages/cli": {
       "name": "@usecannon/cli",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
         "@synthetixio/wei": "^2.74.1",
-        "@usecannon/builder": "^2.5.3",
+        "@usecannon/builder": "^2.5.4",
         "chalk": "^4.1.2",
         "commander": "^9.5.0",
         "debug": "^4.3.4",
@@ -40210,12 +40211,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/hardhat-cannon": {
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
-        "@usecannon/builder": "^2.5.3",
-        "@usecannon/cli": "^2.5.3",
+        "@usecannon/builder": "^2.5.4",
+        "@usecannon/cli": "^2.5.4",
         "adm-zip": "^0.5.9",
         "chalk": "^4.1.2",
         "debug": "^4.3.3",
@@ -46180,9 +46181,9 @@
       "integrity": "sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A=="
     },
     "@lerna/child-process": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-7.1.5.tgz",
-      "integrity": "sha512-YXmxzxXTP3u9HQpSXvK8qqoAm7VWQIFria3FVMQKkOSkWkph1TNnvt3Q1JvKT7/Jgd1HfTc3QrK09a2FND9+8A==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-7.2.0.tgz",
+      "integrity": "sha512-8cRsYYX8rGZTXL1KcLBv0RHD9PMvphWZay8yg4qf2giX6x86dQyTetSU4SplG2LBGVClilmNHJa/CQwvPQNUFA==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -46217,12 +46218,12 @@
       }
     },
     "@lerna/create": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-7.1.5.tgz",
-      "integrity": "sha512-/CDI/cvXJbycgSDzWXzP7DBuJ10qL/uYEouFt3/mxi9+hSfM885fu6lbVPV7QOf8A0otXcTs7PN2dVyMrnWQeg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-7.2.0.tgz",
+      "integrity": "sha512-bBypNfwqOQNcfR2nXJ3mWUeIAIoSFpXg8MjuFSf87PzIiyeTEKa3Z57vAa3bDbHQtcB7x6f0rWysK1eQZSH15Q==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "7.1.5",
+        "@lerna/child-process": "7.2.0",
         "@npmcli/run-script": "6.0.2",
         "@nx/devkit": ">=16.5.1 < 17",
         "@octokit/plugin-enterprise-rest": "6.0.1",
@@ -46247,6 +46248,7 @@
         "ini": "^1.3.8",
         "init-package-json": "5.0.0",
         "inquirer": "^8.2.4",
+        "is-ci": "3.0.1",
         "is-stream": "2.0.0",
         "js-yaml": "4.1.0",
         "libnpmpublish": "7.3.0",
@@ -50587,7 +50589,7 @@
         "@types/prompts": "^2.0.14",
         "@types/semver": "^7.3.12",
         "@types/sinon": "^10.0.15",
-        "@usecannon/builder": "^2.5.3",
+        "@usecannon/builder": "^2.5.4",
         "axios": "^1.3.3",
         "chalk": "^4.1.2",
         "commander": "^9.5.0",
@@ -59533,8 +59535,8 @@
         "@types/node": "^16.0.0",
         "@types/prompts": "^2.0.14",
         "@types/yazl": "^2.4.2",
-        "@usecannon/builder": "^2.5.3",
-        "@usecannon/cli": "^2.5.3",
+        "@usecannon/builder": "^2.5.4",
+        "@usecannon/cli": "^2.5.4",
         "adm-zip": "^0.5.9",
         "bn.js": "^5.2.0",
         "chalk": "^4.1.2",
@@ -61823,13 +61825,13 @@
       }
     },
     "lerna": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-7.1.5.tgz",
-      "integrity": "sha512-5bvfmoIH4Czk5mdoLaRPYkM3M63Ei6+TOuXs3MgXmvqD8vs+vQpHuBVmiYFp5Mwsck3FkidJ+eTxfucltA2Lmw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-7.2.0.tgz",
+      "integrity": "sha512-E13iAY4Tdo+86m4ClAe0j0bP7f8QG2neJReglILPOe+gAOoX17TGqEWanmkDELlUXOrTTwnte0ewc6I6/NOqpg==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "7.1.5",
-        "@lerna/create": "7.1.5",
+        "@lerna/child-process": "7.2.0",
+        "@lerna/create": "7.2.0",
         "@npmcli/run-script": "6.0.2",
         "@nx/devkit": ">=16.5.1 < 17",
         "@octokit/plugin-enterprise-rest": "6.0.1",
@@ -67151,9 +67153,9 @@
           }
         },
         "glob": {
-          "version": "10.3.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
-          "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
+          "version": "10.3.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
+          "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
           "dev": true,
           "requires": {
             "foreground-child": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-prettier": "^4.0.0",
-    "lerna": "^7.1.0",
+    "lerna": "^7.2.0",
     "npm-run-parallel": "^0.6.0",
     "nx-cloud": "^16.0.5",
     "prettier": "^2.5.1",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -44,7 +44,7 @@ interface Params {
   plugins?: boolean;
   publicSourceCode?: boolean;
   providerUrl?: string;
-
+  registryPriority?: 'local' | 'onchain';
   gasPrice?: string;
   gasFee?: string;
   priorityGasFee?: string;
@@ -66,6 +66,7 @@ export async function build({
   plugins = true,
   publicSourceCode = false,
   providerUrl,
+  registryPriority,
   gasPrice,
   gasFee,
   priorityGasFee,
@@ -80,7 +81,7 @@ export async function build({
     );
   }
 
-  const cliSettings = resolveCliSettings();
+  const cliSettings = resolveCliSettings({ registryPriority });
 
   if (plugins) {
     await loadPlugins();

--- a/packages/cli/src/commands/run.test.ts
+++ b/packages/cli/src/commands/run.test.ts
@@ -72,6 +72,7 @@ describe('run function', () => {
       pkgInfo: {},
       preset: 'preset1',
       impersonate: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      registryPriority: 'local',
       mnemonic: 'mnemonic',
       privateKey: 'privateKey',
       upgradeFrom: 'upgradeFrom',

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -29,6 +29,7 @@ export interface RunOptions {
   privateKey?: string;
   upgradeFrom?: string;
   getArtifact?: (name: string) => Promise<ContractArtifact>;
+  registryPriority: 'local' | 'onchain';
   fundAddresses?: string[];
   helpInformation?: string;
   build?: boolean;
@@ -43,11 +44,12 @@ const INSTRUCTIONS = green(
 
 export async function run(packages: PackageSpecification[], options: RunOptions) {
   await setupAnvil();
+
   console.log(bold('Starting local node...\n'));
 
   // Start the rpc server
   const node = options.node;
-  const provider = await getProvider(node);
+  const provider = getProvider(node);
   const nodeLogging = await createLoggingInterface(node);
 
   if (options.fundAddresses && options.fundAddresses.length) {
@@ -56,8 +58,7 @@ export async function run(packages: PackageSpecification[], options: RunOptions)
     }
   }
 
-  const cliSettings = resolveCliSettings();
-
+  const cliSettings = resolveCliSettings(options);
   const resolver = await createDefaultReadRegistry(cliSettings);
 
   const buildOutputs: { pkg: PackageSpecification; outputs: ChainArtifacts }[] = [];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -410,6 +410,7 @@ program
   .option('-c --chain-id <chainId>', 'Chain ID of the variant to inspect', '13370')
   .option('-p --preset <preset>', 'Preset of the variant to inspect', 'main')
   .option('-j --json', 'Output as JSON')
+  .option('--registry-priority <registry>', 'Priority of the registry to use')
   .option(
     '-w --write-deployments <writeDeployments>',
     'Path to write the deployments data (address and ABIs), like "./deployments"'

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -122,7 +122,7 @@ async function checkLocalRegistryOverride({
   if (registry instanceof OnChainRegistry && localResult && localResult != result) {
     console.log(
       yellowBright(
-        `⚠️  The package ${packageRef} was found on the official on-chain registry, but you also have a local build of this package. To use this local build instead, run this command with '--registry local'`
+        `⚠️  The package ${packageRef} was found on the official on-chain registry, but you also have a local build of this package. To use this local build instead, run this command with '--registry-priority local'`
       )
     );
   }

--- a/packages/hardhat-cannon/src/tasks/run.ts
+++ b/packages/hardhat-cannon/src/tasks/run.ts
@@ -16,64 +16,68 @@ task(TASK_RUN, 'Utility for instantly loading cannon packages in standalone cont
   .addOptionalParam('preset', 'Load an alternate setting preset', 'main')
   .addOptionalParam('fundAddresses', 'Comma separated list of addresses to receive a balance of 10,000 ETH', '')
   .addOptionalParam('upgradeFrom', 'Perform an upgrade on existing contracts before running')
+  .addOptionalParam('registryPriority', 'Whether to use local or remote registry first when resolving packages')
   .addFlag('impersonate', 'Create impersonated signers instead of using real wallets')
   .addFlag('logs', 'Show RPC logs instead of an interactive prompt')
-  .setAction(async ({ packageNames, port, logs, preset, impersonate, upgradeFrom, fundAddresses }, hre) => {
-    const packages: PackageSpecification[] = ((packageNames || []) as string[]).reduce((result, val) => {
-      return parsePackagesArguments(val, result);
-    }, [] as PackageSpecification[]);
+  .setAction(
+    async ({ packageNames, port, logs, preset, impersonate, upgradeFrom, fundAddresses, registryPriority }, hre) => {
+      const packages: PackageSpecification[] = ((packageNames || []) as string[]).reduce((result, val) => {
+        return parsePackagesArguments(val, result);
+      }, [] as PackageSpecification[]);
 
-    if (!packages.length) {
-      // derive from the default cannonfile
-      const { name, version } = await loadCannonfile(path.join(hre.config.paths.root, 'cannonfile.toml'));
+      if (!packages.length) {
+        // derive from the default cannonfile
+        const { name, version } = await loadCannonfile(path.join(hre.config.paths.root, 'cannonfile.toml'));
 
-      packages.push({
-        name,
-        version,
-        settings: {},
+        packages.push({
+          name,
+          version,
+          settings: {},
+        });
+      }
+
+      // If its a fork, use the privateKey from the fork network config
+      const networkConfig =
+        hre.network.name !== 'hardhat' ? (hre.network.config as HttpNetworkConfig) : { url: undefined, chainId: undefined };
+      const privateKey = Array.isArray(hre.network.config.accounts)
+        ? _getPrivateKeyFromAccount(hre.network.config.accounts[0])
+        : undefined;
+
+      const node = await runRpc(
+        hre.network.name === 'cannon' || hre.network.name === 'hardhat'
+          ? {
+              port: Number.parseInt(port) || hre.config.networks.cannon.port,
+            }
+          : {
+              port: Number.parseInt(port) || hre.config.networks.cannon.port,
+              forkProvider: new ethers.providers.JsonRpcProvider(networkConfig.url),
+              chainId: networkConfig.chainId,
+            }
+      );
+
+      let toImpersonate: string[] = [];
+      if (impersonate) {
+        toImpersonate = (await hre.ethers.getSigners()).map((s) => s.address);
+      }
+
+      return run(packages, {
+        node,
+        logs,
+        preset,
+        upgradeFrom,
+        registryPriority,
+        getArtifact: (contractName: string) => hre.artifacts.readArtifact(contractName),
+        pkgInfo: loadPackageJson(path.join(hre.config.paths.root, 'package.json')),
+        privateKey,
+        impersonate: toImpersonate.join(','),
+        fundAddresses: fundAddresses
+          .split(',')
+          .filter(Boolean)
+          .map((s: string) => s.trim())
+          .filter(Boolean),
       });
     }
-
-    // If its a fork, use the privateKey from the fork network config
-    const networkConfig =
-      hre.network.name !== 'hardhat' ? (hre.network.config as HttpNetworkConfig) : { url: undefined, chainId: undefined };
-    const privateKey = Array.isArray(hre.network.config.accounts)
-      ? _getPrivateKeyFromAccount(hre.network.config.accounts[0])
-      : undefined;
-
-    const node = await runRpc(
-      hre.network.name === 'cannon' || hre.network.name === 'hardhat'
-        ? {
-            port: Number.parseInt(port) || hre.config.networks.cannon.port,
-          }
-        : {
-            port: Number.parseInt(port) || hre.config.networks.cannon.port,
-            forkProvider: new ethers.providers.JsonRpcProvider(networkConfig.url),
-            chainId: networkConfig.chainId,
-          }
-    );
-
-    let toImpersonate: string[] = [];
-    if (impersonate) {
-      toImpersonate = (await hre.ethers.getSigners()).map((s) => s.address);
-    }
-
-    return run(packages, {
-      node,
-      logs,
-      preset,
-      upgradeFrom,
-      getArtifact: (contractName: string) => hre.artifacts.readArtifact(contractName),
-      pkgInfo: loadPackageJson(path.join(hre.config.paths.root, 'package.json')),
-      privateKey,
-      impersonate: toImpersonate.join(','),
-      fundAddresses: fundAddresses
-        .split(',')
-        .filter(Boolean)
-        .map((s: string) => s.trim())
-        .filter(Boolean),
-    });
-  });
+  );
 
 function _getPrivateKeyFromAccount(acc: string | HardhatNetworkAccountConfig) {
   if (typeof acc === 'string' && acc.length === 66) return acc;


### PR DESCRIPTION
seems there were some things about this new argument which got missed in the review:
* the helper text siad to run `--registry local` but the actual command was `--registry-priority local`
* argument didnt work for `run` command because the arguments were not passed through
* argument should have worked for `inspect` command also