### PR TITLE
fix: add builder/src/ folder to package build

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Add the `src/` folder to the npm package, so the sourcemaps can be used correctly.