### PR TITLE
fix: incorrect handling of providerUrl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,162 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@achingbrain/ip-address": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@achingbrain/ip-address/-/ip-address-8.1.0.tgz",
+      "integrity": "sha512-Zus4vMKVRDm+R1o0QJNhD0PD/8qRGO3Zx8YPsFG5lANt5utVtGg3iHVGBSAF80TfQmhi8rP+Kg/OigdxY0BXHw==",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@achingbrain/ip-address/node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
+    "node_modules/@achingbrain/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "node_modules/@achingbrain/nat-port-mapper": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@achingbrain/nat-port-mapper/-/nat-port-mapper-1.0.11.tgz",
+      "integrity": "sha512-Y2lwx0zmrwEl+IGu+V/QiVBdcdsWscYq1PMMEjvyuuaXnmnppbLWilO8LK1yoLdncxwJBuS0zZtHbpFeWBusRg==",
+      "dependencies": {
+        "@achingbrain/ssdp": "^4.0.1",
+        "@libp2p/logger": "^3.0.0",
+        "default-gateway": "^7.2.2",
+        "err-code": "^3.0.1",
+        "it-first": "^3.0.1",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.1.1",
+        "xml2js": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/@libp2p/logger": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.3.tgz",
+      "integrity": "sha512-85ioPX10QN4ZOZeurAZe5sQeRUCkIBT2DikKRbE/AIWKauIKHvvIrN4CSdCdzLw29XNA+xxNO2FVkf51HGgCeQ==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.3",
+        "@multiformats/multiaddr": "^12.1.5",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/it-first": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+      "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@achingbrain/ssdp": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@achingbrain/ssdp/-/ssdp-4.0.4.tgz",
+      "integrity": "sha512-fY/ShiYJmhLdr45Vn2+f88xTqZjBSH3X3F+EJu/89cjB1JIkMCVtD5CQaaS38YknIL8cEcNhjMZM4cdE3ckSSQ==",
+      "dependencies": {
+        "event-iterator": "^2.0.0",
+        "freeport-promise": "^2.0.0",
+        "merge-options": "^3.0.4",
+        "xml2js": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@achingbrain/ssdp/node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
@@ -247,6 +403,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@arr/every": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@arr/every/-/every-1.0.1.tgz",
+      "integrity": "sha512-UQFQ6SgyJ6LX42W8rHCs8KVc0JS0tzVL9ct4XYedJukskYVWTo49tNiMEK9C2HTyarbNiT/RVIRSY82vH+6sTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/cli": {
@@ -2262,6 +2427,165 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
       "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg=="
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.2.tgz",
+      "integrity": "sha512-ndGqEMG1W5WkGagaqOZHpPU172AGdxr+LD15sv3WIUvT5oCFUrG1Y0CW/v2Egwj4JXEvSibaIIIqImsm98y1nA=="
+    },
+    "node_modules/@chainsafe/libp2p-gossipsub": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-8.0.1.tgz",
+      "integrity": "sha512-vzRN7F1zLd/DKfK9VLQ7rrc/lYQFvE/RGnXjr+EanD2RoX+BjSdqZkvzcrJcaDzkCMJRCvpsFzgz2iLbV7SgYg==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.3",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-connection-manager": "^3.0.1",
+        "@libp2p/interface-keys": "^1.0.3",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-store": "^2.0.3",
+        "@libp2p/interface-pubsub": "^4.0.0",
+        "@libp2p/interface-registrar": "^2.0.3",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@libp2p/pubsub": "^7.0.1",
+        "@libp2p/topology": "^4.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "abortable-iterator": "^5.0.1",
+        "denque": "^1.5.0",
+        "it-length-prefixed": "^9.0.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.0",
+        "multiformats": "^11.0.0",
+        "protobufjs": "^6.11.2",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "npm": ">=8.7.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-noise": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-12.0.2.tgz",
+      "integrity": "sha512-bKlasdYJBXsCgcOw+gNNnpvNo3jD8BiSRpKrhYxEmBPQzesme15PBrj5Cx369PZEk4SvKSHS6dzL4oLxXqPSLw==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-connection-encrypter": "^4.0.0",
+        "@libp2p/interface-keys": "^1.0.6",
+        "@libp2p/interface-metrics": "^4.0.4",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
+        "@noble/ciphers": "^0.1.4",
+        "@noble/curves": "^1.1.0",
+        "@noble/hashes": "^1.3.1",
+        "it-length-prefixed": "^9.0.1",
+        "it-pair": "^2.0.2",
+        "it-pb-stream": "^4.0.1",
+        "it-pipe": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-noise/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-noise/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-noise/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-yamux/-/libp2p-yamux-4.0.2.tgz",
+      "integrity": "sha512-p0m/4ab4JLaIQqUtxvm8bSqdt9sb0uXX8PFj1CQM1eJLeV1LxzzygaSOeLxN/5ckHCuK7q/9eb9xybvl6vz/JA==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.1.0",
+        "@libp2p/interface-stream-muxer": "^4.1.2",
+        "@libp2p/interfaces": "^3.3.2",
+        "@libp2p/logger": "^2.0.7",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.3",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1"
+      }
     },
     "node_modules/@chainsafe/persistent-merkle-tree": {
       "version": "0.4.2",
@@ -6110,6 +6434,79 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@helia/interface": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@helia/interface/-/interface-1.2.2.tgz",
+      "integrity": "sha512-Eij8ATmzNTvMnUdfvPZP/6aZ7k+xAXN/LYcgXqJpVV3DDJYA/NnZZ3Ay9bIauoFIuhoDm2C6VjnW3HzmRDBY9Q==",
+      "dependencies": {
+        "@libp2p/interface-libp2p": "^3.2.0",
+        "@libp2p/interfaces": "^3.3.2",
+        "interface-blockstore": "^5.0.0",
+        "interface-datastore": "^8.0.0",
+        "interface-store": "^5.0.1",
+        "ipfs-bitswap": "^18.0.0",
+        "multiformats": "^11.0.1",
+        "progress-events": "^1.0.0"
+      }
+    },
+    "node_modules/@helia/interface/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@helia/interface/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@helia/interface/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@helia/interface/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@helia/interface/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@helia/interface/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -6763,6 +7160,11 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.2.tgz",
       "integrity": "sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A=="
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
     "node_modules/@lerna/child-process": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-7.2.0.tgz",
@@ -7348,6 +7750,1635 @@
         "node": "^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/@libp2p/bootstrap": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-8.0.0.tgz",
+      "integrity": "sha512-xbaJ+ybx1FGsi8FeGl9g1Wk6P2zf5/Thdk9Fe1qXV0O0xIW0xRWrefOYG5Dvt+BV54C/zlnQ4CG+Xs+Rr7wsbA==",
+      "dependencies": {
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.7",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.1",
+        "@libp2p/peer-id": "^2.0.0",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.17.tgz",
+      "integrity": "sha512-Oeg0Eb/EvAho0gVkOgemXEgrVxWaT3x/DpFgkBdZ9qGxwq75w/E/oPc7souqBz+l1swfz37GWnwV7bIb4Xv5Ag==",
+      "dependencies": {
+        "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interfaces": "^3.2.0",
+        "@noble/ed25519": "^1.6.0",
+        "@noble/secp256k1": "^1.5.4",
+        "multiformats": "^11.0.0",
+        "node-forge": "^1.1.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.3.tgz",
+      "integrity": "sha512-C1O7Xqd2TGVWrIOEDx6kGJSk4YOysWGmYG5Oh3chnsCY0wjUSsLDpl9+wKrdiM/lJbAlHlV65ZOvSkIQ9cWPBQ==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.1.5",
+        "abortable-iterator": "^5.0.1",
+        "it-pushable": "^3.2.0",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "race-signal": "^1.0.0",
+        "uint8arraylist": "^2.4.3"
+      }
+    },
+    "node_modules/@libp2p/interface-address-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-address-manager/-/interface-address-manager-3.0.1.tgz",
+      "integrity": "sha512-8N1nfOtZ/CnZ/cL0Bnj59fhcSs7orI4evmNVsv2DM1VaNHXqc9tPy8JmQE2HRjrUXeUPwtzzG2eoP7l0ZYdC0g==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-5.1.1.tgz",
+      "integrity": "sha512-ytknMbuuNW72LYMmTP7wFGP5ZTaUSGBCmV9f+uQ55XPcFHtKXLtKWVU/HE8IqPmwtyU8AO7veGoJ/qStMHNRVA==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-encrypter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-4.0.1.tgz",
+      "integrity": "sha512-fOtZpaFL2f5vID/RaBpVMAR9OKx5DmDT/yMEFTCarNc6Bb37fWwClI4WNCtoVbDQwcnr4H4ZIo0+9yCxjEIjjQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-gater": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-gater/-/interface-connection-gater-3.0.1.tgz",
+      "integrity": "sha512-3a+EmcKFIdYVM6tmmIKZt/4fREPApA/Z/PZHOEa4lqJA9c/BHO1HTq0YzEoYsptudYTcdhQLgpYzh8FVhfZGDg==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-3.0.1.tgz",
+      "integrity": "sha512-7ZAvzOWfHs3BtaoZoWsT+Ks1bo6HjyRMq1SJdFWDJ+ZkYEzrf6sdtQwsX8eXhwRDO6PuzpUDqLZ9TNQ2GVKEEw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@libp2p/peer-collections": "^3.0.1",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-content-routing": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.1.1.tgz",
+      "integrity": "sha512-nRPOUWgq1K1fDr3FKW93Tip7aH8AFefCw3nJygL4crepxWTSGw95s1GyDpC7t0RJkWTRNHsqZvsFsJ9FkHExKw==",
+      "dependencies": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-content-routing/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-dht": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-dht/-/interface-dht-2.0.3.tgz",
+      "integrity": "sha512-JAKbHvw3egaSeB7CHOf6PF/dLNim4kzAiXX+0IEz2lln8L32/Xf1T7KNOF/RSbSYqO9b7Xxc/b2fuSfyaMwwMQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-dht/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keychain": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.5.tgz",
+      "integrity": "sha512-mb7QNgn9fIvC7CaJCi06GJ+a6DN6RVT9TmEi0NmedZGATeCArPeWWG7r7IfxNVXb9cVOOE1RzV1swK0ZxEJF9Q==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keychain/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keys": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.8.tgz",
+      "integrity": "sha512-CJ1SlrwuoHMquhEEWS77E+4vv7hwB7XORkqzGQrPQmA9MRdIEZRS64bA4JqCLUDa4ltH0l+U1vp0oZHLT67NEA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-libp2p": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-libp2p/-/interface-libp2p-3.2.0.tgz",
+      "integrity": "sha512-Vow6xNdjpQ0M/Kt3EDz1qE/Os5OZUyhFt0YTPU5Fp3/kXw/6ocsxYq/Bzird/96gjUjU5/i+Vukn4WgctJf55Q==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-content-routing": "^2.0.0",
+        "@libp2p/interface-keychain": "^2.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interface-peer-routing": "^1.0.0",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interface-registrar": "^2.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.8.tgz",
+      "integrity": "sha512-1b9HjYyJH0m35kvPHipuoz2EtYCxyq34NUhuV8VK1VNtrouMpA3uCKp5FI7yHCA6V6+ux1R3UriKgNFOSGbIXQ==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-discovery": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-discovery/-/interface-peer-discovery-2.0.0.tgz",
+      "integrity": "sha512-Mien5t3Tc+ntP5p50acKUYJN90ouMnq1lOTQDKQNvGcXoajG8A1AEYLocnzVia/MXiexuj6S/Q28WBBacoOlBg==",
+      "dependencies": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-id/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-info": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.10.tgz",
+      "integrity": "sha512-HQlo8NwQjMyamCHJrnILEZz+YwEOXCB2sIIw3slIrhVUYeYlTaia1R6d9umaAeLHa255Zmdm4qGH8rJLRqhCcg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-routing": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.1.1.tgz",
+      "integrity": "sha512-/XEhwob9qXjdmI8PBcc+qFin32xmtyoC58nRpq8RliqHY5uOVWiHfZoNtdOXIsNvzVvq5FqlHOWt71ofxXTtlg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-store": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-2.0.4.tgz",
+      "integrity": "sha512-jNvBK3O1JPJqSiDN2vkb+PV8bTPnYdP54nxsLtut1BWukNm610lwzwleV7CetFI4bJCn6g+BgBvvq8fdADy0tA==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-pubsub": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-4.0.1.tgz",
+      "integrity": "sha512-PIc5V/J98Yr1ZTHh8lQshP7GdVUh+pKNIqj6wGaDmXs8oQLB40qKCjcpHQNlAnv2e1Bh9mEH2GXv5sGZOA651A==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-pushable": "^3.1.3",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-record": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.7.tgz",
+      "integrity": "sha512-AFPytZWI+p8FJWP0xuK5zbSjalLAOIMzEed2lBKdRWvdGBQUHt9ENLTkfkI9G7p/Pp3hlhVzzBXdIErKd+0GxQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-registrar": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.12.tgz",
+      "integrity": "sha512-EyCi2bycC2rn3oPB4Swr7EqBsvcaWd6RcqR6zsImNIG9BKc4/R1gl6iaF861JaELYgYmzBMS31x1rQpVz5UekQ==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-4.1.2.tgz",
+      "integrity": "sha512-dQJcn67UaAa8YQFRJDhbo4uT453z/2lCzD/ZwTk1YOqJxATXbXgVcB8dXDQFEUiUX3ZjVQ1IBu+NlQd+IZ++zw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@libp2p/logger": "^2.0.7",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "it-pushable": "^3.1.3",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-4.0.3.tgz",
+      "integrity": "sha512-jXFQ3blhFMEyQbFw/U8Glo3F/fUO5LEaX5HIdeqNpCliK+XnwTfpkcaG+WsJrcApWK4FFyUHc+GGqiWR0hAFFg==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-stream-muxer": "^4.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/interfaces": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.2.tgz",
+      "integrity": "sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/ipni-content-routing/-/ipni-content-routing-1.0.2.tgz",
+      "integrity": "sha512-ilsHyPSn4pJl2daAe4duhE/v5pGtqUvY0na3oso3/LBK8q74dCIxAYIho5zdL0Bxj+2E5yj4tL83wfx/B/dxmA==",
+      "dependencies": {
+        "@libp2p/interface-content-routing": "^2.0.2",
+        "@libp2p/interface-peer-info": "^1.0.9",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-id": "^2.0.3",
+        "@multiformats/multiaddr": "^12.1.2",
+        "any-signal": "^4.1.1",
+        "browser-readablestream-to-it": "^2.0.2",
+        "iterable-ndjson": "^1.1.0",
+        "multiformats": "^11.0.2",
+        "p-defer": "^4.0.0",
+        "p-queue": "^7.3.4"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/browser-readablestream-to-it": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.4.tgz",
+      "integrity": "sha512-EOjEEA+tJInvKg/Pml6QYxVY6gD8lka/ceLmkUbEeuWlzZx/a5k5ugupVFUUKSfI/88+v0VFs7JSFi5iYpp3IA=="
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/kad-dht": {
+      "version": "9.3.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-9.3.8.tgz",
+      "integrity": "sha512-vxYp8k6BKdlVexanH0qY3swyN3b9YqUmirdEz+SrbWtFpkqrebIfcuE/P0Hef4qfvF6I3osk4D+GtCDyl+IRhQ==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.4",
+        "@libp2p/interface-address-manager": "^3.0.0",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-connection-manager": "^3.0.0",
+        "@libp2p/interface-content-routing": "^2.1.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-routing": "^1.1.0",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interface-registrar": "^2.0.11",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.1",
+        "@libp2p/peer-collections": "^3.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/record": "^3.0.0",
+        "@libp2p/topology": "^4.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@types/sinon": "^10.0.14",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "datastore-core": "^9.0.1",
+        "events": "^3.3.0",
+        "hashlru": "^2.3.0",
+        "interface-datastore": "^8.0.0",
+        "it-all": "^3.0.1",
+        "it-drain": "^3.0.1",
+        "it-first": "^3.0.1",
+        "it-length": "^3.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-map": "^3.0.1",
+        "it-merge": "^3.0.0",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^3.0.0",
+        "it-stream-types": "^2.0.1",
+        "it-take": "^3.0.1",
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "p-event": "^6.0.0",
+        "p-queue": "^7.3.4",
+        "private-ip": "^3.0.0",
+        "progress-events": "^1.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/it-first": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+      "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/it-map": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+      "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/keychain": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-2.0.1.tgz",
+      "integrity": "sha512-A59jilLYS+8Paq38Z96uSAxbD+3+3LJZx2qcHdMpTyqDO7yfJCbMPfVhP6EKmH5EY3z3qxBwUPVw35P4F4fslg==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-keychain": "^2.0.3",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.1",
+        "interface-datastore": "^8.0.0",
+        "merge-options": "^3.0.4",
+        "sanitize-filename": "^1.6.3",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/keychain/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@libp2p/keychain/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@libp2p/keychain/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/keychain/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@libp2p/keychain/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.1.1.tgz",
+      "integrity": "sha512-2UbzDPctg3cPupF6jrv6abQnAUTrbLybNOj0rmmrdGm1cN2HJ1o/hBu0sXuq4KF9P1h/eVRn1HIRbVIEKnEJrA==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.2",
+        "@multiformats/multiaddr": "^12.1.3",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@libp2p/logger/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mdns": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/mdns/-/mdns-8.0.0.tgz",
+      "integrity": "sha512-/q2qDWGzZpv2/LmvlwsImoEwjOhmaO9H7HDFloEs2D1+rT0dRFuQpXHAm7/sCLwx9PtmSUZp/sNj0ppnGGwK5A==",
+      "dependencies": {
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.8",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.1",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@types/multicast-dns": "^7.2.1",
+        "dns-packet": "^5.4.0",
+        "multicast-dns": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-8.0.4.tgz",
+      "integrity": "sha512-or3F5sGl8cw3TbnQgmkJ8z7/c97rwuzoy6f3b9gmkEVN8EzdxG2jOq+TEsgXzLz1GekRUR8nuDhliJ3UPhUnFw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-stream-muxer": "^4.1.2",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "abortable-iterator": "^5.0.0",
+        "any-signal": "^4.0.1",
+        "benchmark": "^2.1.4",
+        "it-batched-bytes": "^2.0.2",
+        "it-pushable": "^3.1.0",
+        "it-stream-types": "^2.0.1",
+        "rate-limiter-flexible": "^2.3.9",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/multistream-select": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-3.1.9.tgz",
+      "integrity": "sha512-iSNqr8jXvOrkNTyA43h/ARs4wd0Rd55/D6oFRndLcV4yQSUMmfjl7dUcbC5MAw+5/sgskfDx9TMawSwNq47Qwg==",
+      "dependencies": {
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "abortable-iterator": "^5.0.0",
+        "it-first": "^3.0.1",
+        "it-handshake": "^4.1.3",
+        "it-length-prefixed": "^9.0.0",
+        "it-merge": "^3.0.0",
+        "it-pipe": "^3.0.0",
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.3.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/it-first": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+      "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/peer-collections": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-3.0.2.tgz",
+      "integrity": "sha512-3vRVMWVRCF6dVs/1/CHbw4YSv83bcqjZuAt9ZQHW85vn6OfHNFQesOHWT1TbRBuL8TSb//IwJkOfTAVLd6Mymw==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.4.tgz",
+      "integrity": "sha512-gcOsN8Fbhj6izIK+ejiWsqiqKeJ2yWPapi/m55VjOvDa52/ptQzZszxQP8jUk93u36de92ATFXDfZR/Bi6eeUQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id-factory": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.4.tgz",
+      "integrity": "sha512-+0D+oklFzHpjRI3v7uw3PMMx00P36DV7YvAgL0+gpos0VzR/BI9tRiM6dpObZTrQ1hxp78F03p+qR1Zy9Qnmuw==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.0",
+        "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id-factory/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id-factory/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/peer-id-factory/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-record": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.4.tgz",
+      "integrity": "sha512-e+AArf7pwMLqF24mehTe1OYjr1v0SOKshVrI1E9YH/Cb1F3ZZuK3smyGmnLaS4JlqsarRCMSe3V50tRkqMFY7g==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-record": "^2.0.1",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/utils": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^1.0.2",
+        "uint8arraylist": "^2.1.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-record/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-record/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/peer-store": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-8.2.1.tgz",
+      "integrity": "sha512-mr0GsZ7zucta3l5EblOGrBeVgdTVujRJ9WC+FmnYErQe023SRJevAZEv1WeMinMGVGL6CY+gmWw0oLpExu9AWg==",
+      "dependencies": {
+        "@libp2p/interface-libp2p": "^3.1.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-store": "^2.0.4",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-collections": "^3.0.1",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-id-factory": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.3",
+        "@multiformats/multiaddr": "^12.0.0",
+        "interface-datastore": "^8.0.0",
+        "it-all": "^3.0.2",
+        "mortice": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@libp2p/peer-store/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/@libp2p/peer-store/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/pubsub": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-7.0.3.tgz",
+      "integrity": "sha512-BrUBQ6ljN1tU+2Hn1Vq+ZT/foVBGUVIywqoavNrFw5CmaBBTGuVRrmqE/MUToIS8dhonpW5RNCRabz3woq/4iQ==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.0",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interface-pubsub": "^4.0.0",
+        "@libp2p/interface-registrar": "^2.0.11",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-collections": "^3.0.1",
+        "@libp2p/peer-id": "^2.0.3",
+        "@libp2p/topology": "^4.0.1",
+        "abortable-iterator": "^5.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.3",
+        "multiformats": "^11.0.0",
+        "p-queue": "^7.2.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/pubsub/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/@libp2p/pubsub/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/pubsub/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/pubsub/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/pubsub/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/pubsub/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/record": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/record/-/record-3.0.4.tgz",
+      "integrity": "sha512-cVefFlnlvuxkLwPnHvSDF05HT6PyBM33eBi0BtJ7ocbZTtN4hY44DNmkM0z3ht9/9blSQ9e12gXV6nePH4Q4AA==",
+      "dependencies": {
+        "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/record/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/record/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/record/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/tcp": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-7.0.3.tgz",
+      "integrity": "sha512-w1g5/BYDNpZKXrJZd1PW8kUS0GxHwFO6oql3rIizh5WaxmWtMa21LtKWIoHJyC8Wp4vshEUPeZthAIKECqUafg==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/utils": "^3.0.2",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@types/sinon": "^10.0.15",
+        "stream-to-it": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/topology": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/topology/-/topology-4.0.3.tgz",
+      "integrity": "sha512-uXd9ZYpmgb+onMTypsAPUlvKKeY20HMtxwsjAMEfDa29yqshK8DiEunHZNjLmtXaMIIO9CBl2w5ykjt5TtFsBQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-registrar": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/tracked-map": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-3.0.4.tgz",
+      "integrity": "sha512-G5ElrjFoubP10TwQo3dnRVaxhshU9wtu86qq0cIXNv12XCFpvTvx12Vbf8sV1SU5imrWgd6XQgfRKsQtjmu3Ew==",
+      "dependencies": {
+        "@libp2p/interface-metrics": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.13.tgz",
+      "integrity": "sha512-SNwIcQq/FvLpqVsjHHzbxSq7VgbbUK9EB7/865Re4NoLfqgE/6oTUpyPEDlrcJb4aTPFWbVPQzE85cA3raHIIw==",
+      "dependencies": {
+        "@achingbrain/ip-address": "^8.1.0",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "abortable-iterator": "^5.0.0",
+        "is-loopback-addr": "^2.0.1",
+        "it-stream-types": "^2.0.1",
+        "private-ip": "^3.0.0",
+        "uint8arraylist": "^2.3.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/webrtc/-/webrtc-2.0.11.tgz",
+      "integrity": "sha512-6lhlndCYxRrkbqldUFruxIzyyFcrgnyueYIpLXJP2phZf2P19zwhborae0raRyeRz7MwJ+uw+Ksql8D8Ry+KXg==",
+      "dependencies": {
+        "@chainsafe/libp2p-noise": "^12.0.0",
+        "@libp2p/interface-connection": "^5.0.2",
+        "@libp2p/interface-metrics": "^4.0.8",
+        "@libp2p/interface-peer-id": "^2.0.2",
+        "@libp2p/interface-registrar": "^2.0.12",
+        "@libp2p/interface-stream-muxer": "^4.1.2",
+        "@libp2p/interface-transport": "^4.0.3",
+        "@libp2p/interfaces": "^3.3.2",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-id": "^2.0.3",
+        "@multiformats/mafmt": "^12.1.2",
+        "@multiformats/multiaddr": "^12.1.2",
+        "abortable-iterator": "^5.0.1",
+        "detect-browser": "^5.3.0",
+        "it-length-prefixed": "^9.0.1",
+        "it-pb-stream": "^4.0.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.3",
+        "it-stream-types": "^2.0.1",
+        "it-to-buffer": "^4.0.2",
+        "multiformats": "^11.0.2",
+        "multihashes": "^4.0.3",
+        "p-defer": "^4.0.0",
+        "p-event": "^6.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.6.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/multibase": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
+      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "dependencies": {
+        "@multiformats/base-x": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/multihashes": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
+      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
+      "dependencies": {
+        "multibase": "^4.0.1",
+        "uint8arrays": "^3.0.0",
+        "varint": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/multihashes/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "node_modules/@libp2p/webrtc/node_modules/multihashes/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+    },
+    "node_modules/@libp2p/websockets": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-6.0.3.tgz",
+      "integrity": "sha512-pwOr3iAbczWmmCg1nHnC2Dl0Ek81Y6LE8ptImiUbuZ08q1E/fTumM8pRNmrrsogSshG4lugebArIO9SNMylJZg==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/utils": "^3.0.2",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@multiformats/multiaddr-to-uri": "^9.0.2",
+        "@types/ws": "^8.5.4",
+        "abortable-iterator": "^5.0.0",
+        "it-ws": "^6.0.0",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.0.0",
+        "wherearewe": "^2.0.1",
+        "ws": "^8.12.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@libp2p/webtransport": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/webtransport/-/webtransport-2.0.2.tgz",
+      "integrity": "sha512-Vok9j2WT6tF7dlDdbDV3EfenTsGLim1icrR6HqSzTRZAZn7uOBtMKKoO2YnXgGyHmnstqxLt0axnZWc2v5uKNQ==",
+      "dependencies": {
+        "@chainsafe/libp2p-noise": "^12.0.1",
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-stream-muxer": "^4.0.0",
+        "@libp2p/interface-transport": "^4.0.1",
+        "@libp2p/logger": "^2.0.2",
+        "@libp2p/peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.1.0",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arraylist": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/webtransport/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
@@ -7604,6 +9635,98 @@
         "tslib": "^2.3.1"
       }
     },
+    "node_modules/@multiformats/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
+    "node_modules/@multiformats/mafmt": {
+      "version": "12.1.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.6.tgz",
+      "integrity": "sha512-tlJRfL21X+AKn9b5i5VnaTD6bNttpSpcqwKVmDmSHLwxoz97fAHaepqFOk/l1fIu94nImIXneNbhsJx/RQNIww==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^0.1.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^12.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.6.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.7.tgz",
+      "integrity": "sha512-i3ldtPMN6XJt+MCi34hOl0wGuGEHfWWMw6lmNag5BpckPwPTf9XGOOFMmh7ed/uO3Vjah/g173iOe61HTQVoBA==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/dns-over-http-resolver": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.2.tgz",
+      "integrity": "sha512-Bjbf6aZjr3HMnwGslZnoW3MJVqgbTsh39EZWpikx2yLl9xEjw4eZhlOHCFhkOu89zoWaS4rqe2Go53TXW4Byiw==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/native-fetch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
+      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
+      "peerDependencies": {
+        "undici": "*"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/uint8-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
+      "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "13.4.19",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
@@ -7805,6 +9928,14 @@
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "optional": true
     },
+    "node_modules/@noble/ciphers": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.1.4.tgz",
+      "integrity": "sha512-d3ZR8vGSpy3v/nllS+bD/OMN5UZqusWiQqkyj7AwzTnhXFH72pF5oB4Ach6DQ50g5kXxC28LdaYBEpsyv9KOUQ==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
@@ -7826,6 +9957,17 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@noble/hashes": {
       "version": "1.3.0",
@@ -9532,6 +11674,27 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
+      "integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.38.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polka/url": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-0.5.0.tgz",
+      "integrity": "sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw==",
+      "dev": true
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -12674,6 +14837,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz",
+      "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -12729,6 +14902,14 @@
       "integrity": "sha512-amrLbRqTU9bXMCc6uX0sWpxsQzRIo9z6MJPkH1pkez/qOxuqSZVuryJAWoBRq94CeG8JxY+VK4Le9HtjQR5T9A==",
       "dev": true
     },
+    "node_modules/@types/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-F8X3srlDYXQSVGfjAWl0lxd9mGfYtkneMA0QFQ3BFBw/BUmBlhlAbpRjmvE7LbW3wIxf01KHi20/bPstYK6ssA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.44.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
@@ -12760,6 +14941,30 @@
       "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
       "dependencies": {
         "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.18.tgz",
+      "integrity": "sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.37",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz",
+      "integrity": "sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/form-data": {
@@ -12820,6 +15025,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.2.tgz",
+      "integrity": "sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -12936,6 +15147,12 @@
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.7.tgz",
       "integrity": "sha512-BG4tyr+4amr3WsSEmHn/fXPqaCba/AYZ7dsaQTiavihQunHSIxk+uAtqsjvicNpyHN6cm+B9RVrUOtW9VzIKHw=="
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
+      "integrity": "sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==",
+      "dev": true
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -12956,6 +15173,15 @@
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+    },
+    "node_modules/@types/multicast-dns": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.2.tgz",
+      "integrity": "sha512-re0wpYJU2SdKkBbmCh7f5zYMLFA/FCbX46DI0rRMLlkkDqhk+0bTHbYsUVZumk/43GfJehPImK9e202eSuxPKA==",
+      "dependencies": {
+        "@types/dns-packet": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.5.4",
@@ -12992,6 +15218,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/polka": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/polka/-/polka-0.5.5.tgz",
+      "integrity": "sha512-70m2zRjRQRhG9tA0Ni0kYW9xn7pD5PhF39N7ATzyX5U7x6Yz1oHN1r2h41n+K9NMq2a3cFnnce6qQrnRAoNiiw==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/node": "*",
+        "@types/trouter": "*"
+      }
+    },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
@@ -13023,6 +15261,12 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
+      "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.2.14",
@@ -13096,6 +15340,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
@@ -13115,11 +15364,31 @@
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
+    "node_modules/@types/send": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.2.tgz",
+      "integrity": "sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.3.tgz",
+      "integrity": "sha512-yVRvFsEMrv7s0lGhzrggJjNOSmZCdgCjw9xWrPr/kNNLp6FaDfMC1KaYl3TSJ0c58bECwNBMoQrZJ8hA8E1eFg==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sinon": {
       "version": "10.0.16",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.16.tgz",
       "integrity": "sha512-j2Du5SYpXZjJVJtXBokASpPRj+e2z+VUhCPHmM6WMfe3dpHu6iVKJMU6AiBcMp/XTAYnEj6Wc1trJUWwZ0QaAQ==",
-      "dev": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -13127,8 +15396,7 @@
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
-      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
-      "dev": true
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -13136,10 +15404,25 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "node_modules/@types/stoppable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/stoppable/-/stoppable-1.1.1.tgz",
+      "integrity": "sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw=="
+    },
+    "node_modules/@types/trouter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/trouter/-/trouter-3.1.2.tgz",
+      "integrity": "sha512-Q2xKmIsi311ihqTa7vmbp7k3osjQkG7KRcm43omWr42w5Za/BNMwACatUrD7I8XHkRozUCI13thEJLrUz7N0xw==",
+      "dev": true
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.3",
@@ -13475,6 +15758,10 @@
       "resolved": "packages/cli",
       "link": true
     },
+    "node_modules/@usecannon/repo": {
+      "resolved": "packages/repo",
+      "link": true
+    },
     "node_modules/@vanilla-extract/css": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.9.1.tgz",
@@ -13529,6 +15816,11 @@
       "peerDependencies": {
         "@vanilla-extract/css": "^1.0.0"
       }
+    },
+    "node_modules/@vascosantos/moving-average": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/moving-average/-/moving-average-1.1.0.tgz",
+      "integrity": "sha512-MVEJ4vWAPNbrGLjz7ITnHYg+YXZ6ijAqtH5/cHwSoCpbvuJ98aLXwFfPKAUfZpJMQR5uXB58UJajbY130IRF/w=="
     },
     "node_modules/@walletconnect/core": {
       "version": "2.9.2",
@@ -14685,6 +16977,24 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abortable-iterator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+      "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+      "dependencies": {
+        "get-iterator": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/abortable-iterator/node_modules/get-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-2.0.1.tgz",
+      "integrity": "sha512-7HuY/hebu4gryTDT7O/XY/fvY9wRByEGdK6QOa4of8npTcv0+NS6frFKABcf6S9EBAsveTuKTsZQQBFMMNILIg=="
+    },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
@@ -15788,6 +18098,15 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "node_modules/big.js": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
@@ -15924,6 +18243,84 @@
       "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
       "dependencies": {
         "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
+    "node_modules/blockstore-core": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-4.3.4.tgz",
+      "integrity": "sha512-JecnNXiDPEdeS9AeFWO0PUKKmmRMW0D+ggUb4lgK0XMDOUAWmhkaiDPhgBjEKrlya0n60XOjcgBYhg18CUqOFw==",
+      "dependencies": {
+        "@libp2p/logger": "^3.0.0",
+        "err-code": "^3.0.1",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.0.0",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.0",
+        "it-merge": "^3.0.1",
+        "it-pushable": "^3.0.0",
+        "multiformats": "^12.0.1",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/@libp2p/logger": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.3.tgz",
+      "integrity": "sha512-85ioPX10QN4ZOZeurAZe5sQeRUCkIBT2DikKRbE/AIWKauIKHvvIrN4CSdCdzLw29XNA+xxNO2FVkf51HGgCeQ==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.3",
+        "@multiformats/multiaddr": "^12.1.5",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/blockstore-core/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
       }
     },
     "node_modules/bluebird": {
@@ -16313,6 +18710,18 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/byte-access": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/byte-access/-/byte-access-1.0.1.tgz",
+      "integrity": "sha512-GKYa+lvxnzhgHWj9X+LCsQ4s2/C5uvib573eAOiQKywXMkzFFErY2+yQdzmdE5iWVpmqecsRx3bOtOY4/1eINw==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/byte-size": {
@@ -18575,6 +20984,105 @@
       "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
       "dev": true
     },
+    "node_modules/datastore-core": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-9.2.3.tgz",
+      "integrity": "sha512-jcvrVDt+jp7lUp2WhMXXgX/hoi3VcJebN+z/ZXbIRKOVfNOF4bl8cvr7sQ1y9qITikgC2coXFYd79Wzt/n13ZQ==",
+      "dependencies": {
+        "@libp2p/logger": "^3.0.0",
+        "err-code": "^3.0.1",
+        "interface-store": "^5.0.0",
+        "it-all": "^3.0.1",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.0",
+        "it-map": "^3.0.1",
+        "it-merge": "^3.0.1",
+        "it-pipe": "^3.0.0",
+        "it-pushable": "^3.0.0",
+        "it-sort": "^3.0.1",
+        "it-take": "^3.0.1",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/datastore-core/node_modules/@libp2p/logger": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.3.tgz",
+      "integrity": "sha512-85ioPX10QN4ZOZeurAZe5sQeRUCkIBT2DikKRbE/AIWKauIKHvvIrN4CSdCdzLw29XNA+xxNO2FVkf51HGgCeQ==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.3",
+        "@multiformats/multiaddr": "^12.1.5",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/datastore-core/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/datastore-core/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/datastore-core/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/datastore-core/node_modules/it-map": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+      "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+    },
+    "node_modules/datastore-core/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/datastore-core/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -18750,6 +21258,119 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/default-gateway": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-7.2.2.tgz",
+      "integrity": "sha512-AD7TrdNNPXRZIGw63dw+lnGmT4v7ggZC5NHNJgAYWm5njrwoze1q5JSAW9YuLy2tjnoLUG/r8FEB93MCh9QJPg==",
+      "dependencies": {
+        "execa": "^7.1.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/default-gateway/node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/default-gateway/node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/default-gateway/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -18876,6 +21497,14 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "dev": true
+    },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -19049,6 +21678,17 @@
         "debug": "^4.3.1",
         "native-fetch": "^3.0.0",
         "receptacle": "^1.3.2"
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/docker-compose": {
@@ -21528,6 +24168,11 @@
         "npm": ">=3"
       }
     },
+    "node_modules/event-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
+      "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ=="
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -22266,6 +24911,15 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/freeport-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/freeport-promise/-/freeport-promise-2.0.0.tgz",
+      "integrity": "sha512-dwWpT1DdQcwrhmRwnDnPM/ZFny+FtzU+k50qF2eid3KxaQDsMiBrwo1i0G3qSugkN5db6Cb0zgfc68QeTOpEFg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -24203,6 +26857,11 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
     "node_modules/hast-util-parse-selector": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
@@ -24309,6 +26968,176 @@
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/helia": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/helia/-/helia-1.3.12.tgz",
+      "integrity": "sha512-/RCYJPpjBtudX2gHhFpc3I1isQIHZ43fQxzzDnIJ49DGhv8kyWdQ9gko9jt89X5vi0fv80HesQQGmo0rNdEDeA==",
+      "dependencies": {
+        "@chainsafe/libp2p-gossipsub": "^8.0.0",
+        "@chainsafe/libp2p-noise": "^12.0.0",
+        "@chainsafe/libp2p-yamux": "^4.0.2",
+        "@helia/interface": "^1.0.0",
+        "@ipld/dag-pb": "^4.0.3",
+        "@libp2p/bootstrap": "^8.0.0",
+        "@libp2p/interface-libp2p": "^3.2.0",
+        "@libp2p/interface-pubsub": "^4.0.1",
+        "@libp2p/interfaces": "^3.3.2",
+        "@libp2p/ipni-content-routing": "^1.0.0",
+        "@libp2p/kad-dht": "^9.3.3",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/mdns": "^8.0.0",
+        "@libp2p/mplex": "^8.0.3",
+        "@libp2p/tcp": "^7.0.1",
+        "@libp2p/webrtc": "^2.0.4",
+        "@libp2p/websockets": "^6.0.1",
+        "@libp2p/webtransport": "^2.0.1",
+        "blockstore-core": "^4.0.0",
+        "cborg": "^1.10.0",
+        "datastore-core": "^9.0.0",
+        "interface-blockstore": "^5.0.0",
+        "interface-datastore": "^8.0.0",
+        "interface-store": "^5.0.1",
+        "ipfs-bitswap": "^18.0.0",
+        "ipns": "^6.0.0",
+        "it-all": "^3.0.2",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.1",
+        "it-foreach": "^2.0.2",
+        "libp2p": "^0.45.2",
+        "mortice": "^3.0.1",
+        "multiformats": "^11.0.1",
+        "p-defer": "^4.0.0",
+        "p-queue": "^7.3.4",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^4.0.3"
+      }
+    },
+    "node_modules/helia/node_modules/@ipld/dag-pb": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.6.tgz",
+      "integrity": "sha512-wOij3jfDKZsb9yjhQeHp+TQy0pu1vmUkGv324xciFFZ7xGbDfAGTQW03lSA5aJ/7HBBNYgjEE0nvHmNW1Qjfag==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/helia/node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/helia/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/helia/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/helia/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/helia/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/helia/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/helia/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/helia/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/helia/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/helia/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/helia/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/helia/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/hey-listen": {
@@ -24890,6 +27719,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/interface-blockstore": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.2.6.tgz",
+      "integrity": "sha512-Cp6+QPY81kunaxQV/j5BWk3uSW6kpos8dLveJ3P2lbmA/yX2XeMwVlNOnQyGg0evhp1qmMLhf6eCswNiSMW3CA==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/interface-blockstore/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/interface-blockstore/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/interface-datastore": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
@@ -24963,6 +27815,102 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipfs-bitswap": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-18.0.3.tgz",
+      "integrity": "sha512-ebUB/OMeVLbqnHn61VIgSJKTFQcuIJxSjjF0k5yHZRPVll1QE9APYe15dLyKQUiotiEBEQ9tHe7CsoId416PRg==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.1.0",
+        "@libp2p/interface-libp2p": "^3.1.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.8",
+        "@libp2p/interface-registrar": "^2.0.8",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/topology": "^4.0.0",
+        "@libp2p/tracked-map": "^3.0.0",
+        "@multiformats/multiaddr": "^12.1.0",
+        "@vascosantos/moving-average": "^1.1.0",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "blockstore-core": "^4.0.0",
+        "events": "^3.3.0",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.1.0",
+        "it-foreach": "^2.0.2",
+        "it-length-prefixed": "^9.0.0",
+        "it-map": "^3.0.2",
+        "it-pipe": "^3.0.1",
+        "it-take": "^3.0.1",
+        "just-debounce-it": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "progress-events": "^1.0.0",
+        "protons-runtime": "^5.0.0",
+        "timeout-abort-controller": "^3.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0",
+        "varint-decoder": "^1.0.0"
+      }
+    },
+    "node_modules/ipfs-bitswap/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-bitswap/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/ipfs-bitswap/node_modules/it-map": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+      "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/ipfs-bitswap/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+    },
+    "node_modules/ipfs-bitswap/node_modules/just-debounce-it": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-3.2.0.tgz",
+      "integrity": "sha512-WXzwLL0745uNuedrCsCs3rpmfD6DBaf7uuVwaq98/8dafURfgQaBsSpjiPp5+CW6Vjltwy9cOGI6qE71b3T8iQ=="
+    },
+    "node_modules/ipfs-bitswap/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-bitswap/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/ipfs-bitswap/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/ipfs-core-types": {
@@ -25074,6 +28022,130 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipns": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-6.0.7.tgz",
+      "integrity": "sha512-VHC7XAEjqQwBzP1PbCRVOhGo4QFQTVuV93m8Ul3flzJt77WQWU6XPitXUPOT+LZ8yrObMXHzlt/ZheP3Ypwi4g==",
+      "dependencies": {
+        "@libp2p/crypto": "^2.0.3",
+        "@libp2p/interface": "^0.1.2",
+        "@libp2p/logger": "^3.0.2",
+        "@libp2p/peer-id": "^3.0.2",
+        "cborg": "^4.0.1",
+        "err-code": "^3.0.1",
+        "interface-datastore": "^8.1.0",
+        "multiformats": "^12.0.1",
+        "protons-runtime": "^5.0.0",
+        "timestamp-nano": "^1.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/ipns/node_modules/@libp2p/crypto": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-2.0.5.tgz",
+      "integrity": "sha512-m6Rn7i9q3SHCzMUBkEwZgAKS4evpGQ4SEx/YD96pM0ZoPtU5PFO0psfrerraanxFBh8wUX4vkCtKfyTPH7F+bQ==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.3",
+        "@noble/curves": "^1.1.0",
+        "@noble/hashes": "^1.3.1",
+        "multiformats": "^12.0.1",
+        "node-forge": "^1.1.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
+      }
+    },
+    "node_modules/ipns/node_modules/@libp2p/logger": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.3.tgz",
+      "integrity": "sha512-85ioPX10QN4ZOZeurAZe5sQeRUCkIBT2DikKRbE/AIWKauIKHvvIrN4CSdCdzLw29XNA+xxNO2FVkf51HGgCeQ==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.3",
+        "@multiformats/multiaddr": "^12.1.5",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/ipns/node_modules/@libp2p/peer-id": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-3.0.3.tgz",
+      "integrity": "sha512-IPVeywoC40bDd3ohtAIzpN8AOkMmD3U0BjdrFz/5ZbNP1+4n2gDIAwVzkAbF/t1iYYS4CX1TWfHuMqaMvd8l1A==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.3",
+        "multiformats": "^12.0.1",
+        "uint8arrays": "^4.0.6"
+      }
+    },
+    "node_modules/ipns/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ipns/node_modules/cborg": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.3.tgz",
+      "integrity": "sha512-poLvpK30KT5KI8gzDx3J/IuVCbsLqMT2fEbOrOuX0H7Hyj8yg5LezeWhRh9aLa5Z6MfPC5sriW3HVJF328M8LQ==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/ipns/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/ipns/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/ipns/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipns/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
       }
     },
     "node_modules/is-absolute": {
@@ -25443,6 +28515,11 @@
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
+    },
+    "node_modules/is-loopback-addr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-loopback-addr/-/is-loopback-addr-2.0.2.tgz",
+      "integrity": "sha512-26POf2KRCno/KTNL5Q0b/9TYnL00xEsSaLfiFRmjM7m7Lw7ZMmFybzzuX4CcsLAluZGd+niLUiMRxEooVE3aqg=="
     },
     "node_modules/is-lower-case": {
       "version": "2.0.2",
@@ -26003,10 +29080,61 @@
       "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
       "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
     },
+    "node_modules/it-batched-bytes": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-2.0.4.tgz",
+      "integrity": "sha512-n4V19XACvFG+b8lCkuvidYvwpyz3++DAolqZGI+9AcDvIPMAhVwwtFCe9SiDIz45OzQnnNYwBgBxbIinHPgraA==",
+      "dependencies": {
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.4.1"
+      }
+    },
+    "node_modules/it-batched-bytes/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/it-drain": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.3.tgz",
+      "integrity": "sha512-l4s+izxUpFAR2axprpFiCaq0EtxK1QMd0LWbEtau5b+OegiZ5xdRtz35iJyh6KZY9QtuwEiQxydiOfYJc7stoA=="
+    },
+    "node_modules/it-filter": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.0.3.tgz",
+      "integrity": "sha512-2zXUrJuuV6QHM21ahc8NqVUUxkLMVDWXBoUBcj9GCQLQez2OXmddTHN0r0F5B+TkNTpeL618yIgXi1HNPJOxow==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/it-filter/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+    },
     "node_modules/it-first": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
       "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "node_modules/it-foreach": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-2.0.4.tgz",
+      "integrity": "sha512-txxcoc09g+KdLyOapxAuB12H9zUb2FuZC/TqSXRT+YR0T5fHnvcDIhspgvx/e/HiPKlKjOR8onA0qtuiAtcXqg==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/it-foreach/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
     },
     "node_modules/it-glob": {
       "version": "1.0.2",
@@ -26017,20 +29145,266 @@
         "minimatch": "^3.0.4"
       }
     },
+    "node_modules/it-handshake": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-4.1.3.tgz",
+      "integrity": "sha512-V6Lt9A9usox9iduOX+edU1Vo94E6v9Lt9dOvg3ubFaw1qf5NCxXLi93Ao4fyCHWDYd8Y+DUhadwNtWVyn7qqLg==",
+      "dependencies": {
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-handshake/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/it-last": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
       "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+    },
+    "node_modules/it-length": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-length/-/it-length-3.0.3.tgz",
+      "integrity": "sha512-aLoeonDJV6wMgT1ElEruc61c3FYxGa3yymujfZ0Uk4Up7mUJ15xl1ixxPnGbm+BnMkEQylJXjzp1vNYEY9blvg=="
+    },
+    "node_modules/it-length-prefixed": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.3.tgz",
+      "integrity": "sha512-YAu424ceYpXctxtjcLOqn7vJq082CaoP8J646ZusYISfQc3bpzQErgTUqMFj81V262KG2W9/YMBHsy6A/4yvmg==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-length-prefixed/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-length-prefixed/node_modules/uint8-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
+      "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/it-length-prefixed/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
     },
     "node_modules/it-map": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
       "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
     },
+    "node_modules/it-merge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.2.tgz",
+      "integrity": "sha512-bMk2km8lTz+Rwv30hzDUdGIcqQkOemFJqmGT2wqQZ6/zHKCsYqdRunPrteCqHLV/nIVhUK8nZZkDA2eJ4MJZiA==",
+      "dependencies": {
+        "it-pushable": "^3.2.0"
+      }
+    },
+    "node_modules/it-pair": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.6.tgz",
+      "integrity": "sha512-5M0t5RAcYEQYNG5BV7d7cqbdwbCAp5yLdzvkxsZmkuZsLbTdZzah6MQySYfaAQjNDCq6PUnDt0hqBZ4NwMfW6g==",
+      "dependencies": {
+        "it-stream-types": "^2.0.1",
+        "p-defer": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pair/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/it-parallel": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.4.tgz",
+      "integrity": "sha512-fuA+SysGxbZc+Yl7EUvzQqZ8bNYQghZ0Mq9zA+fxMQ5eQYzatNg6oJk1y1PvPvNqLgKJMzEInpRO6PbLC3hGAg==",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      }
+    },
+    "node_modules/it-parallel/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/it-pb-stream": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-4.0.2.tgz",
+      "integrity": "sha512-wZ4Bvx2MfwamZTeyFQdX1SnD97hqdhpnaQwmbHqX4eT0pNWFPZ0mkKXbUkhLw2M0UNQNkEGN4wxljMod95c/ig==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^1.0.6",
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/it-peekable": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
       "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
+    },
+    "node_modules/it-pipe": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+      "dependencies": {
+        "it-merge": "^3.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pushable": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.1.tgz",
+      "integrity": "sha512-sLFz2Q0oyDCJpTciZog7ipP4vSftfPy3e6JnH6YyztRa1XqkpGQaafK3Jw/JlfEBtCXfnX9uVfcpu3xpSAqCVQ==",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pushable/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/it-reader": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.4.tgz",
+      "integrity": "sha512-XCWifEcNFFjjBHtor4Sfaj8rcpt+FkY0L6WdhD578SCDhV4VUm7fCkF3dv5a+fTcfQqvN9BsxBTvWbYO6iCjTg==",
+      "dependencies": {
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-sort": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-3.0.3.tgz",
+      "integrity": "sha512-9BuQc5Y2fmBUNhevQBUDHfItrQmzWoZcnzydJl91V6na6M+RkbNj71UtCPPNIpOt/SQG+va0pe1wMQJ9lP2Oew==",
+      "dependencies": {
+        "it-all": "^3.0.0"
+      }
+    },
+    "node_modules/it-sort/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-take": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-3.0.3.tgz",
+      "integrity": "sha512-Ay5SXEyrBKD0tO8PQif2QjrStImIsLIg0F50Uu4EeXOw8C9DfVIGfsGL3X9s65F2I9skDp9mLgBzl71IToMxNw=="
+    },
+    "node_modules/it-to-buffer": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-4.0.3.tgz",
+      "integrity": "sha512-/xdI2hD/LvK7tzS/9DY9oKATmUZ9rg9uG7IfQRBAokM/LLujJ179fqRGneluqwKpXOtCpMRo43LJZXr8aibv6Q==",
+      "dependencies": {
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/it-to-buffer/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-to-buffer/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
     },
     "node_modules/it-to-stream": {
       "version": "1.0.0",
@@ -26043,6 +29417,68 @@
         "p-defer": "^3.0.0",
         "p-fifo": "^1.0.0",
         "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/it-ws": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-6.0.5.tgz",
+      "integrity": "sha512-xp7tF4fHgx8+vN3Qy/8wGiWUKbC9E1U1g9PwtlbdxD7pY4zld71ZyWZVFHLxnxxg14T9mVNK5uO7U9HK11VQ5g==",
+      "dependencies": {
+        "@types/ws": "^8.2.2",
+        "event-iterator": "^2.0.0",
+        "iso-url": "^1.1.2",
+        "it-stream-types": "^2.0.1",
+        "uint8arrays": "^4.0.2",
+        "ws": "^8.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-ws/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-ws/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/it-ws/node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/iterable-ndjson": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
+      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+      "dependencies": {
+        "string_decoder": "^1.2.0"
       }
     },
     "node_modules/iterator.prototype": {
@@ -27919,6 +31355,213 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/libp2p": {
+      "version": "0.45.9",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.45.9.tgz",
+      "integrity": "sha512-cf2dCf8naZqQoDw3xxSEZ6rKgQ8BBne5iWgtIKHAYrCvL+ulshz72jNgeAG0FQ/jjRD3yzmUuwoMaLHj6gf7Bw==",
+      "dependencies": {
+        "@achingbrain/nat-port-mapper": "^1.0.9",
+        "@libp2p/crypto": "^1.0.17",
+        "@libp2p/interface-address-manager": "^3.0.0",
+        "@libp2p/interface-connection": "^5.1.1",
+        "@libp2p/interface-connection-encrypter": "^4.0.0",
+        "@libp2p/interface-connection-gater": "^3.0.0",
+        "@libp2p/interface-connection-manager": "^3.0.0",
+        "@libp2p/interface-content-routing": "^2.1.0",
+        "@libp2p/interface-keychain": "^2.0.4",
+        "@libp2p/interface-libp2p": "^3.2.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-routing": "^1.1.0",
+        "@libp2p/interface-peer-store": "^2.0.4",
+        "@libp2p/interface-pubsub": "^4.0.0",
+        "@libp2p/interface-record": "^2.0.6",
+        "@libp2p/interface-registrar": "^2.0.3",
+        "@libp2p/interface-stream-muxer": "^4.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/keychain": "^2.0.0",
+        "@libp2p/logger": "^2.1.1",
+        "@libp2p/multistream-select": "^3.1.8",
+        "@libp2p/peer-collections": "^3.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-id-factory": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@libp2p/peer-store": "^8.2.0",
+        "@libp2p/topology": "^4.0.1",
+        "@libp2p/tracked-map": "^3.0.0",
+        "@libp2p/utils": "^3.0.10",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "datastore-core": "^9.0.0",
+        "interface-datastore": "^8.0.0",
+        "it-all": "^3.0.1",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.1",
+        "it-first": "^3.0.1",
+        "it-handshake": "^4.1.3",
+        "it-length-prefixed": "^9.0.1",
+        "it-map": "^3.0.2",
+        "it-merge": "^3.0.0",
+        "it-pair": "^2.0.2",
+        "it-parallel": "^3.0.0",
+        "it-pb-stream": "^4.0.1",
+        "it-pipe": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "merge-options": "^3.0.4",
+        "multiformats": "^11.0.0",
+        "p-defer": "^4.0.0",
+        "p-queue": "^7.3.4",
+        "p-retry": "^5.0.0",
+        "private-ip": "^3.0.0",
+        "protons-runtime": "^5.0.0",
+        "rate-limiter-flexible": "^2.3.11",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2",
+        "wherearewe": "^2.0.0",
+        "xsalsa20": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/libp2p/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/libp2p/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/libp2p/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/libp2p/node_modules/it-first": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+      "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+    },
+    "node_modules/libp2p/node_modules/it-map": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+      "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+    },
+    "node_modules/libp2p/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/libp2p/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/libp2p/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/libp2p/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/libp2p/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/libp2p/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
@@ -28224,6 +31867,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/longbits": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/longbits/-/longbits-1.1.0.tgz",
+      "integrity": "sha512-22U2exkkYy7sr7nuQJYx2NEZ2kEMsC69+BxM5h8auLvkVIJa+LwAB5mFIExnuW2dFuYXFOWsFMKXjaWiq/htYQ==",
+      "dependencies": {
+        "byte-access": "^1.0.1",
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -28542,6 +32198,18 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/matchit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/matchit/-/matchit-1.1.0.tgz",
+      "integrity": "sha512-+nGYoOlfHmxe5BW5tE0EMJppXEwdSf8uBA1GTZC7Q77kbT35+VKLYJMzVNWCHSsga1ps1tPYFtFyvxvKzWVmMA==",
+      "dev": true,
+      "dependencies": {
+        "@arr/every": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mcl-wasm": {
@@ -30706,6 +34374,80 @@
         "node": ">=10"
       }
     },
+    "node_modules/mortice": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.1.tgz",
+      "integrity": "sha512-eyDUsl1nCR9+JtNksKnaESLP9MgAXCA4w1LTtsmOSQNsThnv++f36rrBu5fC/fdGIwTJZmbiaR/QewptH93pYA==",
+      "dependencies": {
+        "nanoid": "^4.0.0",
+        "observable-webworkers": "^2.0.1",
+        "p-queue": "^7.2.0",
+        "p-timeout": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/mortice/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/mortice/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/mortice/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mortice/node_modules/p-queue/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mortice/node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/motion": {
       "version": "10.16.2",
       "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
@@ -30725,6 +34467,15 @@
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -30786,6 +34537,18 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
       }
     },
     "node_modules/multicodec": {
@@ -30972,6 +34735,14 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/next": {
       "version": "13.4.19",
       "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
@@ -31084,6 +34855,14 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp": {
@@ -32445,6 +36224,15 @@
         "http-https": "^1.0.0"
       }
     },
+    "node_modules/observable-webworkers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-2.0.1.tgz",
+      "integrity": "sha512-JI1vB0u3pZjoQKOK1ROWzp0ygxSi7Yb0iR+7UNsw4/Zn4cQ0P3R7XL38zac/Dy2tEA7Lg88/wIJTjF8vYXZ0uw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
@@ -32579,6 +36367,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-event": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.0.tgz",
+      "integrity": "sha512-Xbfxd0CfZmHLGKXH32k1JKjQYX6Rkv0UtQdaFJ8OyNcf+c0oWCeXHc1C4CX/IESZLmcvfPa5aFIO/vCr5gqtag==",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-event/node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-fifo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
@@ -32683,6 +36496,29 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "dependencies": {
+        "@types/retry": "0.12.1",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/p-timeout": {
@@ -33362,6 +37198,55 @@
         "node": ">=8"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
+    },
+    "node_modules/playwright": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
+      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.38.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
+      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -33376,6 +37261,16 @@
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/polka": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/polka/-/polka-0.5.2.tgz",
+      "integrity": "sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^0.5.0",
+        "trouter": "^2.0.1"
       }
     },
     "node_modules/postcss": {
@@ -33558,6 +37453,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/private-ip": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.1.tgz",
+      "integrity": "sha512-Ezc16ANuhSHmWAE6lbXUKburNzGpR0J5X0Zh5Um/PZ/s57Fp+HYqYe6BYPH2QbqKr/5WebfzJQ1jq6Kj5dbRmA==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "ip-regex": "^5.0.0",
+        "ipaddr.js": "^2.1.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/private-ip/node_modules/ip-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/private-ip/node_modules/ipaddr.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/proc-log": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
@@ -33584,6 +37512,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
       "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
+    "node_modules/progress-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.0.tgz",
+      "integrity": "sha512-zIB6QDrSbPfRg+33FZalluFIowkbV5Xh1xSuetjG+rlC5he6u2dc6VQJ0TbMdlN3R1RHdpOqxEFMKTnQ+itUwA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/promise": {
       "version": "7.3.1",
@@ -33700,6 +37637,46 @@
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
       "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
       "dev": true
+    },
+    "node_modules/protons-runtime": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.2.tgz",
+      "integrity": "sha512-eKppVrIS5dDh+Y61Yj4bDEOs2sQLQbQGIhr7EBiybPQhIMGBynzVXlYILPWl3Td1GDadobc8qevh5D+JwfG9bw==",
+      "dependencies": {
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/protons-runtime/node_modules/protobufjs": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -33965,6 +37942,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/race-signal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.0.1.tgz",
+      "integrity": "sha512-a5un4dInIWoB7+76DieVE+Xv+wmyochKJ3P2GVs9dUKIzGuPyFR5iU3gEWJvztde/15fSOGkslbIsPxi+Loosw=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -33990,6 +37972,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/rate-limiter-flexible": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.2.tgz",
+      "integrity": "sha512-rMATGGOdO1suFyf/mI5LYhts71g1sbdhmd6YvdiXO2gJnd42Tt6QS4JUKJKSWVVkMtBacm6l40FR7Trjo6Iruw=="
     },
     "node_modules/raw-body": {
       "version": "2.5.2",
@@ -35689,6 +39676,14 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "node_modules/sass": {
       "version": "1.66.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.1.tgz",
@@ -35711,6 +39706,11 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.3.tgz",
       "integrity": "sha512-808ZFYMsIRAjLAu5xkKo0TsbY9LBy9H5MazTKIEHerNkg0ymgilGfBPMR/3G7d/ihGmuK2Hw8S1izY2d3kd3wA==",
       "devOptional": true
+    },
+    "node_modules/sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
     },
     "node_modules/sc-istanbul": {
       "version": "0.4.6",
@@ -36222,6 +40222,26 @@
       "dependencies": {
         "qs": "^6.3.0"
       }
+    },
+    "node_modules/sirv": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
+      "integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/sirv/node_modules/@polka/url": {
+      "version": "1.0.0-next.23",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
+      "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==",
+      "dev": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -36986,6 +41006,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
       }
     },
     "node_modules/stream-browserify": {
@@ -38135,6 +42165,159 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-ipfs-example": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/test-ipfs-example/-/test-ipfs-example-1.0.0.tgz",
+      "integrity": "sha512-B2HDNJvxStbVxdVI/1snfH4dMqCx+/HeJ83WOPgK3CGEafMkS4aZkuFFm5Zu2nIl9qwNFe55FZn5R8Naxnw+/w==",
+      "dev": true,
+      "dependencies": {
+        "@playwright/test": "^1.33.0",
+        "@types/polka": "^0.5.4",
+        "@types/stoppable": "^1.1.1",
+        "execa": "^7.1.1",
+        "polka": "^0.5.2",
+        "sirv": "^2.0.2",
+        "stoppable": "^1.1.0",
+        "uint8arrays": "^4.0.3"
+      },
+      "bin": {
+        "test-browser-example": "bin/test-browser-example.js",
+        "test-node-example": "bin/test-node-example.js"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
     "node_modules/text-encoding-utf-8": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
@@ -38306,6 +42489,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
     "node_modules/tildify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
@@ -38328,6 +42516,14 @@
       "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
       "dependencies": {
         "retimer": "^3.0.0"
+      }
+    },
+    "node_modules/timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
+      "engines": {
+        "node": ">= 4.5.0"
       }
     },
     "node_modules/tiny-invariant": {
@@ -38426,6 +42622,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -38491,6 +42696,26 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trouter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/trouter/-/trouter-2.0.1.tgz",
+      "integrity": "sha512-kr8SKKw94OI+xTGOkfsvwZQ8mWoikZDd2n8XZHjJVZUARZT+4/VV6cacRS6CLsH9bNm+HFIPU1Zx4CnNnb4qlQ==",
+      "dev": true,
+      "dependencies": {
+        "matchit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
       }
     },
     "node_modules/ts-command-line-args": {
@@ -39087,6 +43312,63 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uint8-varint": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.8.tgz",
+      "integrity": "sha512-QS03THS87Wlc0fBCC3xP5sqScDwfvVZLUrTCeMAQbQxQUWJosPC7C8uTNhpVUEgpTbV1Ut2Fer9Se3kI1KbnlQ==",
+      "dependencies": {
+        "byte-access": "^1.0.0",
+        "longbits": "^1.1.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/uint8-varint/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/uint8-varint/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
+      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
+      "dependencies": {
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
     "node_modules/uint8arrays": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
@@ -39580,6 +43862,11 @@
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -39717,6 +44004,23 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+    },
+    "node_modules/varint-decoder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-1.0.0.tgz",
+      "integrity": "sha512-JkOvdztASWGUAsXshCFHrB9f6AgR2Q8W08CEyJ+43b1qtFocmI8Sp1R/M0E/hDOY2FzVIqk63tOYLgDYWuJ7IQ==",
+      "dependencies": {
+        "varint": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0",
+        "npm": ">=3.0.0"
+      }
+    },
+    "node_modules/varint-decoder/node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -40595,6 +44899,18 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/wherearewe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
+      "dependencies": {
+        "is-electron": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -40948,6 +45264,26 @@
         "cookiejar": "^2.1.1"
       }
     },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -40965,6 +45301,11 @@
       "engines": {
         "node": ">=0.6.0"
       }
+    },
+    "node_modules/xsalsa20": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
+      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -41197,7 +45538,7 @@
     },
     "packages/builder": {
       "name": "@usecannon/builder",
-      "version": "2.7.1",
+      "version": "2.8.1",
       "license": "MIT",
       "dependencies": {
         "@synthetixio/router": "^3.3.0",
@@ -41230,7 +45571,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "ethers": ">=5.6.0"
+        "ethers": ">=5.6.0 < 6.0.0"
       }
     },
     "packages/builder/node_modules/@synthetixio/router": {
@@ -41290,12 +45631,12 @@
     },
     "packages/cli": {
       "name": "@usecannon/cli",
-      "version": "2.7.1",
+      "version": "2.8.1",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
         "@synthetixio/wei": "^2.74.1",
-        "@usecannon/builder": "^2.7.1",
+        "@usecannon/builder": "^2.8.1",
         "chalk": "^4.1.2",
         "commander": "^9.5.0",
         "debug": "^4.3.4",
@@ -41364,12 +45705,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/hardhat-cannon": {
-      "version": "2.7.1",
+      "version": "2.8.1",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
-        "@usecannon/builder": "^2.7.1",
-        "@usecannon/cli": "^2.7.1",
+        "@usecannon/builder": "^2.8.1",
+        "@usecannon/cli": "^2.8.1",
         "adm-zip": "^0.5.9",
         "chalk": "^4.1.2",
         "debug": "^4.3.3",
@@ -41751,6 +46092,30 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "packages/repo": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "helia": "^1.0.0"
+      },
+      "devDependencies": {
+        "test-ipfs-example": "^1.0.0",
+        "typescript": "^5.1.6"
+      }
+    },
+    "packages/repo/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/website": {
@@ -42244,6 +46609,126 @@
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA=="
     },
+    "@achingbrain/ip-address": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@achingbrain/ip-address/-/ip-address-8.1.0.tgz",
+      "integrity": "sha512-Zus4vMKVRDm+R1o0QJNhD0PD/8qRGO3Zx8YPsFG5lANt5utVtGg3iHVGBSAF80TfQmhi8rP+Kg/OigdxY0BXHw==",
+      "requires": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "dependencies": {
+        "jsbn": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+          "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        }
+      }
+    },
+    "@achingbrain/nat-port-mapper": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@achingbrain/nat-port-mapper/-/nat-port-mapper-1.0.11.tgz",
+      "integrity": "sha512-Y2lwx0zmrwEl+IGu+V/QiVBdcdsWscYq1PMMEjvyuuaXnmnppbLWilO8LK1yoLdncxwJBuS0zZtHbpFeWBusRg==",
+      "requires": {
+        "@achingbrain/ssdp": "^4.0.1",
+        "@libp2p/logger": "^3.0.0",
+        "default-gateway": "^7.2.2",
+        "err-code": "^3.0.1",
+        "it-first": "^3.0.1",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.1.1",
+        "xml2js": "^0.6.0"
+      },
+      "dependencies": {
+        "@libp2p/logger": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.3.tgz",
+          "integrity": "sha512-85ioPX10QN4ZOZeurAZe5sQeRUCkIBT2DikKRbE/AIWKauIKHvvIrN4CSdCdzLw29XNA+xxNO2FVkf51HGgCeQ==",
+          "requires": {
+            "@libp2p/interface": "^0.1.3",
+            "@multiformats/multiaddr": "^12.1.5",
+            "debug": "^4.3.4",
+            "interface-datastore": "^8.2.0",
+            "multiformats": "^12.0.1"
+          }
+        },
+        "interface-datastore": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+          "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "it-first": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+          "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        },
+        "p-timeout": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+          "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
+    "@achingbrain/ssdp": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@achingbrain/ssdp/-/ssdp-4.0.4.tgz",
+      "integrity": "sha512-fY/ShiYJmhLdr45Vn2+f88xTqZjBSH3X3F+EJu/89cjB1JIkMCVtD5CQaaS38YknIL8cEcNhjMZM4cdE3ckSSQ==",
+      "requires": {
+        "event-iterator": "^2.0.0",
+        "freeport-promise": "^2.0.0",
+        "merge-options": "^3.0.4",
+        "xml2js": "^0.5.0"
+      },
+      "dependencies": {
+        "xml2js": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+          "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~11.0.0"
+          }
+        }
+      }
+    },
     "@adraffy/ens-normalize": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
@@ -42396,6 +46881,12 @@
       "requires": {
         "node-fetch": "^2.6.1"
       }
+    },
+    "@arr/every": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@arr/every/-/every-1.0.1.tgz",
+      "integrity": "sha512-UQFQ6SgyJ6LX42W8rHCs8KVc0JS0tzVL9ct4XYedJukskYVWTo49tNiMEK9C2HTyarbNiT/RVIRSY82vH+6sTg==",
+      "dev": true
     },
     "@babel/cli": {
       "version": "7.22.15",
@@ -43752,6 +48243,140 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
       "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg=="
+    },
+    "@chainsafe/is-ip": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.2.tgz",
+      "integrity": "sha512-ndGqEMG1W5WkGagaqOZHpPU172AGdxr+LD15sv3WIUvT5oCFUrG1Y0CW/v2Egwj4JXEvSibaIIIqImsm98y1nA=="
+    },
+    "@chainsafe/libp2p-gossipsub": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-8.0.1.tgz",
+      "integrity": "sha512-vzRN7F1zLd/DKfK9VLQ7rrc/lYQFvE/RGnXjr+EanD2RoX+BjSdqZkvzcrJcaDzkCMJRCvpsFzgz2iLbV7SgYg==",
+      "requires": {
+        "@libp2p/crypto": "^1.0.3",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-connection-manager": "^3.0.1",
+        "@libp2p/interface-keys": "^1.0.3",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-store": "^2.0.3",
+        "@libp2p/interface-pubsub": "^4.0.0",
+        "@libp2p/interface-registrar": "^2.0.3",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@libp2p/pubsub": "^7.0.1",
+        "@libp2p/topology": "^4.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "abortable-iterator": "^5.0.1",
+        "denque": "^1.5.0",
+        "it-length-prefixed": "^9.0.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.0",
+        "multiformats": "^11.0.0",
+        "protobufjs": "^6.11.2",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
+      }
+    },
+    "@chainsafe/libp2p-noise": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-12.0.2.tgz",
+      "integrity": "sha512-bKlasdYJBXsCgcOw+gNNnpvNo3jD8BiSRpKrhYxEmBPQzesme15PBrj5Cx369PZEk4SvKSHS6dzL4oLxXqPSLw==",
+      "requires": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-connection-encrypter": "^4.0.0",
+        "@libp2p/interface-keys": "^1.0.6",
+        "@libp2p/interface-metrics": "^4.0.4",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
+        "@noble/ciphers": "^0.1.4",
+        "@noble/curves": "^1.1.0",
+        "@noble/hashes": "^1.3.1",
+        "it-length-prefixed": "^9.0.1",
+        "it-pair": "^2.0.2",
+        "it-pb-stream": "^4.0.1",
+        "it-pipe": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
+    "@chainsafe/libp2p-yamux": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-yamux/-/libp2p-yamux-4.0.2.tgz",
+      "integrity": "sha512-p0m/4ab4JLaIQqUtxvm8bSqdt9sb0uXX8PFj1CQM1eJLeV1LxzzygaSOeLxN/5ckHCuK7q/9eb9xybvl6vz/JA==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.1.0",
+        "@libp2p/interface-stream-muxer": "^4.1.2",
+        "@libp2p/interfaces": "^3.3.2",
+        "@libp2p/logger": "^2.0.7",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.3",
+        "uint8arraylist": "^2.4.3"
+      },
+      "dependencies": {
+        "any-signal": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+          "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA=="
+        }
+      }
+    },
+    "@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "requires": {
+        "@chainsafe/is-ip": "^2.0.1"
+      }
     },
     "@chainsafe/persistent-merkle-tree": {
       "version": "0.4.2",
@@ -46602,6 +51227,63 @@
       "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
       "requires": {}
     },
+    "@helia/interface": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@helia/interface/-/interface-1.2.2.tgz",
+      "integrity": "sha512-Eij8ATmzNTvMnUdfvPZP/6aZ7k+xAXN/LYcgXqJpVV3DDJYA/NnZZ3Ay9bIauoFIuhoDm2C6VjnW3HzmRDBY9Q==",
+      "requires": {
+        "@libp2p/interface-libp2p": "^3.2.0",
+        "@libp2p/interfaces": "^3.3.2",
+        "interface-blockstore": "^5.0.0",
+        "interface-datastore": "^8.0.0",
+        "interface-store": "^5.0.1",
+        "ipfs-bitswap": "^18.0.0",
+        "multiformats": "^11.0.1",
+        "progress-events": "^1.0.0"
+      },
+      "dependencies": {
+        "interface-datastore": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+          "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -47107,6 +51789,11 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.2.tgz",
       "integrity": "sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A=="
     },
+    "@leichtgewicht/ip-codec": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
     "@lerna/child-process": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-7.2.0.tgz",
@@ -47559,6 +52246,1246 @@
         "npmlog": "^6.0.2"
       }
     },
+    "@libp2p/bootstrap": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-8.0.0.tgz",
+      "integrity": "sha512-xbaJ+ybx1FGsi8FeGl9g1Wk6P2zf5/Thdk9Fe1qXV0O0xIW0xRWrefOYG5Dvt+BV54C/zlnQ4CG+Xs+Rr7wsbA==",
+      "requires": {
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.7",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.1",
+        "@libp2p/peer-id": "^2.0.0",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "@libp2p/crypto": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.17.tgz",
+      "integrity": "sha512-Oeg0Eb/EvAho0gVkOgemXEgrVxWaT3x/DpFgkBdZ9qGxwq75w/E/oPc7souqBz+l1swfz37GWnwV7bIb4Xv5Ag==",
+      "requires": {
+        "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interfaces": "^3.2.0",
+        "@noble/ed25519": "^1.6.0",
+        "@noble/secp256k1": "^1.5.4",
+        "multiformats": "^11.0.0",
+        "node-forge": "^1.1.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
+      }
+    },
+    "@libp2p/interface": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.3.tgz",
+      "integrity": "sha512-C1O7Xqd2TGVWrIOEDx6kGJSk4YOysWGmYG5Oh3chnsCY0wjUSsLDpl9+wKrdiM/lJbAlHlV65ZOvSkIQ9cWPBQ==",
+      "requires": {
+        "@multiformats/multiaddr": "^12.1.5",
+        "abortable-iterator": "^5.0.1",
+        "it-pushable": "^3.2.0",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "race-signal": "^1.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        }
+      }
+    },
+    "@libp2p/interface-address-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-address-manager/-/interface-address-manager-3.0.1.tgz",
+      "integrity": "sha512-8N1nfOtZ/CnZ/cL0Bnj59fhcSs7orI4evmNVsv2DM1VaNHXqc9tPy8JmQE2HRjrUXeUPwtzzG2eoP7l0ZYdC0g==",
+      "requires": {
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "@libp2p/interface-connection": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-5.1.1.tgz",
+      "integrity": "sha512-ytknMbuuNW72LYMmTP7wFGP5ZTaUSGBCmV9f+uQ55XPcFHtKXLtKWVU/HE8IqPmwtyU8AO7veGoJ/qStMHNRVA==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.3"
+      }
+    },
+    "@libp2p/interface-connection-encrypter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-4.0.1.tgz",
+      "integrity": "sha512-fOtZpaFL2f5vID/RaBpVMAR9OKx5DmDT/yMEFTCarNc6Bb37fWwClI4WNCtoVbDQwcnr4H4ZIo0+9yCxjEIjjQ==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      }
+    },
+    "@libp2p/interface-connection-gater": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-gater/-/interface-connection-gater-3.0.1.tgz",
+      "integrity": "sha512-3a+EmcKFIdYVM6tmmIKZt/4fREPApA/Z/PZHOEa4lqJA9c/BHO1HTq0YzEoYsptudYTcdhQLgpYzh8FVhfZGDg==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "@libp2p/interface-connection-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-3.0.1.tgz",
+      "integrity": "sha512-7ZAvzOWfHs3BtaoZoWsT+Ks1bo6HjyRMq1SJdFWDJ+ZkYEzrf6sdtQwsX8eXhwRDO6PuzpUDqLZ9TNQ2GVKEEw==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@libp2p/peer-collections": "^3.0.1",
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "@libp2p/interface-content-routing": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.1.1.tgz",
+      "integrity": "sha512-nRPOUWgq1K1fDr3FKW93Tip7aH8AFefCw3nJygL4crepxWTSGw95s1GyDpC7t0RJkWTRNHsqZvsFsJ9FkHExKw==",
+      "requires": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
+      }
+    },
+    "@libp2p/interface-dht": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-dht/-/interface-dht-2.0.3.tgz",
+      "integrity": "sha512-JAKbHvw3egaSeB7CHOf6PF/dLNim4kzAiXX+0IEz2lln8L32/Xf1T7KNOF/RSbSYqO9b7Xxc/b2fuSfyaMwwMQ==",
+      "requires": {
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
+      }
+    },
+    "@libp2p/interface-keychain": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.5.tgz",
+      "integrity": "sha512-mb7QNgn9fIvC7CaJCi06GJ+a6DN6RVT9TmEi0NmedZGATeCArPeWWG7r7IfxNVXb9cVOOE1RzV1swK0ZxEJF9Q==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
+      }
+    },
+    "@libp2p/interface-keys": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.8.tgz",
+      "integrity": "sha512-CJ1SlrwuoHMquhEEWS77E+4vv7hwB7XORkqzGQrPQmA9MRdIEZRS64bA4JqCLUDa4ltH0l+U1vp0oZHLT67NEA=="
+    },
+    "@libp2p/interface-libp2p": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-libp2p/-/interface-libp2p-3.2.0.tgz",
+      "integrity": "sha512-Vow6xNdjpQ0M/Kt3EDz1qE/Os5OZUyhFt0YTPU5Fp3/kXw/6ocsxYq/Bzird/96gjUjU5/i+Vukn4WgctJf55Q==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-content-routing": "^2.0.0",
+        "@libp2p/interface-keychain": "^2.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interface-peer-routing": "^1.0.0",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interface-registrar": "^2.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "@libp2p/interface-metrics": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.8.tgz",
+      "integrity": "sha512-1b9HjYyJH0m35kvPHipuoz2EtYCxyq34NUhuV8VK1VNtrouMpA3uCKp5FI7yHCA6V6+ux1R3UriKgNFOSGbIXQ==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0"
+      }
+    },
+    "@libp2p/interface-peer-discovery": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-discovery/-/interface-peer-discovery-2.0.0.tgz",
+      "integrity": "sha512-Mien5t3Tc+ntP5p50acKUYJN90ouMnq1lOTQDKQNvGcXoajG8A1AEYLocnzVia/MXiexuj6S/Q28WBBacoOlBg==",
+      "requires": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
+      }
+    },
+    "@libp2p/interface-peer-id": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "requires": {
+        "multiformats": "^11.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
+      }
+    },
+    "@libp2p/interface-peer-info": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.10.tgz",
+      "integrity": "sha512-HQlo8NwQjMyamCHJrnILEZz+YwEOXCB2sIIw3slIrhVUYeYlTaia1R6d9umaAeLHa255Zmdm4qGH8rJLRqhCcg==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "@libp2p/interface-peer-routing": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.1.1.tgz",
+      "integrity": "sha512-/XEhwob9qXjdmI8PBcc+qFin32xmtyoC58nRpq8RliqHY5uOVWiHfZoNtdOXIsNvzVvq5FqlHOWt71ofxXTtlg==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
+      }
+    },
+    "@libp2p/interface-peer-store": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-2.0.4.tgz",
+      "integrity": "sha512-jNvBK3O1JPJqSiDN2vkb+PV8bTPnYdP54nxsLtut1BWukNm610lwzwleV7CetFI4bJCn6g+BgBvvq8fdADy0tA==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "@libp2p/interface-pubsub": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-4.0.1.tgz",
+      "integrity": "sha512-PIc5V/J98Yr1ZTHh8lQshP7GdVUh+pKNIqj6wGaDmXs8oQLB40qKCjcpHQNlAnv2e1Bh9mEH2GXv5sGZOA651A==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-pushable": "^3.1.3",
+        "uint8arraylist": "^2.4.3"
+      }
+    },
+    "@libp2p/interface-record": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.7.tgz",
+      "integrity": "sha512-AFPytZWI+p8FJWP0xuK5zbSjalLAOIMzEed2lBKdRWvdGBQUHt9ENLTkfkI9G7p/Pp3hlhVzzBXdIErKd+0GxQ==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "uint8arraylist": "^2.4.3"
+      }
+    },
+    "@libp2p/interface-registrar": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.12.tgz",
+      "integrity": "sha512-EyCi2bycC2rn3oPB4Swr7EqBsvcaWd6RcqR6zsImNIG9BKc4/R1gl6iaF861JaELYgYmzBMS31x1rQpVz5UekQ==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0"
+      }
+    },
+    "@libp2p/interface-stream-muxer": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-4.1.2.tgz",
+      "integrity": "sha512-dQJcn67UaAa8YQFRJDhbo4uT453z/2lCzD/ZwTk1YOqJxATXbXgVcB8dXDQFEUiUX3ZjVQ1IBu+NlQd+IZ++zw==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@libp2p/logger": "^2.0.7",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "it-pushable": "^3.1.3",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.3"
+      },
+      "dependencies": {
+        "any-signal": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+          "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA=="
+        }
+      }
+    },
+    "@libp2p/interface-transport": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-4.0.3.tgz",
+      "integrity": "sha512-jXFQ3blhFMEyQbFw/U8Glo3F/fUO5LEaX5HIdeqNpCliK+XnwTfpkcaG+WsJrcApWK4FFyUHc+GGqiWR0hAFFg==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-stream-muxer": "^4.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^2.0.1"
+      }
+    },
+    "@libp2p/interfaces": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.2.tgz",
+      "integrity": "sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g=="
+    },
+    "@libp2p/ipni-content-routing": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/ipni-content-routing/-/ipni-content-routing-1.0.2.tgz",
+      "integrity": "sha512-ilsHyPSn4pJl2daAe4duhE/v5pGtqUvY0na3oso3/LBK8q74dCIxAYIho5zdL0Bxj+2E5yj4tL83wfx/B/dxmA==",
+      "requires": {
+        "@libp2p/interface-content-routing": "^2.0.2",
+        "@libp2p/interface-peer-info": "^1.0.9",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-id": "^2.0.3",
+        "@multiformats/multiaddr": "^12.1.2",
+        "any-signal": "^4.1.1",
+        "browser-readablestream-to-it": "^2.0.2",
+        "iterable-ndjson": "^1.1.0",
+        "multiformats": "^11.0.2",
+        "p-defer": "^4.0.0",
+        "p-queue": "^7.3.4"
+      },
+      "dependencies": {
+        "any-signal": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+          "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA=="
+        },
+        "browser-readablestream-to-it": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.4.tgz",
+          "integrity": "sha512-EOjEEA+tJInvKg/Pml6QYxVY6gD8lka/ceLmkUbEeuWlzZx/a5k5ugupVFUUKSfI/88+v0VFs7JSFi5iYpp3IA=="
+        },
+        "eventemitter3": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        },
+        "p-queue": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+          "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+          "requires": {
+            "eventemitter3": "^5.0.1",
+            "p-timeout": "^5.0.2"
+          }
+        },
+        "p-timeout": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+          "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
+        }
+      }
+    },
+    "@libp2p/kad-dht": {
+      "version": "9.3.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-9.3.8.tgz",
+      "integrity": "sha512-vxYp8k6BKdlVexanH0qY3swyN3b9YqUmirdEz+SrbWtFpkqrebIfcuE/P0Hef4qfvF6I3osk4D+GtCDyl+IRhQ==",
+      "requires": {
+        "@libp2p/crypto": "^1.0.4",
+        "@libp2p/interface-address-manager": "^3.0.0",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-connection-manager": "^3.0.0",
+        "@libp2p/interface-content-routing": "^2.1.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-routing": "^1.1.0",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interface-registrar": "^2.0.11",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.1",
+        "@libp2p/peer-collections": "^3.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/record": "^3.0.0",
+        "@libp2p/topology": "^4.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@types/sinon": "^10.0.14",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "datastore-core": "^9.0.1",
+        "events": "^3.3.0",
+        "hashlru": "^2.3.0",
+        "interface-datastore": "^8.0.0",
+        "it-all": "^3.0.1",
+        "it-drain": "^3.0.1",
+        "it-first": "^3.0.1",
+        "it-length": "^3.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-map": "^3.0.1",
+        "it-merge": "^3.0.0",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^3.0.0",
+        "it-stream-types": "^2.0.1",
+        "it-take": "^3.0.1",
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "p-event": "^6.0.0",
+        "p-queue": "^7.3.4",
+        "private-ip": "^3.0.0",
+        "progress-events": "^1.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "any-signal": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+          "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA=="
+        },
+        "eventemitter3": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+        },
+        "interface-datastore": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+          "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "it-all": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+          "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+        },
+        "it-first": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+          "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+        },
+        "it-map": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+          "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+          "requires": {
+            "it-peekable": "^3.0.0"
+          }
+        },
+        "it-peekable": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+          "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        },
+        "p-queue": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+          "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+          "requires": {
+            "eventemitter3": "^5.0.1",
+            "p-timeout": "^5.0.2"
+          }
+        },
+        "p-timeout": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+          "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
+    "@libp2p/keychain": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-2.0.1.tgz",
+      "integrity": "sha512-A59jilLYS+8Paq38Z96uSAxbD+3+3LJZx2qcHdMpTyqDO7yfJCbMPfVhP6EKmH5EY3z3qxBwUPVw35P4F4fslg==",
+      "requires": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-keychain": "^2.0.3",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.1",
+        "interface-datastore": "^8.0.0",
+        "merge-options": "^3.0.4",
+        "sanitize-filename": "^1.6.3",
+        "uint8arrays": "^4.0.3"
+      },
+      "dependencies": {
+        "interface-datastore": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+          "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
+    "@libp2p/logger": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.1.1.tgz",
+      "integrity": "sha512-2UbzDPctg3cPupF6jrv6abQnAUTrbLybNOj0rmmrdGm1cN2HJ1o/hBu0sXuq4KF9P1h/eVRn1HIRbVIEKnEJrA==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.2",
+        "@multiformats/multiaddr": "^12.1.3",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^11.0.2"
+      },
+      "dependencies": {
+        "interface-datastore": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+          "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
+      }
+    },
+    "@libp2p/mdns": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/mdns/-/mdns-8.0.0.tgz",
+      "integrity": "sha512-/q2qDWGzZpv2/LmvlwsImoEwjOhmaO9H7HDFloEs2D1+rT0dRFuQpXHAm7/sCLwx9PtmSUZp/sNj0ppnGGwK5A==",
+      "requires": {
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.8",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.1",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@types/multicast-dns": "^7.2.1",
+        "dns-packet": "^5.4.0",
+        "multicast-dns": "^7.2.5"
+      }
+    },
+    "@libp2p/mplex": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-8.0.4.tgz",
+      "integrity": "sha512-or3F5sGl8cw3TbnQgmkJ8z7/c97rwuzoy6f3b9gmkEVN8EzdxG2jOq+TEsgXzLz1GekRUR8nuDhliJ3UPhUnFw==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-stream-muxer": "^4.1.2",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "abortable-iterator": "^5.0.0",
+        "any-signal": "^4.0.1",
+        "benchmark": "^2.1.4",
+        "it-batched-bytes": "^2.0.2",
+        "it-pushable": "^3.1.0",
+        "it-stream-types": "^2.0.1",
+        "rate-limiter-flexible": "^2.3.9",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "any-signal": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+          "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA=="
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
+    "@libp2p/multistream-select": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-3.1.9.tgz",
+      "integrity": "sha512-iSNqr8jXvOrkNTyA43h/ARs4wd0Rd55/D6oFRndLcV4yQSUMmfjl7dUcbC5MAw+5/sgskfDx9TMawSwNq47Qwg==",
+      "requires": {
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "abortable-iterator": "^5.0.0",
+        "it-first": "^3.0.1",
+        "it-handshake": "^4.1.3",
+        "it-length-prefixed": "^9.0.0",
+        "it-merge": "^3.0.0",
+        "it-pipe": "^3.0.0",
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.3.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "it-first": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+          "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
+    "@libp2p/peer-collections": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-3.0.2.tgz",
+      "integrity": "sha512-3vRVMWVRCF6dVs/1/CHbw4YSv83bcqjZuAt9ZQHW85vn6OfHNFQesOHWT1TbRBuL8TSb//IwJkOfTAVLd6Mymw==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0"
+      }
+    },
+    "@libp2p/peer-id": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.4.tgz",
+      "integrity": "sha512-gcOsN8Fbhj6izIK+ejiWsqiqKeJ2yWPapi/m55VjOvDa52/ptQzZszxQP8jUk93u36de92ATFXDfZR/Bi6eeUQ==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
+      }
+    },
+    "@libp2p/peer-id-factory": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.4.tgz",
+      "integrity": "sha512-+0D+oklFzHpjRI3v7uw3PMMx00P36DV7YvAgL0+gpos0VzR/BI9tRiM6dpObZTrQ1hxp78F03p+qR1Zy9Qnmuw==",
+      "requires": {
+        "@libp2p/crypto": "^1.0.0",
+        "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
+      }
+    },
+    "@libp2p/peer-record": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.4.tgz",
+      "integrity": "sha512-e+AArf7pwMLqF24mehTe1OYjr1v0SOKshVrI1E9YH/Cb1F3ZZuK3smyGmnLaS4JlqsarRCMSe3V50tRkqMFY7g==",
+      "requires": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-record": "^2.0.1",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/utils": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^1.0.2",
+        "uint8arraylist": "^2.1.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
+    "@libp2p/peer-store": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-8.2.1.tgz",
+      "integrity": "sha512-mr0GsZ7zucta3l5EblOGrBeVgdTVujRJ9WC+FmnYErQe023SRJevAZEv1WeMinMGVGL6CY+gmWw0oLpExu9AWg==",
+      "requires": {
+        "@libp2p/interface-libp2p": "^3.1.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-store": "^2.0.4",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-collections": "^3.0.1",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-id-factory": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.3",
+        "@multiformats/multiaddr": "^12.0.0",
+        "interface-datastore": "^8.0.0",
+        "it-all": "^3.0.2",
+        "mortice": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "interface-datastore": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+          "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "it-all": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+          "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
+      }
+    },
+    "@libp2p/pubsub": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-7.0.3.tgz",
+      "integrity": "sha512-BrUBQ6ljN1tU+2Hn1Vq+ZT/foVBGUVIywqoavNrFw5CmaBBTGuVRrmqE/MUToIS8dhonpW5RNCRabz3woq/4iQ==",
+      "requires": {
+        "@libp2p/crypto": "^1.0.0",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interface-pubsub": "^4.0.0",
+        "@libp2p/interface-registrar": "^2.0.11",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-collections": "^3.0.1",
+        "@libp2p/peer-id": "^2.0.3",
+        "@libp2p/topology": "^4.0.1",
+        "abortable-iterator": "^5.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.3",
+        "multiformats": "^11.0.0",
+        "p-queue": "^7.2.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "p-queue": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+          "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+          "requires": {
+            "eventemitter3": "^5.0.1",
+            "p-timeout": "^5.0.2"
+          }
+        },
+        "p-timeout": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+          "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
+      }
+    },
+    "@libp2p/record": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/record/-/record-3.0.4.tgz",
+      "integrity": "sha512-cVefFlnlvuxkLwPnHvSDF05HT6PyBM33eBi0BtJ7ocbZTtN4hY44DNmkM0z3ht9/9blSQ9e12gXV6nePH4Q4AA==",
+      "requires": {
+        "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
+      }
+    },
+    "@libp2p/tcp": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-7.0.3.tgz",
+      "integrity": "sha512-w1g5/BYDNpZKXrJZd1PW8kUS0GxHwFO6oql3rIizh5WaxmWtMa21LtKWIoHJyC8Wp4vshEUPeZthAIKECqUafg==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/utils": "^3.0.2",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@types/sinon": "^10.0.15",
+        "stream-to-it": "^0.2.2"
+      }
+    },
+    "@libp2p/topology": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/topology/-/topology-4.0.3.tgz",
+      "integrity": "sha512-uXd9ZYpmgb+onMTypsAPUlvKKeY20HMtxwsjAMEfDa29yqshK8DiEunHZNjLmtXaMIIO9CBl2w5ykjt5TtFsBQ==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-registrar": "^2.0.3"
+      }
+    },
+    "@libp2p/tracked-map": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-3.0.4.tgz",
+      "integrity": "sha512-G5ElrjFoubP10TwQo3dnRVaxhshU9wtu86qq0cIXNv12XCFpvTvx12Vbf8sV1SU5imrWgd6XQgfRKsQtjmu3Ew==",
+      "requires": {
+        "@libp2p/interface-metrics": "^4.0.0"
+      }
+    },
+    "@libp2p/utils": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.13.tgz",
+      "integrity": "sha512-SNwIcQq/FvLpqVsjHHzbxSq7VgbbUK9EB7/865Re4NoLfqgE/6oTUpyPEDlrcJb4aTPFWbVPQzE85cA3raHIIw==",
+      "requires": {
+        "@achingbrain/ip-address": "^8.1.0",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "abortable-iterator": "^5.0.0",
+        "is-loopback-addr": "^2.0.1",
+        "it-stream-types": "^2.0.1",
+        "private-ip": "^3.0.0",
+        "uint8arraylist": "^2.3.2"
+      }
+    },
+    "@libp2p/webrtc": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/webrtc/-/webrtc-2.0.11.tgz",
+      "integrity": "sha512-6lhlndCYxRrkbqldUFruxIzyyFcrgnyueYIpLXJP2phZf2P19zwhborae0raRyeRz7MwJ+uw+Ksql8D8Ry+KXg==",
+      "requires": {
+        "@chainsafe/libp2p-noise": "^12.0.0",
+        "@libp2p/interface-connection": "^5.0.2",
+        "@libp2p/interface-metrics": "^4.0.8",
+        "@libp2p/interface-peer-id": "^2.0.2",
+        "@libp2p/interface-registrar": "^2.0.12",
+        "@libp2p/interface-stream-muxer": "^4.1.2",
+        "@libp2p/interface-transport": "^4.0.3",
+        "@libp2p/interfaces": "^3.3.2",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-id": "^2.0.3",
+        "@multiformats/mafmt": "^12.1.2",
+        "@multiformats/multiaddr": "^12.1.2",
+        "abortable-iterator": "^5.0.1",
+        "detect-browser": "^5.3.0",
+        "it-length-prefixed": "^9.0.1",
+        "it-pb-stream": "^4.0.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.3",
+        "it-stream-types": "^2.0.1",
+        "it-to-buffer": "^4.0.2",
+        "multiformats": "^11.0.2",
+        "multihashes": "^4.0.3",
+        "p-defer": "^4.0.0",
+        "p-event": "^6.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.3"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
+          "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
+          "requires": {
+            "@multiformats/base-x": "^4.0.1"
+          }
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "multihashes": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
+          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
+          "requires": {
+            "multibase": "^4.0.1",
+            "uint8arrays": "^3.0.0",
+            "varint": "^5.0.2"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "9.9.0",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+              "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+            },
+            "uint8arrays": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+              "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+              "requires": {
+                "multiformats": "^9.4.2"
+              }
+            }
+          }
+        },
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        },
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
+      }
+    },
+    "@libp2p/websockets": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-6.0.3.tgz",
+      "integrity": "sha512-pwOr3iAbczWmmCg1nHnC2Dl0Ek81Y6LE8ptImiUbuZ08q1E/fTumM8pRNmrrsogSshG4lugebArIO9SNMylJZg==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/utils": "^3.0.2",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@multiformats/multiaddr-to-uri": "^9.0.2",
+        "@types/ws": "^8.5.4",
+        "abortable-iterator": "^5.0.0",
+        "it-ws": "^6.0.0",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.0.0",
+        "wherearewe": "^2.0.1",
+        "ws": "^8.12.1"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        },
+        "p-timeout": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+          "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ=="
+        },
+        "ws": {
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+          "requires": {}
+        }
+      }
+    },
+    "@libp2p/webtransport": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/webtransport/-/webtransport-2.0.2.tgz",
+      "integrity": "sha512-Vok9j2WT6tF7dlDdbDV3EfenTsGLim1icrR6HqSzTRZAZn7uOBtMKKoO2YnXgGyHmnstqxLt0axnZWc2v5uKNQ==",
+      "requires": {
+        "@chainsafe/libp2p-noise": "^12.0.1",
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-stream-muxer": "^4.0.0",
+        "@libp2p/interface-transport": "^4.0.1",
+        "@libp2p/logger": "^2.0.2",
+        "@libp2p/peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.1.0",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arraylist": "^2.3.3"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
+      }
+    },
     "@lit-labs/ssr-dom-shim": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
@@ -47782,6 +53709,82 @@
         "tslib": "^2.3.1"
       }
     },
+    "@multiformats/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
+    "@multiformats/mafmt": {
+      "version": "12.1.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.6.tgz",
+      "integrity": "sha512-tlJRfL21X+AKn9b5i5VnaTD6bNttpSpcqwKVmDmSHLwxoz97fAHaepqFOk/l1fIu94nImIXneNbhsJx/RQNIww==",
+      "requires": {
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "@multiformats/multiaddr": {
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
+      "requires": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^0.1.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^12.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "dns-over-http-resolver": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.2.tgz",
+          "integrity": "sha512-Bjbf6aZjr3HMnwGslZnoW3MJVqgbTsh39EZWpikx2yLl9xEjw4eZhlOHCFhkOu89zoWaS4rqe2Go53TXW4Byiw==",
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "native-fetch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
+          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
+          "requires": {}
+        },
+        "uint8-varint": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
+          "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+          "requires": {
+            "uint8arraylist": "^2.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
+    "@multiformats/multiaddr-to-uri": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.7.tgz",
+      "integrity": "sha512-i3ldtPMN6XJt+MCi34hOl0wGuGEHfWWMw6lmNag5BpckPwPTf9XGOOFMmh7ed/uO3Vjah/g173iOe61HTQVoBA==",
+      "requires": {
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
     "@next/env": {
       "version": "13.4.19",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
@@ -47885,6 +53888,11 @@
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "optional": true
     },
+    "@noble/ciphers": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.1.4.tgz",
+      "integrity": "sha512-d3ZR8vGSpy3v/nllS+bD/OMN5UZqusWiQqkyj7AwzTnhXFH72pF5oB4Ach6DQ50g5kXxC28LdaYBEpsyv9KOUQ=="
+    },
     "@noble/curves": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
@@ -47899,6 +53907,11 @@
           "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
         }
       }
+    },
+    "@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ=="
     },
     "@noble/hashes": {
       "version": "1.3.0",
@@ -49026,6 +55039,21 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
       "optional": true
+    },
+    "@playwright/test": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
+      "integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.38.1"
+      }
+    },
+    "@polka/url": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-0.5.0.tgz",
+      "integrity": "sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw==",
+      "dev": true
     },
     "@popperjs/core": {
       "version": "2.11.8",
@@ -51461,6 +57489,16 @@
         "@types/node": "*"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz",
+      "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -51516,6 +57554,14 @@
       "integrity": "sha512-amrLbRqTU9bXMCc6uX0sWpxsQzRIo9z6MJPkH1pkez/qOxuqSZVuryJAWoBRq94CeG8JxY+VK4Le9HtjQR5T9A==",
       "dev": true
     },
+    "@types/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-F8X3srlDYXQSVGfjAWl0lxd9mGfYtkneMA0QFQ3BFBw/BUmBlhlAbpRjmvE7LbW3wIxf01KHi20/bPstYK6ssA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint": {
       "version": "8.44.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
@@ -51547,6 +57593,30 @@
       "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
       "requires": {
         "@types/estree": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.18.tgz",
+      "integrity": "sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.37",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz",
+      "integrity": "sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "@types/form-data": {
@@ -51606,6 +57676,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "@types/http-errors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.2.tgz",
+      "integrity": "sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -51722,6 +57798,12 @@
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.7.tgz",
       "integrity": "sha512-BG4tyr+4amr3WsSEmHn/fXPqaCba/AYZ7dsaQTiavihQunHSIxk+uAtqsjvicNpyHN6cm+B9RVrUOtW9VzIKHw=="
     },
+    "@types/mime": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
+      "integrity": "sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -51742,6 +57824,15 @@
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+    },
+    "@types/multicast-dns": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.2.tgz",
+      "integrity": "sha512-re0wpYJU2SdKkBbmCh7f5zYMLFA/FCbX46DI0rRMLlkkDqhk+0bTHbYsUVZumk/43GfJehPImK9e202eSuxPKA==",
+      "requires": {
+        "@types/dns-packet": "*",
+        "@types/node": "*"
+      }
     },
     "@types/node": {
       "version": "20.5.4",
@@ -51778,6 +57869,18 @@
         "@types/node": "*"
       }
     },
+    "@types/polka": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/polka/-/polka-0.5.5.tgz",
+      "integrity": "sha512-70m2zRjRQRhG9tA0Ni0kYW9xn7pD5PhF39N7ATzyX5U7x6Yz1oHN1r2h41n+K9NMq2a3cFnnce6qQrnRAoNiiw==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/node": "*",
+        "@types/trouter": "*"
+      }
+    },
     "@types/prettier": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
@@ -51809,6 +57912,12 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "@types/range-parser": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
+      "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==",
+      "dev": true
     },
     "@types/react": {
       "version": "18.2.14",
@@ -51884,6 +57993,11 @@
         "@types/node": "*"
       }
     },
+    "@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
     "@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
@@ -51903,11 +58017,31 @@
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
+    "@types/send": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.2.tgz",
+      "integrity": "sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.3.tgz",
+      "integrity": "sha512-yVRvFsEMrv7s0lGhzrggJjNOSmZCdgCjw9xWrPr/kNNLp6FaDfMC1KaYl3TSJ0c58bECwNBMoQrZJ8hA8E1eFg==",
+      "dev": true,
+      "requires": {
+        "@types/http-errors": "*",
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/sinon": {
       "version": "10.0.16",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.16.tgz",
       "integrity": "sha512-j2Du5SYpXZjJVJtXBokASpPRj+e2z+VUhCPHmM6WMfe3dpHu6iVKJMU6AiBcMp/XTAYnEj6Wc1trJUWwZ0QaAQ==",
-      "dev": true,
       "requires": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -51915,8 +58049,7 @@
     "@types/sinonjs__fake-timers": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
-      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
-      "dev": true
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA=="
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -51924,10 +58057,25 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "@types/stoppable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/stoppable/-/stoppable-1.1.1.tgz",
+      "integrity": "sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw=="
+    },
+    "@types/trouter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/trouter/-/trouter-3.1.2.tgz",
+      "integrity": "sha512-Q2xKmIsi311ihqTa7vmbp7k3osjQkG7KRcm43omWr42w5Za/BNMwACatUrD7I8XHkRozUCI13thEJLrUz7N0xw==",
+      "dev": true
     },
     "@types/trusted-types": {
       "version": "2.0.3",
@@ -52226,7 +58374,7 @@
         "@types/prompts": "^2.0.14",
         "@types/semver": "^7.3.12",
         "@types/sinon": "^10.0.15",
-        "@usecannon/builder": "^2.7.1",
+        "@usecannon/builder": "^2.8.1",
         "axios": "^1.3.3",
         "chalk": "^4.1.2",
         "commander": "^9.5.0",
@@ -52270,6 +58418,22 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "@usecannon/repo": {
+      "version": "file:packages/repo",
+      "requires": {
+        "helia": "^1.0.0",
+        "test-ipfs-example": "^1.0.0",
+        "typescript": "^5.1.6"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true
         }
       }
     },
@@ -52321,6 +58485,11 @@
       "resolved": "https://registry.npmjs.org/@vanilla-extract/sprinkles/-/sprinkles-1.5.0.tgz",
       "integrity": "sha512-W58f2Rzz5lLmk0jbhgStVlZl5wEiPB1Ur3fRvUaBM+MrifZ3qskmFq/CiH//fEYeG5Dh9vF1qRviMMH46cX9Nw==",
       "requires": {}
+    },
+    "@vascosantos/moving-average": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/moving-average/-/moving-average-1.1.0.tgz",
+      "integrity": "sha512-MVEJ4vWAPNbrGLjz7ITnHYg+YXZ6ijAqtH5/cHwSoCpbvuJ98aLXwFfPKAUfZpJMQR5uXB58UJajbY130IRF/w=="
     },
     "@walletconnect/core": {
       "version": "2.9.2",
@@ -53381,6 +59550,22 @@
         "event-target-shim": "^5.0.0"
       }
     },
+    "abortable-iterator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+      "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+      "requires": {
+        "get-iterator": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "dependencies": {
+        "get-iterator": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-2.0.1.tgz",
+          "integrity": "sha512-7HuY/hebu4gryTDT7O/XY/fvY9wRByEGdK6QOa4of8npTcv0+NS6frFKABcf6S9EBAsveTuKTsZQQBFMMNILIg=="
+        }
+      }
+    },
     "abortcontroller-polyfill": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
@@ -54239,6 +60424,15 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "big.js": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
@@ -54339,6 +60533,70 @@
       "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
       "requires": {
         "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
+    "blockstore-core": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-4.3.4.tgz",
+      "integrity": "sha512-JecnNXiDPEdeS9AeFWO0PUKKmmRMW0D+ggUb4lgK0XMDOUAWmhkaiDPhgBjEKrlya0n60XOjcgBYhg18CUqOFw==",
+      "requires": {
+        "@libp2p/logger": "^3.0.0",
+        "err-code": "^3.0.1",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.0.0",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.0",
+        "it-merge": "^3.0.1",
+        "it-pushable": "^3.0.0",
+        "multiformats": "^12.0.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "@libp2p/logger": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.3.tgz",
+          "integrity": "sha512-85ioPX10QN4ZOZeurAZe5sQeRUCkIBT2DikKRbE/AIWKauIKHvvIrN4CSdCdzLw29XNA+xxNO2FVkf51HGgCeQ==",
+          "requires": {
+            "@libp2p/interface": "^0.1.3",
+            "@multiformats/multiaddr": "^12.1.5",
+            "debug": "^4.3.4",
+            "interface-datastore": "^8.2.0",
+            "multiformats": "^12.0.1"
+          }
+        },
+        "interface-datastore": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+          "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
       }
     },
     "bluebird": {
@@ -54660,6 +60918,14 @@
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "requires": {
         "streamsearch": "^1.1.0"
+      }
+    },
+    "byte-access": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/byte-access/-/byte-access-1.0.1.tgz",
+      "integrity": "sha512-GKYa+lvxnzhgHWj9X+LCsQ4s2/C5uvib573eAOiQKywXMkzFFErY2+yQdzmdE5iWVpmqecsRx3bOtOY4/1eINw==",
+      "requires": {
+        "uint8arraylist": "^2.0.0"
       }
     },
     "byte-size": {
@@ -56923,6 +63189,91 @@
       "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
       "dev": true
     },
+    "datastore-core": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-9.2.3.tgz",
+      "integrity": "sha512-jcvrVDt+jp7lUp2WhMXXgX/hoi3VcJebN+z/ZXbIRKOVfNOF4bl8cvr7sQ1y9qITikgC2coXFYd79Wzt/n13ZQ==",
+      "requires": {
+        "@libp2p/logger": "^3.0.0",
+        "err-code": "^3.0.1",
+        "interface-store": "^5.0.0",
+        "it-all": "^3.0.1",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.0",
+        "it-map": "^3.0.1",
+        "it-merge": "^3.0.1",
+        "it-pipe": "^3.0.0",
+        "it-pushable": "^3.0.0",
+        "it-sort": "^3.0.1",
+        "it-take": "^3.0.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "@libp2p/logger": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.3.tgz",
+          "integrity": "sha512-85ioPX10QN4ZOZeurAZe5sQeRUCkIBT2DikKRbE/AIWKauIKHvvIrN4CSdCdzLw29XNA+xxNO2FVkf51HGgCeQ==",
+          "requires": {
+            "@libp2p/interface": "^0.1.3",
+            "@multiformats/multiaddr": "^12.1.5",
+            "debug": "^4.3.4",
+            "interface-datastore": "^8.2.0",
+            "multiformats": "^12.0.1"
+          }
+        },
+        "interface-datastore": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+          "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "it-all": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+          "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+        },
+        "it-map": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+          "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+          "requires": {
+            "it-peekable": "^3.0.0"
+          }
+        },
+        "it-peekable": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+          "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
     "date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -57041,6 +63392,73 @@
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
       "integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw=="
     },
+    "default-gateway": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-7.2.2.tgz",
+      "integrity": "sha512-AD7TrdNNPXRZIGw63dw+lnGmT4v7ggZC5NHNJgAYWm5njrwoze1q5JSAW9YuLy2tjnoLUG/r8FEB93MCh9QJPg==",
+      "requires": {
+        "execa": "^7.1.1"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+          "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^4.3.0",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+          "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ=="
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
+        },
+        "npm-run-path": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
+        }
+      }
+    },
     "defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -57125,6 +63543,11 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "dev": true
+    },
+    "denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depd": {
       "version": "2.0.0",
@@ -57262,6 +63685,14 @@
         "debug": "^4.3.1",
         "native-fetch": "^3.0.0",
         "receptacle": "^1.3.2"
+      }
+    },
+    "dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "requires": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
       }
     },
     "docker-compose": {
@@ -59230,6 +65661,11 @@
         "strip-hex-prefix": "1.0.0"
       }
     },
+    "event-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
+      "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ=="
+    },
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -59827,6 +66263,11 @@
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
+    },
+    "freeport-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/freeport-promise/-/freeport-promise-2.0.0.tgz",
+      "integrity": "sha512-dwWpT1DdQcwrhmRwnDnPM/ZFny+FtzU+k50qF2eid3KxaQDsMiBrwo1i0G3qSugkN5db6Cb0zgfc68QeTOpEFg=="
     },
     "fresh": {
       "version": "0.5.2",
@@ -61204,8 +67645,8 @@
         "@types/node": "^16.0.0",
         "@types/prompts": "^2.0.14",
         "@types/yazl": "^2.4.2",
-        "@usecannon/builder": "^2.7.1",
-        "@usecannon/cli": "^2.7.1",
+        "@usecannon/builder": "^2.8.1",
+        "@usecannon/cli": "^2.8.1",
         "adm-zip": "^0.5.9",
         "bn.js": "^5.2.0",
         "chalk": "^4.1.2",
@@ -61322,6 +67763,11 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
     "hast-util-parse-selector": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
@@ -61399,6 +67845,136 @@
       "requires": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "helia": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/helia/-/helia-1.3.12.tgz",
+      "integrity": "sha512-/RCYJPpjBtudX2gHhFpc3I1isQIHZ43fQxzzDnIJ49DGhv8kyWdQ9gko9jt89X5vi0fv80HesQQGmo0rNdEDeA==",
+      "requires": {
+        "@chainsafe/libp2p-gossipsub": "^8.0.0",
+        "@chainsafe/libp2p-noise": "^12.0.0",
+        "@chainsafe/libp2p-yamux": "^4.0.2",
+        "@helia/interface": "^1.0.0",
+        "@ipld/dag-pb": "^4.0.3",
+        "@libp2p/bootstrap": "^8.0.0",
+        "@libp2p/interface-libp2p": "^3.2.0",
+        "@libp2p/interface-pubsub": "^4.0.1",
+        "@libp2p/interfaces": "^3.3.2",
+        "@libp2p/ipni-content-routing": "^1.0.0",
+        "@libp2p/kad-dht": "^9.3.3",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/mdns": "^8.0.0",
+        "@libp2p/mplex": "^8.0.3",
+        "@libp2p/tcp": "^7.0.1",
+        "@libp2p/webrtc": "^2.0.4",
+        "@libp2p/websockets": "^6.0.1",
+        "@libp2p/webtransport": "^2.0.1",
+        "blockstore-core": "^4.0.0",
+        "cborg": "^1.10.0",
+        "datastore-core": "^9.0.0",
+        "interface-blockstore": "^5.0.0",
+        "interface-datastore": "^8.0.0",
+        "interface-store": "^5.0.1",
+        "ipfs-bitswap": "^18.0.0",
+        "ipns": "^6.0.0",
+        "it-all": "^3.0.2",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.1",
+        "it-foreach": "^2.0.2",
+        "libp2p": "^0.45.2",
+        "mortice": "^3.0.1",
+        "multiformats": "^11.0.1",
+        "p-defer": "^4.0.0",
+        "p-queue": "^7.3.4",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^4.0.3"
+      },
+      "dependencies": {
+        "@ipld/dag-pb": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.6.tgz",
+          "integrity": "sha512-wOij3jfDKZsb9yjhQeHp+TQy0pu1vmUkGv324xciFFZ7xGbDfAGTQW03lSA5aJ/7HBBNYgjEE0nvHmNW1Qjfag==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+        },
+        "interface-datastore": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+          "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "it-all": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+          "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        },
+        "p-queue": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+          "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+          "requires": {
+            "eventemitter3": "^5.0.1",
+            "p-timeout": "^5.0.2"
+          }
+        },
+        "p-timeout": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+          "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
       }
     },
     "hey-listen": {
@@ -61859,6 +68435,27 @@
         "wrap-ansi": "^6.0.1"
       }
     },
+    "interface-blockstore": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.2.6.tgz",
+      "integrity": "sha512-Cp6+QPY81kunaxQV/j5BWk3uSW6kpos8dLveJ3P2lbmA/yX2XeMwVlNOnQyGg0evhp1qmMLhf6eCswNiSMW3CA==",
+      "requires": {
+        "interface-store": "^5.0.0",
+        "multiformats": "^12.0.1"
+      },
+      "dependencies": {
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        }
+      }
+    },
     "interface-datastore": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
@@ -61921,6 +68518,94 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "ipfs-bitswap": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-18.0.3.tgz",
+      "integrity": "sha512-ebUB/OMeVLbqnHn61VIgSJKTFQcuIJxSjjF0k5yHZRPVll1QE9APYe15dLyKQUiotiEBEQ9tHe7CsoId416PRg==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.1.0",
+        "@libp2p/interface-libp2p": "^3.1.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.8",
+        "@libp2p/interface-registrar": "^2.0.8",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/topology": "^4.0.0",
+        "@libp2p/tracked-map": "^3.0.0",
+        "@multiformats/multiaddr": "^12.1.0",
+        "@vascosantos/moving-average": "^1.1.0",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "blockstore-core": "^4.0.0",
+        "events": "^3.3.0",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.1.0",
+        "it-foreach": "^2.0.2",
+        "it-length-prefixed": "^9.0.0",
+        "it-map": "^3.0.2",
+        "it-pipe": "^3.0.1",
+        "it-take": "^3.0.1",
+        "just-debounce-it": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "progress-events": "^1.0.0",
+        "protons-runtime": "^5.0.0",
+        "timeout-abort-controller": "^3.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0",
+        "varint-decoder": "^1.0.0"
+      },
+      "dependencies": {
+        "any-signal": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+          "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA=="
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "it-map": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+          "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+          "requires": {
+            "it-peekable": "^3.0.0"
+          }
+        },
+        "it-peekable": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+          "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+        },
+        "just-debounce-it": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-3.2.0.tgz",
+          "integrity": "sha512-WXzwLL0745uNuedrCsCs3rpmfD6DBaf7uuVwaq98/8dafURfgQaBsSpjiPp5+CW6Vjltwy9cOGI6qE71b3T8iQ=="
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
+      }
     },
     "ipfs-core-types": {
       "version": "0.10.3",
@@ -62016,6 +68701,107 @@
         "node-fetch": "^2.6.8",
         "react-native-fetch-api": "^3.0.0",
         "stream-to-it": "^0.2.2"
+      }
+    },
+    "ipns": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-6.0.7.tgz",
+      "integrity": "sha512-VHC7XAEjqQwBzP1PbCRVOhGo4QFQTVuV93m8Ul3flzJt77WQWU6XPitXUPOT+LZ8yrObMXHzlt/ZheP3Ypwi4g==",
+      "requires": {
+        "@libp2p/crypto": "^2.0.3",
+        "@libp2p/interface": "^0.1.2",
+        "@libp2p/logger": "^3.0.2",
+        "@libp2p/peer-id": "^3.0.2",
+        "cborg": "^4.0.1",
+        "err-code": "^3.0.1",
+        "interface-datastore": "^8.1.0",
+        "multiformats": "^12.0.1",
+        "protons-runtime": "^5.0.0",
+        "timestamp-nano": "^1.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "@libp2p/crypto": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-2.0.5.tgz",
+          "integrity": "sha512-m6Rn7i9q3SHCzMUBkEwZgAKS4evpGQ4SEx/YD96pM0ZoPtU5PFO0psfrerraanxFBh8wUX4vkCtKfyTPH7F+bQ==",
+          "requires": {
+            "@libp2p/interface": "^0.1.3",
+            "@noble/curves": "^1.1.0",
+            "@noble/hashes": "^1.3.1",
+            "multiformats": "^12.0.1",
+            "node-forge": "^1.1.0",
+            "protons-runtime": "^5.0.0",
+            "uint8arraylist": "^2.4.3",
+            "uint8arrays": "^4.0.6"
+          }
+        },
+        "@libp2p/logger": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.3.tgz",
+          "integrity": "sha512-85ioPX10QN4ZOZeurAZe5sQeRUCkIBT2DikKRbE/AIWKauIKHvvIrN4CSdCdzLw29XNA+xxNO2FVkf51HGgCeQ==",
+          "requires": {
+            "@libp2p/interface": "^0.1.3",
+            "@multiformats/multiaddr": "^12.1.5",
+            "debug": "^4.3.4",
+            "interface-datastore": "^8.2.0",
+            "multiformats": "^12.0.1"
+          }
+        },
+        "@libp2p/peer-id": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-3.0.3.tgz",
+          "integrity": "sha512-IPVeywoC40bDd3ohtAIzpN8AOkMmD3U0BjdrFz/5ZbNP1+4n2gDIAwVzkAbF/t1iYYS4CX1TWfHuMqaMvd8l1A==",
+          "requires": {
+            "@libp2p/interface": "^0.1.3",
+            "multiformats": "^12.0.1",
+            "uint8arrays": "^4.0.6"
+          }
+        },
+        "@noble/hashes": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+        },
+        "cborg": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.3.tgz",
+          "integrity": "sha512-poLvpK30KT5KI8gzDx3J/IuVCbsLqMT2fEbOrOuX0H7Hyj8yg5LezeWhRh9aLa5Z6MfPC5sriW3HVJF328M8LQ=="
+        },
+        "interface-datastore": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+          "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
       }
     },
     "is-absolute": {
@@ -62245,6 +69031,11 @@
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
+    },
+    "is-loopback-addr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-loopback-addr/-/is-loopback-addr-2.0.2.tgz",
+      "integrity": "sha512-26POf2KRCno/KTNL5Q0b/9TYnL00xEsSaLfiFRmjM7m7Lw7ZMmFybzzuX4CcsLAluZGd+niLUiMRxEooVE3aqg=="
     },
     "is-lower-case": {
       "version": "2.0.2",
@@ -62645,10 +69436,61 @@
       "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
       "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
     },
+    "it-batched-bytes": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-2.0.4.tgz",
+      "integrity": "sha512-n4V19XACvFG+b8lCkuvidYvwpyz3++DAolqZGI+9AcDvIPMAhVwwtFCe9SiDIz45OzQnnNYwBgBxbIinHPgraA==",
+      "requires": {
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.4.1"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        }
+      }
+    },
+    "it-drain": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.3.tgz",
+      "integrity": "sha512-l4s+izxUpFAR2axprpFiCaq0EtxK1QMd0LWbEtau5b+OegiZ5xdRtz35iJyh6KZY9QtuwEiQxydiOfYJc7stoA=="
+    },
+    "it-filter": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.0.3.tgz",
+      "integrity": "sha512-2zXUrJuuV6QHM21ahc8NqVUUxkLMVDWXBoUBcj9GCQLQez2OXmddTHN0r0F5B+TkNTpeL618yIgXi1HNPJOxow==",
+      "requires": {
+        "it-peekable": "^3.0.0"
+      },
+      "dependencies": {
+        "it-peekable": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+          "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+        }
+      }
+    },
     "it-first": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
       "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "it-foreach": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-2.0.4.tgz",
+      "integrity": "sha512-txxcoc09g+KdLyOapxAuB12H9zUb2FuZC/TqSXRT+YR0T5fHnvcDIhspgvx/e/HiPKlKjOR8onA0qtuiAtcXqg==",
+      "requires": {
+        "it-peekable": "^3.0.0"
+      },
+      "dependencies": {
+        "it-peekable": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+          "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+        }
+      }
     },
     "it-glob": {
       "version": "1.0.2",
@@ -62659,20 +69501,216 @@
         "minimatch": "^3.0.4"
       }
     },
+    "it-handshake": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-4.1.3.tgz",
+      "integrity": "sha512-V6Lt9A9usox9iduOX+edU1Vo94E6v9Lt9dOvg3ubFaw1qf5NCxXLi93Ao4fyCHWDYd8Y+DUhadwNtWVyn7qqLg==",
+      "requires": {
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.0.0"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        }
+      }
+    },
     "it-last": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
       "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+    },
+    "it-length": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-length/-/it-length-3.0.3.tgz",
+      "integrity": "sha512-aLoeonDJV6wMgT1ElEruc61c3FYxGa3yymujfZ0Uk4Up7mUJ15xl1ixxPnGbm+BnMkEQylJXjzp1vNYEY9blvg=="
+    },
+    "it-length-prefixed": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.3.tgz",
+      "integrity": "sha512-YAu424ceYpXctxtjcLOqn7vJq082CaoP8J646ZusYISfQc3bpzQErgTUqMFj81V262KG2W9/YMBHsy6A/4yvmg==",
+      "requires": {
+        "err-code": "^3.0.1",
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "uint8-varint": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
+          "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+          "requires": {
+            "uint8arraylist": "^2.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
     },
     "it-map": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
       "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
     },
+    "it-merge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.2.tgz",
+      "integrity": "sha512-bMk2km8lTz+Rwv30hzDUdGIcqQkOemFJqmGT2wqQZ6/zHKCsYqdRunPrteCqHLV/nIVhUK8nZZkDA2eJ4MJZiA==",
+      "requires": {
+        "it-pushable": "^3.2.0"
+      }
+    },
+    "it-pair": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.6.tgz",
+      "integrity": "sha512-5M0t5RAcYEQYNG5BV7d7cqbdwbCAp5yLdzvkxsZmkuZsLbTdZzah6MQySYfaAQjNDCq6PUnDt0hqBZ4NwMfW6g==",
+      "requires": {
+        "it-stream-types": "^2.0.1",
+        "p-defer": "^4.0.0"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        }
+      }
+    },
+    "it-parallel": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.4.tgz",
+      "integrity": "sha512-fuA+SysGxbZc+Yl7EUvzQqZ8bNYQghZ0Mq9zA+fxMQ5eQYzatNg6oJk1y1PvPvNqLgKJMzEInpRO6PbLC3hGAg==",
+      "requires": {
+        "p-defer": "^4.0.0"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        }
+      }
+    },
+    "it-pb-stream": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-4.0.2.tgz",
+      "integrity": "sha512-wZ4Bvx2MfwamZTeyFQdX1SnD97hqdhpnaQwmbHqX4eT0pNWFPZ0mkKXbUkhLw2M0UNQNkEGN4wxljMod95c/ig==",
+      "requires": {
+        "err-code": "^3.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^1.0.6",
+        "uint8arraylist": "^2.0.0"
+      }
+    },
     "it-peekable": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
       "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
+    },
+    "it-pipe": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+      "requires": {
+        "it-merge": "^3.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1"
+      }
+    },
+    "it-pushable": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.1.tgz",
+      "integrity": "sha512-sLFz2Q0oyDCJpTciZog7ipP4vSftfPy3e6JnH6YyztRa1XqkpGQaafK3Jw/JlfEBtCXfnX9uVfcpu3xpSAqCVQ==",
+      "requires": {
+        "p-defer": "^4.0.0"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        }
+      }
+    },
+    "it-reader": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.4.tgz",
+      "integrity": "sha512-XCWifEcNFFjjBHtor4Sfaj8rcpt+FkY0L6WdhD578SCDhV4VUm7fCkF3dv5a+fTcfQqvN9BsxBTvWbYO6iCjTg==",
+      "requires": {
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.0.0"
+      }
+    },
+    "it-sort": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-3.0.3.tgz",
+      "integrity": "sha512-9BuQc5Y2fmBUNhevQBUDHfItrQmzWoZcnzydJl91V6na6M+RkbNj71UtCPPNIpOt/SQG+va0pe1wMQJ9lP2Oew==",
+      "requires": {
+        "it-all": "^3.0.0"
+      },
+      "dependencies": {
+        "it-all": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+          "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+        }
+      }
+    },
+    "it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg=="
+    },
+    "it-take": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-3.0.3.tgz",
+      "integrity": "sha512-Ay5SXEyrBKD0tO8PQif2QjrStImIsLIg0F50Uu4EeXOw8C9DfVIGfsGL3X9s65F2I9skDp9mLgBzl71IToMxNw=="
+    },
+    "it-to-buffer": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-4.0.3.tgz",
+      "integrity": "sha512-/xdI2hD/LvK7tzS/9DY9oKATmUZ9rg9uG7IfQRBAokM/LLujJ179fqRGneluqwKpXOtCpMRo43LJZXr8aibv6Q==",
+      "requires": {
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
     },
     "it-to-stream": {
       "version": "1.0.0",
@@ -62685,6 +69723,48 @@
         "p-defer": "^3.0.0",
         "p-fifo": "^1.0.0",
         "readable-stream": "^3.6.0"
+      }
+    },
+    "it-ws": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-6.0.5.tgz",
+      "integrity": "sha512-xp7tF4fHgx8+vN3Qy/8wGiWUKbC9E1U1g9PwtlbdxD7pY4zld71ZyWZVFHLxnxxg14T9mVNK5uO7U9HK11VQ5g==",
+      "requires": {
+        "@types/ws": "^8.2.2",
+        "event-iterator": "^2.0.0",
+        "iso-url": "^1.1.2",
+        "it-stream-types": "^2.0.1",
+        "uint8arrays": "^4.0.2",
+        "ws": "^8.4.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        },
+        "ws": {
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+          "requires": {}
+        }
+      }
+    },
+    "iterable-ndjson": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
+      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+      "requires": {
+        "string_decoder": "^1.2.0"
       }
     },
     "iterator.prototype": {
@@ -64123,6 +71203,171 @@
         }
       }
     },
+    "libp2p": {
+      "version": "0.45.9",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.45.9.tgz",
+      "integrity": "sha512-cf2dCf8naZqQoDw3xxSEZ6rKgQ8BBne5iWgtIKHAYrCvL+ulshz72jNgeAG0FQ/jjRD3yzmUuwoMaLHj6gf7Bw==",
+      "requires": {
+        "@achingbrain/nat-port-mapper": "^1.0.9",
+        "@libp2p/crypto": "^1.0.17",
+        "@libp2p/interface-address-manager": "^3.0.0",
+        "@libp2p/interface-connection": "^5.1.1",
+        "@libp2p/interface-connection-encrypter": "^4.0.0",
+        "@libp2p/interface-connection-gater": "^3.0.0",
+        "@libp2p/interface-connection-manager": "^3.0.0",
+        "@libp2p/interface-content-routing": "^2.1.0",
+        "@libp2p/interface-keychain": "^2.0.4",
+        "@libp2p/interface-libp2p": "^3.2.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-routing": "^1.1.0",
+        "@libp2p/interface-peer-store": "^2.0.4",
+        "@libp2p/interface-pubsub": "^4.0.0",
+        "@libp2p/interface-record": "^2.0.6",
+        "@libp2p/interface-registrar": "^2.0.3",
+        "@libp2p/interface-stream-muxer": "^4.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/keychain": "^2.0.0",
+        "@libp2p/logger": "^2.1.1",
+        "@libp2p/multistream-select": "^3.1.8",
+        "@libp2p/peer-collections": "^3.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-id-factory": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@libp2p/peer-store": "^8.2.0",
+        "@libp2p/topology": "^4.0.1",
+        "@libp2p/tracked-map": "^3.0.0",
+        "@libp2p/utils": "^3.0.10",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "datastore-core": "^9.0.0",
+        "interface-datastore": "^8.0.0",
+        "it-all": "^3.0.1",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.1",
+        "it-first": "^3.0.1",
+        "it-handshake": "^4.1.3",
+        "it-length-prefixed": "^9.0.1",
+        "it-map": "^3.0.2",
+        "it-merge": "^3.0.0",
+        "it-pair": "^2.0.2",
+        "it-parallel": "^3.0.0",
+        "it-pb-stream": "^4.0.1",
+        "it-pipe": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "merge-options": "^3.0.4",
+        "multiformats": "^11.0.0",
+        "p-defer": "^4.0.0",
+        "p-queue": "^7.3.4",
+        "p-retry": "^5.0.0",
+        "private-ip": "^3.0.0",
+        "protons-runtime": "^5.0.0",
+        "rate-limiter-flexible": "^2.3.11",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2",
+        "wherearewe": "^2.0.0",
+        "xsalsa20": "^1.1.0"
+      },
+      "dependencies": {
+        "any-signal": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+          "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA=="
+        },
+        "eventemitter3": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+        },
+        "interface-datastore": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+          "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+          "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+        },
+        "it-all": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+          "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+        },
+        "it-first": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+          "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+        },
+        "it-map": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+          "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+          "requires": {
+            "it-peekable": "^3.0.0"
+          }
+        },
+        "it-peekable": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+          "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        },
+        "p-queue": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+          "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+          "requires": {
+            "eventemitter3": "^5.0.1",
+            "p-timeout": "^5.0.2"
+          }
+        },
+        "p-timeout": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+          "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+              "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+            }
+          }
+        }
+      }
+    },
     "lines-and-columns": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
@@ -64382,6 +71627,15 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
+    "longbits": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/longbits/-/longbits-1.1.0.tgz",
+      "integrity": "sha512-22U2exkkYy7sr7nuQJYx2NEZ2kEMsC69+BxM5h8auLvkVIJa+LwAB5mFIExnuW2dFuYXFOWsFMKXjaWiq/htYQ==",
+      "requires": {
+        "byte-access": "^1.0.1",
+        "uint8arraylist": "^2.0.0"
+      }
+    },
     "longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -64632,6 +71886,15 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
+    },
+    "matchit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/matchit/-/matchit-1.1.0.tgz",
+      "integrity": "sha512-+nGYoOlfHmxe5BW5tE0EMJppXEwdSf8uBA1GTZC7Q77kbT35+VKLYJMzVNWCHSsga1ps1tPYFtFyvxvKzWVmMA==",
+      "dev": true,
+      "requires": {
+        "@arr/every": "^1.0.0"
+      }
     },
     "mcl-wasm": {
       "version": "0.7.9",
@@ -66143,6 +73406,50 @@
       "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
       "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA=="
     },
+    "mortice": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.1.tgz",
+      "integrity": "sha512-eyDUsl1nCR9+JtNksKnaESLP9MgAXCA4w1LTtsmOSQNsThnv++f36rrBu5fC/fdGIwTJZmbiaR/QewptH93pYA==",
+      "requires": {
+        "nanoid": "^4.0.0",
+        "observable-webworkers": "^2.0.1",
+        "p-queue": "^7.2.0",
+        "p-timeout": "^6.0.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        },
+        "p-queue": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+          "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+          "requires": {
+            "eventemitter3": "^5.0.1",
+            "p-timeout": "^5.0.2"
+          },
+          "dependencies": {
+            "p-timeout": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+              "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
+            }
+          }
+        },
+        "p-timeout": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+          "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ=="
+        }
+      }
+    },
     "motion": {
       "version": "10.16.2",
       "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
@@ -66160,6 +73467,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
+    },
+    "mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -66205,6 +73518,15 @@
             "ieee754": "^1.1.13"
           }
         }
+      }
+    },
+    "multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "requires": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
       }
     },
     "multicodec": {
@@ -66347,6 +73669,11 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
+    "netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
+    },
     "next": {
       "version": "13.4.19",
       "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
@@ -66426,6 +73753,11 @@
       "requires": {
         "whatwg-url": "^5.0.0"
       }
+    },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-gyp": {
       "version": "9.4.0",
@@ -67477,6 +74809,11 @@
         "http-https": "^1.0.0"
       }
     },
+    "observable-webworkers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-2.0.1.tgz",
+      "integrity": "sha512-JI1vB0u3pZjoQKOK1ROWzp0ygxSi7Yb0iR+7UNsw4/Zn4cQ0P3R7XL38zac/Dy2tEA7Lg88/wIJTjF8vYXZ0uw=="
+    },
     "on-exit-leak-free": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
@@ -67578,6 +74915,21 @@
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
       "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
     },
+    "p-event": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.0.tgz",
+      "integrity": "sha512-Xbfxd0CfZmHLGKXH32k1JKjQYX6Rkv0UtQdaFJ8OyNcf+c0oWCeXHc1C4CX/IESZLmcvfPa5aFIO/vCr5gqtag==",
+      "requires": {
+        "p-timeout": "^6.1.2"
+      },
+      "dependencies": {
+        "p-timeout": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+          "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ=="
+        }
+      }
+    },
     "p-fifo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
@@ -67644,6 +74996,22 @@
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
       "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
       "dev": true
+    },
+    "p-retry": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "requires": {
+        "@types/retry": "0.12.1",
+        "retry": "^0.13.1"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+          "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+        }
+      }
     },
     "p-timeout": {
       "version": "3.2.0",
@@ -68183,6 +75551,36 @@
         }
       }
     },
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
+    },
+    "playwright": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
+      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.38.1"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
+      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "dev": true
+    },
     "pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -68192,6 +75590,16 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+    },
+    "polka": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/polka/-/polka-0.5.2.tgz",
+      "integrity": "sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^0.5.0",
+        "trouter": "^2.0.1"
+      }
     },
     "postcss": {
       "version": "8.4.14",
@@ -68315,6 +75723,29 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
       "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
     },
+    "private-ip": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.1.tgz",
+      "integrity": "sha512-Ezc16ANuhSHmWAE6lbXUKburNzGpR0J5X0Zh5Um/PZ/s57Fp+HYqYe6BYPH2QbqKr/5WebfzJQ1jq6Kj5dbRmA==",
+      "requires": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "ip-regex": "^5.0.0",
+        "ipaddr.js": "^2.1.0",
+        "netmask": "^2.0.2"
+      },
+      "dependencies": {
+        "ip-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
+        },
+        "ipaddr.js": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+          "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ=="
+        }
+      }
+    },
     "proc-log": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
@@ -68335,6 +75766,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
       "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
+    "progress-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.0.tgz",
+      "integrity": "sha512-zIB6QDrSbPfRg+33FZalluFIowkbV5Xh1xSuetjG+rlC5he6u2dc6VQJ0TbMdlN3R1RHdpOqxEFMKTnQ+itUwA=="
     },
     "promise": {
       "version": "7.3.1",
@@ -68432,6 +75868,41 @@
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
       "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
       "dev": true
+    },
+    "protons-runtime": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.2.tgz",
+      "integrity": "sha512-eKppVrIS5dDh+Y61Yj4bDEOs2sQLQbQGIhr7EBiybPQhIMGBynzVXlYILPWl3Td1GDadobc8qevh5D+JwfG9bw==",
+      "requires": {
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        },
+        "protobufjs": {
+          "version": "7.2.5",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+          "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          }
+        }
+      }
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -68635,6 +76106,11 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
     },
+    "race-signal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.0.1.tgz",
+      "integrity": "sha512-a5un4dInIWoB7+76DieVE+Xv+wmyochKJ3P2GVs9dUKIzGuPyFR5iU3gEWJvztde/15fSOGkslbIsPxi+Loosw=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -68657,6 +76133,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "rate-limiter-flexible": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.2.tgz",
+      "integrity": "sha512-rMATGGOdO1suFyf/mI5LYhts71g1sbdhmd6YvdiXO2gJnd42Tt6QS4JUKJKSWVVkMtBacm6l40FR7Trjo6Iruw=="
     },
     "raw-body": {
       "version": "2.5.2",
@@ -69899,6 +77380,14 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "sass": {
       "version": "1.66.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.1.tgz",
@@ -69917,6 +77406,11 @@
           "devOptional": true
         }
       }
+    },
+    "sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
     },
     "sc-istanbul": {
       "version": "0.4.6",
@@ -70329,6 +77823,25 @@
       "integrity": "sha512-We67lWa9dq+g2JP0Qhce1oby+Zwsc11EIXK4lCHQ8oth7LsqgyWoHhZ/DjwcI+Mi7fjLMzgy/qhpXfJ0qj5qfw==",
       "requires": {
         "qs": "^6.3.0"
+      }
+    },
+    "sirv": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
+      "integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^3.0.0"
+      },
+      "dependencies": {
+        "@polka/url": {
+          "version": "1.0.0-next.23",
+          "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
+          "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==",
+          "dev": true
+        }
       }
     },
     "sisteransi": {
@@ -70956,6 +78469,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
+      "dev": true
+    },
+    "stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
       "dev": true
     },
     "stream-browserify": {
@@ -71815,6 +79334,104 @@
         "minimatch": "^3.0.4"
       }
     },
+    "test-ipfs-example": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/test-ipfs-example/-/test-ipfs-example-1.0.0.tgz",
+      "integrity": "sha512-B2HDNJvxStbVxdVI/1snfH4dMqCx+/HeJ83WOPgK3CGEafMkS4aZkuFFm5Zu2nIl9qwNFe55FZn5R8Naxnw+/w==",
+      "dev": true,
+      "requires": {
+        "@playwright/test": "^1.33.0",
+        "@types/polka": "^0.5.4",
+        "@types/stoppable": "^1.1.1",
+        "execa": "^7.1.1",
+        "polka": "^0.5.2",
+        "sirv": "^2.0.2",
+        "stoppable": "^1.1.0",
+        "uint8arrays": "^4.0.3"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+          "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^4.3.0",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+          "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "dev": true
+        },
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
     "text-encoding-utf-8": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
@@ -71978,6 +79595,11 @@
         }
       }
     },
+    "thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
     "tildify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
@@ -71995,6 +79617,11 @@
       "requires": {
         "retimer": "^3.0.0"
       }
+    },
+    "timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA=="
     },
     "tiny-invariant": {
       "version": "1.3.1",
@@ -72076,6 +79703,12 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -72121,6 +79754,23 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
       "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+    },
+    "trouter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/trouter/-/trouter-2.0.1.tgz",
+      "integrity": "sha512-kr8SKKw94OI+xTGOkfsvwZQ8mWoikZDd2n8XZHjJVZUARZT+4/VV6cacRS6CLsH9bNm+HFIPU1Zx4CnNnb4qlQ==",
+      "dev": true,
+      "requires": {
+        "matchit": "^1.0.0"
+      }
+    },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
     },
     "ts-command-line-args": {
       "version": "2.5.1",
@@ -72532,6 +80182,55 @@
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "optional": true
     },
+    "uint8-varint": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.8.tgz",
+      "integrity": "sha512-QS03THS87Wlc0fBCC3xP5sqScDwfvVZLUrTCeMAQbQxQUWJosPC7C8uTNhpVUEgpTbV1Ut2Fer9Se3kI1KbnlQ==",
+      "requires": {
+        "byte-access": "^1.0.0",
+        "longbits": "^1.1.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
+    "uint8arraylist": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
+      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
+      "requires": {
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.1.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+          "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ=="
+        },
+        "uint8arrays": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+          "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          }
+        }
+      }
+    },
     "uint8arrays": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
@@ -72874,6 +80573,11 @@
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
+    },
     "util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -72978,6 +80682,21 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+    },
+    "varint-decoder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-1.0.0.tgz",
+      "integrity": "sha512-JkOvdztASWGUAsXshCFHrB9f6AgR2Q8W08CEyJ+43b1qtFocmI8Sp1R/M0E/hDOY2FzVIqk63tOYLgDYWuJ7IQ==",
+      "requires": {
+        "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
+      }
     },
     "vary": {
       "version": "1.1.2",
@@ -73735,6 +81454,14 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "wherearewe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
+      "requires": {
+        "is-electron": "^2.2.0"
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -74010,6 +81737,20 @@
         "cookiejar": "^2.1.1"
       }
     },
+    "xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    },
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -74021,6 +81762,11 @@
       "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
       "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
       "dev": true
+    },
+    "xsalsa20": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
+      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -23,6 +23,9 @@ import { createDefaultReadRegistry } from '../registry';
 import { listInstalledPlugins, loadPlugins } from '../plugins';
 import { getMainLoader } from '../loader';
 
+import Debug from 'debug';
+const debug = Debug('cannon:cli:build');
+
 import pkg from '../../package.json';
 
 interface Params {
@@ -101,6 +104,8 @@ export async function build({
   if (plugins) {
     await loadPlugins();
   }
+
+  debug('checking provider', provider);
 
   const chainId = (await provider.getNetwork()).chainId;
 

--- a/packages/cli/src/util/provider.ts
+++ b/packages/cli/src/util/provider.ts
@@ -64,13 +64,17 @@ export async function resolveProviderAndSigners({
 
   // ensure provider is enabled and on the chain we expect
   try {
-    await rawProvider.setChain(Number.parseInt(chainId.toString())); // its important here we ensure chainId is a number
+    rawProvider.setChain(Number.parseInt(chainId.toString())); // its important here we ensure chainId is a number
   } catch (err) {
     console.error(`Failed to use chain id ${chainId}`, err);
     throw err;
   }
 
-  const ethersProvider = new CannonWrapperGenericProvider({}, new ethers.providers.Web3Provider(rawProvider as any), false);
+  let ethersProvider = new CannonWrapperGenericProvider({}, new ethers.providers.Web3Provider(rawProvider as any), false);
+
+  if (checkProviders[0].startsWith('http')) {
+    ethersProvider = new CannonWrapperGenericProvider({}, new ethers.providers.JsonRpcProvider(checkProviders[0]));
+  }
 
   const signers = [];
 


### PR DESCRIPTION
for some reason the eth-provider library does not properly handle explicit `--provider-url` when they are specified, at least for localhost forks which are created for a manual test. When this occurs, it becomes impossible to specify a local fork as a target network for a test. this error probably only is relevant when the user is running a foundry instance (and goes away as soon as the foundry instance is shut down).

To solve this problem, bypass eth-provider ocmpletely when an explicit url is provided by the user.