### PR TITLE
fix(cli): proper error on providerurl chainid and chainid mismatch

### DIFF
--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -11,7 +11,6 @@ import { chains } from './chains';
 import { IChainData } from './types';
 import { resolveCliSettings } from './settings';
 import { isConnectedToInternet } from './util/is-connected-to-internet';
-import { ethers } from 'ethers';
 import Debug from 'debug';
 const debug = Debug('cannon:cli:helpers');
 
@@ -304,17 +303,4 @@ export function toArgs(options: { [key: string]: string | boolean | number | big
 
     return [flag, stringified];
   });
-}
-
-/**
- * Extract chain id of given provider.
- *
- * @param providerUrl The provider url.
- * @returns The chain id of the provider url.
- */
-export async function getChainIdFromProviderUrl(providerUrl: string) {
-  const provider = new ethers.providers.JsonRpcProvider(providerUrl);
-  const network = await provider.getNetwork();
-
-  return network.chainId;
 }

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -11,6 +11,7 @@ import { chains } from './chains';
 import { IChainData } from './types';
 import { resolveCliSettings } from './settings';
 import { isConnectedToInternet } from './util/is-connected-to-internet';
+import { ethers } from 'ethers';
 import Debug from 'debug';
 const debug = Debug('cannon:cli:helpers');
 
@@ -303,4 +304,17 @@ export function toArgs(options: { [key: string]: string | boolean | number | big
 
     return [flag, stringified];
   });
+}
+
+/**
+ * Extract chain id of given provider.
+ *
+ * @param providerUrl The provider url.
+ * @returns The chain id of the provider url.
+ */
+export async function getChainIdFromProviderUrl(providerUrl: string) {
+  const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+  const network = await provider.getNetwork();
+
+  return network.chainId;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,7 +11,7 @@ import {
   CannonStorage,
 } from '@usecannon/builder';
 
-import { checkCannonVersion, loadCannonfile } from './helpers';
+import { checkCannonVersion, loadCannonfile, getChainIdFromProviderUrl } from './helpers';
 import { parsePackageArguments, parsePackagesArguments, parseSettings } from './util/params';
 
 import pkg from '../package.json';
@@ -105,6 +105,15 @@ function configureRun(program: Command) {
       const { run } = await import('./commands/run');
 
       options.port = Number.parseInt(options.port) || 8545;
+
+      if (options.chainId && options.providerUrl) {
+        const providerChainId = await getChainIdFromProviderUrl(options.providerUrl);
+        if (providerChainId != options.chainId) {
+          throw new Error(
+            `Provided providerUrl's blockchain chainId ${providerChainId} does not match with chainId you provided ${options.chainId}`
+          );
+        }
+      }
 
       let node: CannonRpcNode;
       if (options.chainId) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,7 +11,7 @@ import {
   CannonStorage,
 } from '@usecannon/builder';
 
-import { checkCannonVersion, loadCannonfile, getChainIdFromProviderUrl } from './helpers';
+import { checkCannonVersion, loadCannonfile } from './helpers';
 import { parsePackageArguments, parsePackagesArguments, parseSettings } from './util/params';
 
 import pkg from '../package.json';
@@ -106,21 +106,21 @@ function configureRun(program: Command) {
 
       options.port = Number.parseInt(options.port) || 8545;
 
-      if (options.chainId && options.providerUrl) {
-        const providerChainId = await getChainIdFromProviderUrl(options.providerUrl);
-        if (providerChainId != options.chainId) {
-          throw new Error(
-            `Supplied providerUrl's blockchain chainId ${providerChainId} does not match with chainId you provided ${options.chainId}`
-          );
-        }
-      }
-
       let node: CannonRpcNode;
       if (options.chainId) {
         const settings = resolveCliSettings(options);
 
         const { provider } = await resolveWriteProvider(settings, Number.parseInt(options.chainId));
 
+        if (options.providerUrl) {
+          const providerChainId = (await provider.getNetwork()).chainId;
+          if (providerChainId != options.chainId) {
+            throw new Error(
+              `Supplied providerUrl's blockchain chainId ${providerChainId} does not match with chainId you provided ${options.chainId}`
+            );
+          }
+        }
+        
         node = await runRpc(pickAnvilOptions(options), {
           forkProvider: provider.passThroughProvider as ethers.providers.JsonRpcProvider,
         });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -120,7 +120,7 @@ function configureRun(program: Command) {
             );
           }
         }
-        
+
         node = await runRpc(pickAnvilOptions(options), {
           forkProvider: provider.passThroughProvider as ethers.providers.JsonRpcProvider,
         });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -110,7 +110,7 @@ function configureRun(program: Command) {
         const providerChainId = await getChainIdFromProviderUrl(options.providerUrl);
         if (providerChainId != options.chainId) {
           throw new Error(
-            `Provided providerUrl's blockchain chainId ${providerChainId} does not match with chainId you provided ${options.chainId}`
+            `Supplied providerUrl's blockchain chainId ${providerChainId} does not match with chainId you provided ${options.chainId}`
           );
         }
       }


### PR DESCRIPTION
When a user provides a providerurl and chainid, ensure that the chain ids match else display a proper error message

<img width="883" alt="Screenshot 2023-10-24 at 9 27 27 AM" src="https://github.com/usecannon/cannon/assets/92117477/01271452-e8db-4e7c-8010-0b168bd2ce47">

