### PR TITLE
feat(abi): add the option to use a literal abi string

### DIFF
--- a/packages/builder/src/steps/contract.ts
+++ b/packages/builder/src/steps/contract.ts
@@ -241,7 +241,7 @@ export default {
 
     // override abi?
     if (config.abi) {
-      if (config.abi.startsWith('[')) {
+      if (config.abi.trimStart().startsWith('[')) {
         // Allow to pass in a literal abi string
         abi = JSON.parse(config.abi);
       } else {


### PR DESCRIPTION
This feature allows the user to set a custom abi for a given contract, e.g.:

```toml
[contract.Proxy]
artifact = "Proxy"
abi = '[[{"stateMutability":"payable","type":"fallback"},{"stateMutability":"payable","type":"receive"}]]'
from = "<%= settings.admin %>"
```

Specifically, this is useful for the case that we want to pass on an abi as a provision setting:
```toml
[provision.proxy]
source = "transparent-upgradable-proxy:4.9.3"
options.admin = "<%= settings.admin %>"
options.implementation = "<%= contracts.Router.address %>"
options.abi = "<%= JSON.stringify(contracts.Router.abi) %>"
depends = ["router.Router"]
```