### PR TITLE
feat(website): handle tuples in the queue transactions ui

### DIFF
--- a/packages/website/src/features/Deploy/DisplayedTransaction.tsx
+++ b/packages/website/src/features/Deploy/DisplayedTransaction.tsx
@@ -241,6 +241,25 @@ export function DisplayedTransaction(props: {
               secondary: l,
             })),
           ];
+        case 'tuple':
+          try {
+            return typeof execFuncArgs[arg] === 'object' &&
+              Object.keys(execFuncArgs[arg] as any).length
+              ? [
+                  {
+                    label:
+                      encodeArg(
+                        execFuncFragment.inputs[arg].type,
+                        (execFuncArgs[arg] as string) || ''
+                      ) || '',
+                    secondary: 'JSON',
+                  },
+                  { label: '{}', secondary: 'JSON' },
+                ]
+              : [{ label: '{}', secondary: 'JSON' }];
+          } catch (e) {
+            return [{ label: '{}', secondary: 'JSON' }];
+          }
         default: // bytes32, string
           return [
             {
@@ -256,7 +275,6 @@ export function DisplayedTransaction(props: {
     }
 
     return [];
-    //const input =
   }
 
   function extractFunctionNames(contractAbi: any[]) {


### PR DESCRIPTION
Closes #434

<img width="1792" alt="Screenshot 2023-09-14 at 12 24 45" src="https://github.com/usecannon/cannon/assets/61683409/e74ec36b-6056-4ac2-b69a-c4e10935259f">
<img width="1792" alt="Screenshot 2023-09-14 at 12 25 04" src="https://github.com/usecannon/cannon/assets/61683409/39c1a3f7-c3bb-4a6c-9e4f-276c8cd02380">

