### PR TITLE
fix(cli): much faster startup

### DIFF
--- a/packages/cli/bin/cannon.js
+++ b/packages/cli/bin/cannon.js
@@ -3,7 +3,7 @@
 const { red } = require('chalk');
 const cli = require('../dist/src');
 
-cli
+cli.default
   .parseAsync()
   .then(() => {
     process.exit(0);

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -100,7 +100,8 @@ export async function resolveCannonVersion(): Promise<string> {
 
   const resolvedVersion = await execPromise('npm view @usecannon/cli version');
 
-  fs.writeFileSync(versionFile, `${resolvedVersion}:${now}`);
+  await fs.mkdirp(settings.cannonDirectory);
+  await fs.writeFile(versionFile, `${resolvedVersion}:${now}`);
 
   return resolvedVersion;
 }

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -100,7 +100,7 @@ export async function resolveCannonVersion(): Promise<string> {
 
   const resolvedVersion = await execPromise('npm view @usecannon/cli version');
 
-  await fs.mkdirp(settings.cannonDirectory);
+  await fs.mkdirp(settings.cannonDirectory || 'undefined');
   await fs.writeFile(versionFile, `${resolvedVersion}:${now}`);
 
   return resolvedVersion;

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -107,7 +107,7 @@ export async function resolveCannonVersion(): Promise<string> {
 
 export async function checkCannonVersion(currentVersion: string): Promise<void> {
   const latestVersion = await resolveCannonVersion();
-  if (currentVersion !== latestVersion) {
+  if (latestVersion && currentVersion !== latestVersion) {
     console.warn(yellowBright(`⚠️  There is a new version of Cannon (${latestVersion})`));
     console.warn(yellow('Upgrade with ' + bold('npm install -g @usecannon/cli\n')));
   }

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -153,4 +153,4 @@ function _resolveCliSettings(overrides: Partial<CliSettings> = {}): CliSettings 
   return finalSettings;
 }
 
-export const resolveCliSettings = _.once(_resolveCliSettings);
+export const resolveCliSettings = _.memoize(_resolveCliSettings);


### PR DESCRIPTION
often cannon cli would startup slow because the `npm view` command that is called to resolve the latest cannon version has to call the internet to get the latest version. Its not necessary to call out to the internet every time the user uses cannon to check for the latest version, just very periodically.

to solve this problem, the `npm view` command is called only once a week at max. in other cases, the version is loaded from a file stored in their cannon directory.

on my computer this brings the startup time of the cannon process from 1-2 seconds to start every time to near instant.