### PR TITLE
fix(website): show publish time of the currently selected variant of the package

### DIFF
--- a/packages/website/src/app/packages/[name]/[tag]/[variant]/layout.tsx
+++ b/packages/website/src/app/packages/[name]/[tag]/[variant]/layout.tsx
@@ -56,7 +56,7 @@ export default function PackageLayout({
                   <Heading as="h1" size="lg" mb="2">
                     {pkg?.name}
                   </Heading>
-                  <PublishInfo p={pkg} />
+                  <PublishInfo p={currentVariant} />
                 </Box>
                 <Box ml={[0, 0, 'auto']} mt={[6, 6, 0]}>
                   <VersionSelect pkg={pkg} currentVariant={currentVariant} />


### PR DESCRIPTION
Closes #469

<img width="1009" alt="Screenshot 2023-10-12 at 19 45 36" src="https://github.com/usecannon/cannon/assets/61683409/be49ec3b-2cad-465f-8df1-407c040e8543">