### PR TITLE
fix(website): fix chains modal overflow

### DIFF
--- a/packages/website/src/app/walletProvider.tsx
+++ b/packages/website/src/app/walletProvider.tsx
@@ -44,9 +44,22 @@ const wagmiConfig = createConfig({
 });
 
 function WalletProvider({ children }: { children: ReactNode }) {
+  // NOTE: have to hack the style below becuase otherwise it overflows the page.
+  // hopefully the class name doesnt change from compile to compile lol
+  // related issue: https://github.com/rainbow-me/rainbowkit/issues/1007
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains} theme={darkTheme()}>
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `
+            div.ju367v1i {
+              max-height: 90vh;
+              overflow: auto;
+            }
+          `,
+          }}
+        />
         {children}
       </RainbowKitProvider>
     </WagmiConfig>


### PR DESCRIPTION
Closes #426

@noahlitvin I've fixed overflow issue, but there are too many options still. Looks like there is no way to add a search or something like that, so the only way is to specify chain list manually (right now we use all supported chains). Do you have some ideas about relevant chain list that we want to use? Or I can reduce it myself and we will add missing ones ad hoc.

<img width="837" alt="Screenshot 2023-09-15 at 16 55 58" src="https://github.com/usecannon/cannon/assets/61683409/459807ed-e76e-4dc4-b02f-ec020f5765ee">