### PR TITLE
fix(builder): handling of package url modification during copy

### DIFF
--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -143,6 +143,8 @@ export async function verify(packageRef: string, apiKey: string, presetArg: stri
 
       await sleep(500);
     }
+
+    return {};
   };
 
   const deployData = await runtime.readDeploy(basePackageRef, selectedPreset, chainId);


### PR DESCRIPTION
when copying from local fs (aka file:// scheme), it is possible that an uploaded package can end up not having its url updated. this leads to builder issues because `file://` scheme artifacts generally only exist on the builder's system, so we have to make sure these get scrubbed out always.

to fix, the `forPackageRecursive` has been updated to automatically update the url stored inside the deployment info object if a url is returned by the copy function. for functions which do not return a url, this change has no effect.