### PR TITLE
fix(website): rendering of contract tx details page

### DIFF
--- a/packages/website/src/app/walletProvider.tsx
+++ b/packages/website/src/app/walletProvider.tsx
@@ -6,10 +6,9 @@ import {
 } from '@rainbow-me/rainbowkit';
 import { configureChains, createConfig, WagmiConfig } from 'wagmi';
 import * as Chains from 'wagmi/chains';
-import { publicProvider } from 'wagmi/providers/public';
-import { infuraProvider } from 'wagmi/providers/infura';
 import { ReactNode } from 'react';
 import _ from 'lodash';
+import { createProviders } from '@/helpers/rpc';
 
 const cannonLocalHost = {
   ...Chains.localhost,
@@ -22,12 +21,7 @@ export const supportedChains = [..._chains, cannonLocalHost];
 
 const { chains, publicClient, webSocketPublicClient } = configureChains(
   supportedChains,
-  [
-    infuraProvider({
-      apiKey: process.env.NEXT_PUBLIC_INFURA_API_KEY || '',
-    }),
-    publicProvider(),
-  ]
+  createProviders()
 );
 
 const { connectors } = getDefaultWallets({

--- a/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
+++ b/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
@@ -112,11 +112,15 @@ const TransactionDetailsPage: FC<{
   const hintData = parseHintedMulticall(safeTxn?.data as any);
 
   const cannonPackage = useCannonPackage(
-    `@ipfs:${_.last(hintData?.cannonPackage.split('/'))}`
+    hintData?.cannonPackage
+      ? `@ipfs:${_.last(hintData?.cannonPackage.split('/'))}`
+      : ''
   );
 
   const reverseLookupCannonPackage = useCannonPackage(
-    `${cannonPackage.resolvedName}:${cannonPackage.resolvedVersion}`
+    cannonPackage.resolvedName
+      ? `${cannonPackage.resolvedName}:${cannonPackage.resolvedVersion}`
+      : ''
   );
 
   const executed = Number(safeNonce) > Number(nonce);

--- a/packages/website/src/helpers/rpc.ts
+++ b/packages/website/src/helpers/rpc.ts
@@ -1,6 +1,21 @@
 import * as chains from '@wagmi/core/chains';
 import { infuraProvider } from 'wagmi/providers/infura';
+import { publicProvider } from 'wagmi/providers/public';
 import { ethers } from 'ethers';
+
+export function createProviders() {
+  const providers = [publicProvider()];
+
+  if (process.env.NEXT_PUBLIC_INFURA_API_KEY) {
+    providers.unshift(
+      infuraProvider({
+        apiKey: process.env.NEXT_PUBLIC_INFURA_API_KEY || '',
+      })
+    );
+  }
+
+  return providers;
+}
 
 function findChainUrl(chainId: number) {
   if (typeof chainId !== 'number') {

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -281,7 +281,7 @@ export function useCannonPackage(packageRef: string, variant = '') {
 
   const registryQuery = useQuery(['cannon', 'registry', packageRef, variant], {
     queryFn: async () => {
-      if (packageRef.length < 3) {
+      if (!packageRef || packageRef.length < 3) {
         return null;
       }
 
@@ -306,6 +306,9 @@ export function useCannonPackage(packageRef: string, variant = '') {
   const ipfsQuery = useQuery(['cannon', 'pkg', pkgUrl], {
     queryFn: async () => {
       console.log('LOADING PKG URL', pkgUrl);
+
+      if (!pkgUrl) return null;
+
       const loader = new IPFSBrowserLoader(settings.ipfsUrl || 'https://ipfs.io/ipfs/');
 
       const deployInfo: DeploymentInfo = await loader.read(pkgUrl as any);


### PR DESCRIPTION
This PR fixed a bug that wasn't taking into account the rendering of queued transactions with custom contract addresses and data, instead of using the Cannon images.

The fix looks like this:
<img width="1512" alt="Screenshot 2023-09-27 at 18 12 53" src="https://github.com/usecannon/cannon/assets/558901/ed306d1a-9a42-49ea-ae17-4f665fb7c7be">

