### PR TITLE
fix: `cannon trace` bugs

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -509,6 +509,7 @@ program
   .option('-v --value <value>', 'Amonut of gas token to send in the traced call')
   .option('-b --block-number <value>', 'The block to simulate when the call is on')
   .option('-p --preset <preset>', 'Preset of the variant to inspect', 'main')
+  .option('-n --provider-url [url]', 'RPC endpoint to fork off of')
   .option('-j --json', 'Output as JSON')
   .action(async function (packageName, data, options) {
     const { trace } = await import('./commands/trace');
@@ -518,6 +519,7 @@ program
       data,
       chainId: options.chainId,
       preset: options.preset,
+      providerUrl: options.providerUrl,
       from: options.from,
       to: options.to,
       value: options.value,

--- a/packages/cli/src/util/anvil.ts
+++ b/packages/cli/src/util/anvil.ts
@@ -40,7 +40,7 @@ export type AnvilOptions = {
    *
    * Requires `forkUrl` to be set.
    */
-  forkBlockNumber?: number | bigint | undefined;
+  forkBlockNumber?: string | undefined;
   /**
    * Specify chain id to skip fetching it from remote endpoint. This enables offline-start mode.
    *


### PR DESCRIPTION
* accept block tag (instead of just number) as the `--block-number` argument
* accept provider-url argument
* warn the user if the txn they inputted is probably not existing
* fix forking on correct block number not working properly