### PR TITLE
feat(cli): ability to trace transactions while in cannon run

### DIFF
--- a/packages/cli/src/commands/run.test.ts
+++ b/packages/cli/src/commands/run.test.ts
@@ -51,6 +51,7 @@ jest.mock('../rpc', () => ({
     getNetwork: jest.fn().mockImplementation(() => {
       return Promise.resolve(chainId);
     }),
+    on: jest.fn(),
   }),
 }));
 


### PR DESCRIPTION
this PR augments the `cannon run` command to support automatic tracing and decoding of executed transactions from inside the CLI upon execution. Currently, there are 2 trace output modes: console.log only, and full trace output.

A user can push the `v` to enable tracing and display of `console.log` trace events. If the user pushes the `v` command once more, they will be given the ability to see the full trace output. The logs are automatically decoded with the contents of the cannon package that is currently active.

demo: https://www.terminalizer.com/view/562c63b05783

fixes https://linear.app/usecannon/issue/CAN-10