### PR TITLE
fix(builder): use in memory during build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,142 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@achingbrain/ip-address": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@achingbrain/ip-address/-/ip-address-8.1.0.tgz",
+      "integrity": "sha512-Zus4vMKVRDm+R1o0QJNhD0PD/8qRGO3Zx8YPsFG5lANt5utVtGg3iHVGBSAF80TfQmhi8rP+Kg/OigdxY0BXHw==",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@achingbrain/ip-address/node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
+    "node_modules/@achingbrain/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "node_modules/@achingbrain/nat-port-mapper": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@achingbrain/nat-port-mapper/-/nat-port-mapper-1.0.12.tgz",
+      "integrity": "sha512-rU4G75TEOTIPlkeDnPEVwx/VmMMFta42kY2SMmVobRkrtNLnxtU08Yhriu6tSBc9oO0wXdfNNeuLnNnEnL7w/A==",
+      "dependencies": {
+        "@achingbrain/ssdp": "^4.0.1",
+        "@libp2p/logger": "^3.0.0",
+        "default-gateway": "^7.2.2",
+        "err-code": "^3.0.1",
+        "it-first": "^3.0.1",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.1.1",
+        "xml2js": "^0.6.0"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/@libp2p/logger": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.4.tgz",
+      "integrity": "sha512-MF42c7SOJIx5YmHhIsFaSYfaC266YYmMbAJHjjH8Zl5unFsqW82M+Xr7sGVj9/WXrWAd37ts8xJaQrkIXc3OZQ==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.4",
+        "@multiformats/multiaddr": "^12.1.5",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/it-first": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+      "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@achingbrain/ssdp": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@achingbrain/ssdp/-/ssdp-4.0.6.tgz",
+      "integrity": "sha512-Y4JE2L9150i50V6lg/Y8+ilhxRpUZKKv+PKo68Aj7MjPfaUAar6ZHilF9h4/Zb3q0fqGMXNc9o11cQLNI8J8bA==",
+      "dependencies": {
+        "event-iterator": "^2.0.0",
+        "freeport-promise": "^2.0.0",
+        "merge-options": "^3.0.4",
+        "xml2js": "^0.6.2"
+      }
+    },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.4.tgz",
@@ -249,6 +385,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@arr/every": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@arr/every/-/every-1.0.1.tgz",
+      "integrity": "sha512-UQFQ6SgyJ6LX42W8rHCs8KVc0JS0tzVL9ct4XYedJukskYVWTo49tNiMEK9C2HTyarbNiT/RVIRSY82vH+6sTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2240,6 +2385,154 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
       "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg=="
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.2.tgz",
+      "integrity": "sha512-ndGqEMG1W5WkGagaqOZHpPU172AGdxr+LD15sv3WIUvT5oCFUrG1Y0CW/v2Egwj4JXEvSibaIIIqImsm98y1nA=="
+    },
+    "node_modules/@chainsafe/libp2p-gossipsub": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-8.0.1.tgz",
+      "integrity": "sha512-vzRN7F1zLd/DKfK9VLQ7rrc/lYQFvE/RGnXjr+EanD2RoX+BjSdqZkvzcrJcaDzkCMJRCvpsFzgz2iLbV7SgYg==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.3",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-connection-manager": "^3.0.1",
+        "@libp2p/interface-keys": "^1.0.3",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-store": "^2.0.3",
+        "@libp2p/interface-pubsub": "^4.0.0",
+        "@libp2p/interface-registrar": "^2.0.3",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@libp2p/pubsub": "^7.0.1",
+        "@libp2p/topology": "^4.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "abortable-iterator": "^5.0.1",
+        "denque": "^1.5.0",
+        "it-length-prefixed": "^9.0.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.0",
+        "multiformats": "^11.0.0",
+        "protobufjs": "^6.11.2",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "npm": ">=8.7.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-noise": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-12.0.2.tgz",
+      "integrity": "sha512-bKlasdYJBXsCgcOw+gNNnpvNo3jD8BiSRpKrhYxEmBPQzesme15PBrj5Cx369PZEk4SvKSHS6dzL4oLxXqPSLw==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-connection-encrypter": "^4.0.0",
+        "@libp2p/interface-keys": "^1.0.6",
+        "@libp2p/interface-metrics": "^4.0.4",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
+        "@noble/ciphers": "^0.1.4",
+        "@noble/curves": "^1.1.0",
+        "@noble/hashes": "^1.3.1",
+        "it-length-prefixed": "^9.0.1",
+        "it-pair": "^2.0.2",
+        "it-pb-stream": "^4.0.1",
+        "it-pipe": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-noise/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-noise/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-yamux/-/libp2p-yamux-4.0.2.tgz",
+      "integrity": "sha512-p0m/4ab4JLaIQqUtxvm8bSqdt9sb0uXX8PFj1CQM1eJLeV1LxzzygaSOeLxN/5ckHCuK7q/9eb9xybvl6vz/JA==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.1.0",
+        "@libp2p/interface-stream-muxer": "^4.1.2",
+        "@libp2p/interfaces": "^3.3.2",
+        "@libp2p/logger": "^2.0.7",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.3",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1"
+      }
     },
     "node_modules/@chainsafe/persistent-merkle-tree": {
       "version": "0.4.2",
@@ -6090,6 +6383,79 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@helia/interface": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@helia/interface/-/interface-1.2.2.tgz",
+      "integrity": "sha512-Eij8ATmzNTvMnUdfvPZP/6aZ7k+xAXN/LYcgXqJpVV3DDJYA/NnZZ3Ay9bIauoFIuhoDm2C6VjnW3HzmRDBY9Q==",
+      "dependencies": {
+        "@libp2p/interface-libp2p": "^3.2.0",
+        "@libp2p/interfaces": "^3.3.2",
+        "interface-blockstore": "^5.0.0",
+        "interface-datastore": "^8.0.0",
+        "interface-store": "^5.0.1",
+        "ipfs-bitswap": "^18.0.0",
+        "multiformats": "^11.0.1",
+        "progress-events": "^1.0.0"
+      }
+    },
+    "node_modules/@helia/interface/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@helia/interface/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@helia/interface/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@helia/interface/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@helia/interface/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@helia/interface/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
@@ -6737,6 +7103,11 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.2.tgz",
       "integrity": "sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A=="
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
     "node_modules/@lerna/child-process": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-7.4.1.tgz",
@@ -7338,6 +7709,1636 @@
         "node": "^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/@libp2p/bootstrap": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-8.0.0.tgz",
+      "integrity": "sha512-xbaJ+ybx1FGsi8FeGl9g1Wk6P2zf5/Thdk9Fe1qXV0O0xIW0xRWrefOYG5Dvt+BV54C/zlnQ4CG+Xs+Rr7wsbA==",
+      "dependencies": {
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.7",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.1",
+        "@libp2p/peer-id": "^2.0.0",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.17.tgz",
+      "integrity": "sha512-Oeg0Eb/EvAho0gVkOgemXEgrVxWaT3x/DpFgkBdZ9qGxwq75w/E/oPc7souqBz+l1swfz37GWnwV7bIb4Xv5Ag==",
+      "dependencies": {
+        "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interfaces": "^3.2.0",
+        "@noble/ed25519": "^1.6.0",
+        "@noble/secp256k1": "^1.5.4",
+        "multiformats": "^11.0.0",
+        "node-forge": "^1.1.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.4.tgz",
+      "integrity": "sha512-Pk8mzit/w7PbTh28n77RDLTU1CQBBzLygiNC07MvcEjaIwqXdNPN3Vuzr/5qiF6aDsbM9fA1W5dWoCif9xBdxg==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.1.5",
+        "abortable-iterator": "^5.0.1",
+        "it-pushable": "^3.2.0",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "race-signal": "^1.0.0",
+        "uint8arraylist": "^2.4.3"
+      }
+    },
+    "node_modules/@libp2p/interface-address-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-address-manager/-/interface-address-manager-3.0.1.tgz",
+      "integrity": "sha512-8N1nfOtZ/CnZ/cL0Bnj59fhcSs7orI4evmNVsv2DM1VaNHXqc9tPy8JmQE2HRjrUXeUPwtzzG2eoP7l0ZYdC0g==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-5.1.1.tgz",
+      "integrity": "sha512-ytknMbuuNW72LYMmTP7wFGP5ZTaUSGBCmV9f+uQ55XPcFHtKXLtKWVU/HE8IqPmwtyU8AO7veGoJ/qStMHNRVA==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-encrypter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-4.0.1.tgz",
+      "integrity": "sha512-fOtZpaFL2f5vID/RaBpVMAR9OKx5DmDT/yMEFTCarNc6Bb37fWwClI4WNCtoVbDQwcnr4H4ZIo0+9yCxjEIjjQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-gater": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-gater/-/interface-connection-gater-3.0.1.tgz",
+      "integrity": "sha512-3a+EmcKFIdYVM6tmmIKZt/4fREPApA/Z/PZHOEa4lqJA9c/BHO1HTq0YzEoYsptudYTcdhQLgpYzh8FVhfZGDg==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-3.0.1.tgz",
+      "integrity": "sha512-7ZAvzOWfHs3BtaoZoWsT+Ks1bo6HjyRMq1SJdFWDJ+ZkYEzrf6sdtQwsX8eXhwRDO6PuzpUDqLZ9TNQ2GVKEEw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@libp2p/peer-collections": "^3.0.1",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-content-routing": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.1.1.tgz",
+      "integrity": "sha512-nRPOUWgq1K1fDr3FKW93Tip7aH8AFefCw3nJygL4crepxWTSGw95s1GyDpC7t0RJkWTRNHsqZvsFsJ9FkHExKw==",
+      "dependencies": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-content-routing/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-dht": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-dht/-/interface-dht-2.0.3.tgz",
+      "integrity": "sha512-JAKbHvw3egaSeB7CHOf6PF/dLNim4kzAiXX+0IEz2lln8L32/Xf1T7KNOF/RSbSYqO9b7Xxc/b2fuSfyaMwwMQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-dht/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keychain": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.5.tgz",
+      "integrity": "sha512-mb7QNgn9fIvC7CaJCi06GJ+a6DN6RVT9TmEi0NmedZGATeCArPeWWG7r7IfxNVXb9cVOOE1RzV1swK0ZxEJF9Q==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keychain/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keys": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.8.tgz",
+      "integrity": "sha512-CJ1SlrwuoHMquhEEWS77E+4vv7hwB7XORkqzGQrPQmA9MRdIEZRS64bA4JqCLUDa4ltH0l+U1vp0oZHLT67NEA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-libp2p": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-libp2p/-/interface-libp2p-3.2.0.tgz",
+      "integrity": "sha512-Vow6xNdjpQ0M/Kt3EDz1qE/Os5OZUyhFt0YTPU5Fp3/kXw/6ocsxYq/Bzird/96gjUjU5/i+Vukn4WgctJf55Q==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-content-routing": "^2.0.0",
+        "@libp2p/interface-keychain": "^2.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interface-peer-routing": "^1.0.0",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interface-registrar": "^2.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.8.tgz",
+      "integrity": "sha512-1b9HjYyJH0m35kvPHipuoz2EtYCxyq34NUhuV8VK1VNtrouMpA3uCKp5FI7yHCA6V6+ux1R3UriKgNFOSGbIXQ==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-discovery": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-discovery/-/interface-peer-discovery-2.0.0.tgz",
+      "integrity": "sha512-Mien5t3Tc+ntP5p50acKUYJN90ouMnq1lOTQDKQNvGcXoajG8A1AEYLocnzVia/MXiexuj6S/Q28WBBacoOlBg==",
+      "dependencies": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-id/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-info": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.10.tgz",
+      "integrity": "sha512-HQlo8NwQjMyamCHJrnILEZz+YwEOXCB2sIIw3slIrhVUYeYlTaia1R6d9umaAeLHa255Zmdm4qGH8rJLRqhCcg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-routing": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.1.1.tgz",
+      "integrity": "sha512-/XEhwob9qXjdmI8PBcc+qFin32xmtyoC58nRpq8RliqHY5uOVWiHfZoNtdOXIsNvzVvq5FqlHOWt71ofxXTtlg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-store": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-2.0.4.tgz",
+      "integrity": "sha512-jNvBK3O1JPJqSiDN2vkb+PV8bTPnYdP54nxsLtut1BWukNm610lwzwleV7CetFI4bJCn6g+BgBvvq8fdADy0tA==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-pubsub": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-4.0.1.tgz",
+      "integrity": "sha512-PIc5V/J98Yr1ZTHh8lQshP7GdVUh+pKNIqj6wGaDmXs8oQLB40qKCjcpHQNlAnv2e1Bh9mEH2GXv5sGZOA651A==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-pushable": "^3.1.3",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-record": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.7.tgz",
+      "integrity": "sha512-AFPytZWI+p8FJWP0xuK5zbSjalLAOIMzEed2lBKdRWvdGBQUHt9ENLTkfkI9G7p/Pp3hlhVzzBXdIErKd+0GxQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-registrar": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.12.tgz",
+      "integrity": "sha512-EyCi2bycC2rn3oPB4Swr7EqBsvcaWd6RcqR6zsImNIG9BKc4/R1gl6iaF861JaELYgYmzBMS31x1rQpVz5UekQ==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-4.1.2.tgz",
+      "integrity": "sha512-dQJcn67UaAa8YQFRJDhbo4uT453z/2lCzD/ZwTk1YOqJxATXbXgVcB8dXDQFEUiUX3ZjVQ1IBu+NlQd+IZ++zw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@libp2p/logger": "^2.0.7",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "it-pushable": "^3.1.3",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-4.0.3.tgz",
+      "integrity": "sha512-jXFQ3blhFMEyQbFw/U8Glo3F/fUO5LEaX5HIdeqNpCliK+XnwTfpkcaG+WsJrcApWK4FFyUHc+GGqiWR0hAFFg==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-stream-muxer": "^4.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/interfaces": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.2.tgz",
+      "integrity": "sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/ipni-content-routing/-/ipni-content-routing-1.0.2.tgz",
+      "integrity": "sha512-ilsHyPSn4pJl2daAe4duhE/v5pGtqUvY0na3oso3/LBK8q74dCIxAYIho5zdL0Bxj+2E5yj4tL83wfx/B/dxmA==",
+      "deprecated": "As",
+      "dependencies": {
+        "@libp2p/interface-content-routing": "^2.0.2",
+        "@libp2p/interface-peer-info": "^1.0.9",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-id": "^2.0.3",
+        "@multiformats/multiaddr": "^12.1.2",
+        "any-signal": "^4.1.1",
+        "browser-readablestream-to-it": "^2.0.2",
+        "iterable-ndjson": "^1.1.0",
+        "multiformats": "^11.0.2",
+        "p-defer": "^4.0.0",
+        "p-queue": "^7.3.4"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/browser-readablestream-to-it": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.4.tgz",
+      "integrity": "sha512-EOjEEA+tJInvKg/Pml6QYxVY6gD8lka/ceLmkUbEeuWlzZx/a5k5ugupVFUUKSfI/88+v0VFs7JSFi5iYpp3IA=="
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/ipni-content-routing/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/kad-dht": {
+      "version": "9.3.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-9.3.8.tgz",
+      "integrity": "sha512-vxYp8k6BKdlVexanH0qY3swyN3b9YqUmirdEz+SrbWtFpkqrebIfcuE/P0Hef4qfvF6I3osk4D+GtCDyl+IRhQ==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.4",
+        "@libp2p/interface-address-manager": "^3.0.0",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-connection-manager": "^3.0.0",
+        "@libp2p/interface-content-routing": "^2.1.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-routing": "^1.1.0",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interface-registrar": "^2.0.11",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.1",
+        "@libp2p/peer-collections": "^3.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/record": "^3.0.0",
+        "@libp2p/topology": "^4.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@types/sinon": "^10.0.14",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "datastore-core": "^9.0.1",
+        "events": "^3.3.0",
+        "hashlru": "^2.3.0",
+        "interface-datastore": "^8.0.0",
+        "it-all": "^3.0.1",
+        "it-drain": "^3.0.1",
+        "it-first": "^3.0.1",
+        "it-length": "^3.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-map": "^3.0.1",
+        "it-merge": "^3.0.0",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^3.0.0",
+        "it-stream-types": "^2.0.1",
+        "it-take": "^3.0.1",
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "p-event": "^6.0.0",
+        "p-queue": "^7.3.4",
+        "private-ip": "^3.0.0",
+        "progress-events": "^1.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/it-first": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+      "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/it-map": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+      "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/keychain": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-2.0.1.tgz",
+      "integrity": "sha512-A59jilLYS+8Paq38Z96uSAxbD+3+3LJZx2qcHdMpTyqDO7yfJCbMPfVhP6EKmH5EY3z3qxBwUPVw35P4F4fslg==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-keychain": "^2.0.3",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.1",
+        "interface-datastore": "^8.0.0",
+        "merge-options": "^3.0.4",
+        "sanitize-filename": "^1.6.3",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/keychain/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@libp2p/keychain/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@libp2p/keychain/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/keychain/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@libp2p/keychain/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.1.1.tgz",
+      "integrity": "sha512-2UbzDPctg3cPupF6jrv6abQnAUTrbLybNOj0rmmrdGm1cN2HJ1o/hBu0sXuq4KF9P1h/eVRn1HIRbVIEKnEJrA==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.2",
+        "@multiformats/multiaddr": "^12.1.3",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@libp2p/logger/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mdns": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/mdns/-/mdns-8.0.0.tgz",
+      "integrity": "sha512-/q2qDWGzZpv2/LmvlwsImoEwjOhmaO9H7HDFloEs2D1+rT0dRFuQpXHAm7/sCLwx9PtmSUZp/sNj0ppnGGwK5A==",
+      "dependencies": {
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.8",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.1",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@types/multicast-dns": "^7.2.1",
+        "dns-packet": "^5.4.0",
+        "multicast-dns": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-8.0.4.tgz",
+      "integrity": "sha512-or3F5sGl8cw3TbnQgmkJ8z7/c97rwuzoy6f3b9gmkEVN8EzdxG2jOq+TEsgXzLz1GekRUR8nuDhliJ3UPhUnFw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-stream-muxer": "^4.1.2",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "abortable-iterator": "^5.0.0",
+        "any-signal": "^4.0.1",
+        "benchmark": "^2.1.4",
+        "it-batched-bytes": "^2.0.2",
+        "it-pushable": "^3.1.0",
+        "it-stream-types": "^2.0.1",
+        "rate-limiter-flexible": "^2.3.9",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/multistream-select": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-3.1.9.tgz",
+      "integrity": "sha512-iSNqr8jXvOrkNTyA43h/ARs4wd0Rd55/D6oFRndLcV4yQSUMmfjl7dUcbC5MAw+5/sgskfDx9TMawSwNq47Qwg==",
+      "dependencies": {
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "abortable-iterator": "^5.0.0",
+        "it-first": "^3.0.1",
+        "it-handshake": "^4.1.3",
+        "it-length-prefixed": "^9.0.0",
+        "it-merge": "^3.0.0",
+        "it-pipe": "^3.0.0",
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.3.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/it-first": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+      "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/peer-collections": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-3.0.2.tgz",
+      "integrity": "sha512-3vRVMWVRCF6dVs/1/CHbw4YSv83bcqjZuAt9ZQHW85vn6OfHNFQesOHWT1TbRBuL8TSb//IwJkOfTAVLd6Mymw==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.4.tgz",
+      "integrity": "sha512-gcOsN8Fbhj6izIK+ejiWsqiqKeJ2yWPapi/m55VjOvDa52/ptQzZszxQP8jUk93u36de92ATFXDfZR/Bi6eeUQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id-factory": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.4.tgz",
+      "integrity": "sha512-+0D+oklFzHpjRI3v7uw3PMMx00P36DV7YvAgL0+gpos0VzR/BI9tRiM6dpObZTrQ1hxp78F03p+qR1Zy9Qnmuw==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.0",
+        "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id-factory/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id-factory/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/peer-id-factory/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-record": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.4.tgz",
+      "integrity": "sha512-e+AArf7pwMLqF24mehTe1OYjr1v0SOKshVrI1E9YH/Cb1F3ZZuK3smyGmnLaS4JlqsarRCMSe3V50tRkqMFY7g==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-record": "^2.0.1",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/utils": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^1.0.2",
+        "uint8arraylist": "^2.1.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-record/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-record/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/peer-store": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-8.2.1.tgz",
+      "integrity": "sha512-mr0GsZ7zucta3l5EblOGrBeVgdTVujRJ9WC+FmnYErQe023SRJevAZEv1WeMinMGVGL6CY+gmWw0oLpExu9AWg==",
+      "dependencies": {
+        "@libp2p/interface-libp2p": "^3.1.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-store": "^2.0.4",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-collections": "^3.0.1",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-id-factory": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.3",
+        "@multiformats/multiaddr": "^12.0.0",
+        "interface-datastore": "^8.0.0",
+        "it-all": "^3.0.2",
+        "mortice": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/@libp2p/peer-store/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/@libp2p/peer-store/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/pubsub": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-7.0.3.tgz",
+      "integrity": "sha512-BrUBQ6ljN1tU+2Hn1Vq+ZT/foVBGUVIywqoavNrFw5CmaBBTGuVRrmqE/MUToIS8dhonpW5RNCRabz3woq/4iQ==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.0",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interface-pubsub": "^4.0.0",
+        "@libp2p/interface-registrar": "^2.0.11",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-collections": "^3.0.1",
+        "@libp2p/peer-id": "^2.0.3",
+        "@libp2p/topology": "^4.0.1",
+        "abortable-iterator": "^5.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.3",
+        "multiformats": "^11.0.0",
+        "p-queue": "^7.2.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/pubsub/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/@libp2p/pubsub/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/pubsub/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/pubsub/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/pubsub/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/pubsub/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/record": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/record/-/record-3.0.4.tgz",
+      "integrity": "sha512-cVefFlnlvuxkLwPnHvSDF05HT6PyBM33eBi0BtJ7ocbZTtN4hY44DNmkM0z3ht9/9blSQ9e12gXV6nePH4Q4AA==",
+      "dependencies": {
+        "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/record/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/record/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/record/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/tcp": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-7.0.3.tgz",
+      "integrity": "sha512-w1g5/BYDNpZKXrJZd1PW8kUS0GxHwFO6oql3rIizh5WaxmWtMa21LtKWIoHJyC8Wp4vshEUPeZthAIKECqUafg==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/utils": "^3.0.2",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@types/sinon": "^10.0.15",
+        "stream-to-it": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/topology": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/topology/-/topology-4.0.3.tgz",
+      "integrity": "sha512-uXd9ZYpmgb+onMTypsAPUlvKKeY20HMtxwsjAMEfDa29yqshK8DiEunHZNjLmtXaMIIO9CBl2w5ykjt5TtFsBQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-registrar": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/tracked-map": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-3.0.4.tgz",
+      "integrity": "sha512-G5ElrjFoubP10TwQo3dnRVaxhshU9wtu86qq0cIXNv12XCFpvTvx12Vbf8sV1SU5imrWgd6XQgfRKsQtjmu3Ew==",
+      "dependencies": {
+        "@libp2p/interface-metrics": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.13.tgz",
+      "integrity": "sha512-SNwIcQq/FvLpqVsjHHzbxSq7VgbbUK9EB7/865Re4NoLfqgE/6oTUpyPEDlrcJb4aTPFWbVPQzE85cA3raHIIw==",
+      "dependencies": {
+        "@achingbrain/ip-address": "^8.1.0",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "abortable-iterator": "^5.0.0",
+        "is-loopback-addr": "^2.0.1",
+        "it-stream-types": "^2.0.1",
+        "private-ip": "^3.0.0",
+        "uint8arraylist": "^2.3.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/webrtc/-/webrtc-2.0.11.tgz",
+      "integrity": "sha512-6lhlndCYxRrkbqldUFruxIzyyFcrgnyueYIpLXJP2phZf2P19zwhborae0raRyeRz7MwJ+uw+Ksql8D8Ry+KXg==",
+      "dependencies": {
+        "@chainsafe/libp2p-noise": "^12.0.0",
+        "@libp2p/interface-connection": "^5.0.2",
+        "@libp2p/interface-metrics": "^4.0.8",
+        "@libp2p/interface-peer-id": "^2.0.2",
+        "@libp2p/interface-registrar": "^2.0.12",
+        "@libp2p/interface-stream-muxer": "^4.1.2",
+        "@libp2p/interface-transport": "^4.0.3",
+        "@libp2p/interfaces": "^3.3.2",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/peer-id": "^2.0.3",
+        "@multiformats/mafmt": "^12.1.2",
+        "@multiformats/multiaddr": "^12.1.2",
+        "abortable-iterator": "^5.0.1",
+        "detect-browser": "^5.3.0",
+        "it-length-prefixed": "^9.0.1",
+        "it-pb-stream": "^4.0.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.3",
+        "it-stream-types": "^2.0.1",
+        "it-to-buffer": "^4.0.2",
+        "multiformats": "^11.0.2",
+        "multihashes": "^4.0.3",
+        "p-defer": "^4.0.0",
+        "p-event": "^6.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.6.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/multibase": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
+      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "dependencies": {
+        "@multiformats/base-x": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/multihashes": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
+      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
+      "dependencies": {
+        "multibase": "^4.0.1",
+        "uint8arrays": "^3.0.0",
+        "varint": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/multihashes/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "node_modules/@libp2p/webrtc/node_modules/multihashes/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+    },
+    "node_modules/@libp2p/websockets": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-6.0.3.tgz",
+      "integrity": "sha512-pwOr3iAbczWmmCg1nHnC2Dl0Ek81Y6LE8ptImiUbuZ08q1E/fTumM8pRNmrrsogSshG4lugebArIO9SNMylJZg==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/utils": "^3.0.2",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@multiformats/multiaddr-to-uri": "^9.0.2",
+        "@types/ws": "^8.5.4",
+        "abortable-iterator": "^5.0.0",
+        "it-ws": "^6.0.0",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.0.0",
+        "wherearewe": "^2.0.1",
+        "ws": "^8.12.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@libp2p/webtransport": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/webtransport/-/webtransport-2.0.2.tgz",
+      "integrity": "sha512-Vok9j2WT6tF7dlDdbDV3EfenTsGLim1icrR6HqSzTRZAZn7uOBtMKKoO2YnXgGyHmnstqxLt0axnZWc2v5uKNQ==",
+      "dependencies": {
+        "@chainsafe/libp2p-noise": "^12.0.1",
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-stream-muxer": "^4.0.0",
+        "@libp2p/interface-transport": "^4.0.1",
+        "@libp2p/logger": "^2.0.2",
+        "@libp2p/peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.1.0",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arraylist": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/webtransport/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
@@ -7594,6 +9595,90 @@
         "tslib": "^2.3.1"
       }
     },
+    "node_modules/@multiformats/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
+    "node_modules/@multiformats/mafmt": {
+      "version": "12.1.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.6.tgz",
+      "integrity": "sha512-tlJRfL21X+AKn9b5i5VnaTD6bNttpSpcqwKVmDmSHLwxoz97fAHaepqFOk/l1fIu94nImIXneNbhsJx/RQNIww==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "12.1.8",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.8.tgz",
+      "integrity": "sha512-9WCmSiQV3X8T3YR7cb7TieEumnJhRd9aGjeYFIN0VVvjAj7WciryDOE9Ot3W9RDwpjNeEwHDubM+tHBkPrdpzg==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^0.1.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^12.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.7.tgz",
+      "integrity": "sha512-i3ldtPMN6XJt+MCi34hOl0wGuGEHfWWMw6lmNag5BpckPwPTf9XGOOFMmh7ed/uO3Vjah/g173iOe61HTQVoBA==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/native-fetch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
+      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
+      "peerDependencies": {
+        "undici": "*"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/uint8-varint": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.2.tgz",
+      "integrity": "sha512-LZXmBT0jiHR7J4oKM1GUhtdLFW1yPauzI8NjJlotXn92TprO9u8VMvEVR4QMk8xhUVUd+2fqfU2/kGbVHYSSWw==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "13.5.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz",
@@ -7789,6 +9874,14 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.1.4.tgz",
+      "integrity": "sha512-d3ZR8vGSpy3v/nllS+bD/OMN5UZqusWiQqkyj7AwzTnhXFH72pF5oB4Ach6DQ50g5kXxC28LdaYBEpsyv9KOUQ==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
@@ -7799,6 +9892,17 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@noble/hashes": {
       "version": "1.3.2",
@@ -9520,6 +11624,27 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+      "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.39.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polka/url": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-0.5.0.tgz",
+      "integrity": "sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw==",
+      "dev": true
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -12632,6 +14757,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.4.tgz",
+      "integrity": "sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -12687,6 +14822,14 @@
       "integrity": "sha512-adBosR2GntaQQiuHnfRN9HtxYpoHHJBcdyz7VSXhjpSAmtvIfu/S1fjTqwuIx/Ypba6LCZdfWIqPYx2BR5TneQ==",
       "dev": true
     },
+    "node_modules/@types/dns-packet": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.2.tgz",
+      "integrity": "sha512-vgUZ0ilYvpnTDx7tBmmAUn1HsyzK3huAtulHaDbBBCW5UdaDrEei5XJjWHnD4s8r9/MSL1hJ8s+nvJdcvNKgMA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.44.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.6.tgz",
@@ -12718,6 +14861,30 @@
       "integrity": "sha512-GNBWlGBMjiiiL5TSkvPtOteuXsiVitw5MYGY1UYlrAq0SKyczsls6sCD7TZ8fsjRsvCVxml7EbyjJezPb3DrSA==",
       "dependencies": {
         "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.20.tgz",
+      "integrity": "sha512-rOaqlkgEvOW495xErXMsmyX3WKBInbhG5eqojXYi3cGUaLoRDlXa5d52fkfWZT963AZ3v2eZ4MbKE6WpDAGVsw==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.39",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.39.tgz",
+      "integrity": "sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/form-data": {
@@ -12778,6 +14945,12 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
       "integrity": "sha512-V46MYLFp08Wf2mmaBhvgjStM3tPa+2GAdy/iqoX+noX1//zje2x4XmrIU0cAwyClATsTmahbtoQ2EwP7I5WSiA=="
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.3.tgz",
+      "integrity": "sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -12894,6 +15067,12 @@
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.9.tgz",
       "integrity": "sha512-OKMdj17y8Cs+k1r0XFyp59ChSOwf8ODGtMQ4mnpfz5eFDk1aO41yN3pSKGuvVzmWAkFp37seubY1tzOVpwfWwg=="
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha512-1Gjee59G25MrQGk8bsNvC6fxNiRgUlGn2wlhGf95a59DrprnnHk80FIMMFG9XHMdrfsuA119ht06QPDXA1Z7tw==",
+      "dev": true
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -12923,6 +15102,15 @@
       "version": "0.7.33",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.33.tgz",
       "integrity": "sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ=="
+    },
+    "node_modules/@types/multicast-dns": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.3.tgz",
+      "integrity": "sha512-2SZ079yRhuhDn5BssqkQGp07vErjm3PD8S/JAlduWXacZ8SVHF0q6R2m0PwjjgTDU1vE3kibNPlmnr1iKbP/Sw==",
+      "dependencies": {
+        "@types/dns-packet": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.8.9",
@@ -12962,6 +15150,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/polka": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@types/polka/-/polka-0.5.6.tgz",
+      "integrity": "sha512-DU+Esoykng6azh+5jOMhsPQKz9m4QFGcSCrhm9KB/cUIgspPbslrxqIpF79b/Y/+HseTHpP/E6BstlAwH5I1ig==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/node": "*",
+        "@types/trouter": "*"
+      }
+    },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
@@ -12992,6 +15192,12 @@
       "version": "6.9.9",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.9.tgz",
       "integrity": "sha512-wYLxw35euwqGvTDx6zfY1vokBFnsK0HNrzc6xNHchxfO2hpuRg74GbkEW7e3sSmPvj0TjCDT1VCa6OtHXnubsg=="
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.6.tgz",
+      "integrity": "sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.2.14",
@@ -13065,6 +15271,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.5",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.5.tgz",
@@ -13084,11 +15295,31 @@
       "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
       "dev": true
     },
+    "node_modules/@types/send": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.3.tgz",
+      "integrity": "sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.4.tgz",
+      "integrity": "sha512-aqqNfs1XTF0HDrFdlY//+SGUxmdSUbjeRXb5iaZc3x0/vMbYmdw9qvOgHWOyyLFxSSRnUuP5+724zBgfw8/WAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sinon": {
       "version": "10.0.20",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
       "integrity": "sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==",
-      "dev": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -13096,8 +15327,7 @@
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.4",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.4.tgz",
-      "integrity": "sha512-GDV68H0mBSN449sa5HEj51E0wfpVQb8xNSMzxf/PrypMFcLTMwJMOM/cgXiv71Mq5drkOQmUGvL1okOZcu6RrQ==",
-      "dev": true
+      "integrity": "sha512-GDV68H0mBSN449sa5HEj51E0wfpVQb8xNSMzxf/PrypMFcLTMwJMOM/cgXiv71Mq5drkOQmUGvL1okOZcu6RrQ=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.2",
@@ -13105,10 +15335,25 @@
       "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==",
       "dev": true
     },
+    "node_modules/@types/stoppable": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/stoppable/-/stoppable-1.1.2.tgz",
+      "integrity": "sha512-zRBGFTIdkCAdM4VDeFvka5NbD6JVfz7yEYzggKrXQ03ZplrZp5vqQPWHTw0wk81wer61dwi44Tp6FDDXoPBW5A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stylis": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.2.tgz",
       "integrity": "sha512-Rm17MsTpQQP5Jq4BF7CdrxJsDufoiL/q5IbJZYZmOZAJALyijgF7BzLgobXUqraNcQdqFYLYGeglDp6QzaxPpg=="
+    },
+    "node_modules/@types/trouter": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/trouter/-/trouter-3.1.3.tgz",
+      "integrity": "sha512-NNcyQHeUe3Jv09YxBF21EkKbiqCaI1480BPqaGKy0Xby993d0MBHB+XMG/cVf5lCPxm9Qd8AdEYHd1IVLwq7lA==",
+      "dev": true
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.5",
@@ -13449,6 +15694,10 @@
       "resolved": "packages/cli",
       "link": true
     },
+    "node_modules/@usecannon/repo": {
+      "resolved": "packages/repo",
+      "link": true
+    },
     "node_modules/@vanilla-extract/css": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.9.1.tgz",
@@ -13503,6 +15752,11 @@
       "peerDependencies": {
         "@vanilla-extract/css": "^1.0.0"
       }
+    },
+    "node_modules/@vascosantos/moving-average": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/moving-average/-/moving-average-1.1.0.tgz",
+      "integrity": "sha512-MVEJ4vWAPNbrGLjz7ITnHYg+YXZ6ijAqtH5/cHwSoCpbvuJ98aLXwFfPKAUfZpJMQR5uXB58UJajbY130IRF/w=="
     },
     "node_modules/@vercel/analytics": {
       "version": "1.1.1",
@@ -14667,6 +16921,24 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abortable-iterator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+      "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+      "dependencies": {
+        "get-iterator": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/abortable-iterator/node_modules/get-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-2.0.1.tgz",
+      "integrity": "sha512-7HuY/hebu4gryTDT7O/XY/fvY9wRByEGdK6QOa4of8npTcv0+NS6frFKABcf6S9EBAsveTuKTsZQQBFMMNILIg=="
+    },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
@@ -15764,6 +18036,15 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "node_modules/big.js": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
@@ -15900,6 +18181,84 @@
       "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
       "dependencies": {
         "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
+    "node_modules/blockstore-core": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-4.3.4.tgz",
+      "integrity": "sha512-JecnNXiDPEdeS9AeFWO0PUKKmmRMW0D+ggUb4lgK0XMDOUAWmhkaiDPhgBjEKrlya0n60XOjcgBYhg18CUqOFw==",
+      "dependencies": {
+        "@libp2p/logger": "^3.0.0",
+        "err-code": "^3.0.1",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.0.0",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.0",
+        "it-merge": "^3.0.1",
+        "it-pushable": "^3.0.0",
+        "multiformats": "^12.0.1",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/@libp2p/logger": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.4.tgz",
+      "integrity": "sha512-MF42c7SOJIx5YmHhIsFaSYfaC266YYmMbAJHjjH8Zl5unFsqW82M+Xr7sGVj9/WXrWAd37ts8xJaQrkIXc3OZQ==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.4",
+        "@multiformats/multiaddr": "^12.1.5",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/blockstore-core/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
       }
     },
     "node_modules/bluebird": {
@@ -16292,6 +18651,18 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/byte-access": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/byte-access/-/byte-access-1.0.1.tgz",
+      "integrity": "sha512-GKYa+lvxnzhgHWj9X+LCsQ4s2/C5uvib573eAOiQKywXMkzFFErY2+yQdzmdE5iWVpmqecsRx3bOtOY4/1eINw==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/byte-size": {
@@ -18595,6 +20966,105 @@
       "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
       "dev": true
     },
+    "node_modules/datastore-core": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-9.2.3.tgz",
+      "integrity": "sha512-jcvrVDt+jp7lUp2WhMXXgX/hoi3VcJebN+z/ZXbIRKOVfNOF4bl8cvr7sQ1y9qITikgC2coXFYd79Wzt/n13ZQ==",
+      "dependencies": {
+        "@libp2p/logger": "^3.0.0",
+        "err-code": "^3.0.1",
+        "interface-store": "^5.0.0",
+        "it-all": "^3.0.1",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.0",
+        "it-map": "^3.0.1",
+        "it-merge": "^3.0.1",
+        "it-pipe": "^3.0.0",
+        "it-pushable": "^3.0.0",
+        "it-sort": "^3.0.1",
+        "it-take": "^3.0.1",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/datastore-core/node_modules/@libp2p/logger": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.4.tgz",
+      "integrity": "sha512-MF42c7SOJIx5YmHhIsFaSYfaC266YYmMbAJHjjH8Zl5unFsqW82M+Xr7sGVj9/WXrWAd37ts8xJaQrkIXc3OZQ==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.4",
+        "@multiformats/multiaddr": "^12.1.5",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/datastore-core/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/datastore-core/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/datastore-core/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/datastore-core/node_modules/it-map": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+      "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+    },
+    "node_modules/datastore-core/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/datastore-core/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -18772,6 +21242,119 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/default-gateway": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-7.2.2.tgz",
+      "integrity": "sha512-AD7TrdNNPXRZIGw63dw+lnGmT4v7ggZC5NHNJgAYWm5njrwoze1q5JSAW9YuLy2tjnoLUG/r8FEB93MCh9QJPg==",
+      "dependencies": {
+        "execa": "^7.1.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/default-gateway/node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/default-gateway/node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/default-gateway/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -18914,6 +21497,14 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "dev": true
+    },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -19087,6 +21678,17 @@
         "debug": "^4.3.1",
         "native-fetch": "^3.0.0",
         "receptacle": "^1.3.2"
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/docker-compose": {
@@ -21398,6 +24000,11 @@
         "npm": ">=3"
       }
     },
+    "node_modules/event-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
+      "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ=="
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -22136,6 +24743,15 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/freeport-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/freeport-promise/-/freeport-promise-2.0.0.tgz",
+      "integrity": "sha512-dwWpT1DdQcwrhmRwnDnPM/ZFny+FtzU+k50qF2eid3KxaQDsMiBrwo1i0G3qSugkN5db6Cb0zgfc68QeTOpEFg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -24077,6 +26693,11 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
     "node_modules/hasown": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
@@ -24194,6 +26815,176 @@
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/helia": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/helia/-/helia-1.3.12.tgz",
+      "integrity": "sha512-/RCYJPpjBtudX2gHhFpc3I1isQIHZ43fQxzzDnIJ49DGhv8kyWdQ9gko9jt89X5vi0fv80HesQQGmo0rNdEDeA==",
+      "dependencies": {
+        "@chainsafe/libp2p-gossipsub": "^8.0.0",
+        "@chainsafe/libp2p-noise": "^12.0.0",
+        "@chainsafe/libp2p-yamux": "^4.0.2",
+        "@helia/interface": "^1.0.0",
+        "@ipld/dag-pb": "^4.0.3",
+        "@libp2p/bootstrap": "^8.0.0",
+        "@libp2p/interface-libp2p": "^3.2.0",
+        "@libp2p/interface-pubsub": "^4.0.1",
+        "@libp2p/interfaces": "^3.3.2",
+        "@libp2p/ipni-content-routing": "^1.0.0",
+        "@libp2p/kad-dht": "^9.3.3",
+        "@libp2p/logger": "^2.0.7",
+        "@libp2p/mdns": "^8.0.0",
+        "@libp2p/mplex": "^8.0.3",
+        "@libp2p/tcp": "^7.0.1",
+        "@libp2p/webrtc": "^2.0.4",
+        "@libp2p/websockets": "^6.0.1",
+        "@libp2p/webtransport": "^2.0.1",
+        "blockstore-core": "^4.0.0",
+        "cborg": "^1.10.0",
+        "datastore-core": "^9.0.0",
+        "interface-blockstore": "^5.0.0",
+        "interface-datastore": "^8.0.0",
+        "interface-store": "^5.0.1",
+        "ipfs-bitswap": "^18.0.0",
+        "ipns": "^6.0.0",
+        "it-all": "^3.0.2",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.1",
+        "it-foreach": "^2.0.2",
+        "libp2p": "^0.45.2",
+        "mortice": "^3.0.1",
+        "multiformats": "^11.0.1",
+        "p-defer": "^4.0.0",
+        "p-queue": "^7.3.4",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^4.0.3"
+      }
+    },
+    "node_modules/helia/node_modules/@ipld/dag-pb": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.6.tgz",
+      "integrity": "sha512-wOij3jfDKZsb9yjhQeHp+TQy0pu1vmUkGv324xciFFZ7xGbDfAGTQW03lSA5aJ/7HBBNYgjEE0nvHmNW1Qjfag==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/helia/node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/helia/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/helia/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/helia/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/helia/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/helia/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/helia/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/helia/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/helia/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/helia/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/helia/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/helia/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/hey-listen": {
@@ -24791,6 +27582,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/interface-blockstore": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.2.6.tgz",
+      "integrity": "sha512-Cp6+QPY81kunaxQV/j5BWk3uSW6kpos8dLveJ3P2lbmA/yX2XeMwVlNOnQyGg0evhp1qmMLhf6eCswNiSMW3CA==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/interface-blockstore/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/interface-blockstore/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/interface-datastore": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
@@ -24864,6 +27678,102 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipfs-bitswap": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-18.0.3.tgz",
+      "integrity": "sha512-ebUB/OMeVLbqnHn61VIgSJKTFQcuIJxSjjF0k5yHZRPVll1QE9APYe15dLyKQUiotiEBEQ9tHe7CsoId416PRg==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.1.0",
+        "@libp2p/interface-libp2p": "^3.1.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.8",
+        "@libp2p/interface-registrar": "^2.0.8",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/topology": "^4.0.0",
+        "@libp2p/tracked-map": "^3.0.0",
+        "@multiformats/multiaddr": "^12.1.0",
+        "@vascosantos/moving-average": "^1.1.0",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "blockstore-core": "^4.0.0",
+        "events": "^3.3.0",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.1.0",
+        "it-foreach": "^2.0.2",
+        "it-length-prefixed": "^9.0.0",
+        "it-map": "^3.0.2",
+        "it-pipe": "^3.0.1",
+        "it-take": "^3.0.1",
+        "just-debounce-it": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "progress-events": "^1.0.0",
+        "protons-runtime": "^5.0.0",
+        "timeout-abort-controller": "^3.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0",
+        "varint-decoder": "^1.0.0"
+      }
+    },
+    "node_modules/ipfs-bitswap/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-bitswap/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/ipfs-bitswap/node_modules/it-map": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+      "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/ipfs-bitswap/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+    },
+    "node_modules/ipfs-bitswap/node_modules/just-debounce-it": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-3.2.0.tgz",
+      "integrity": "sha512-WXzwLL0745uNuedrCsCs3rpmfD6DBaf7uuVwaq98/8dafURfgQaBsSpjiPp5+CW6Vjltwy9cOGI6qE71b3T8iQ=="
+    },
+    "node_modules/ipfs-bitswap/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-bitswap/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/ipfs-bitswap/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/ipfs-core-types": {
@@ -24975,6 +27885,119 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipns": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-6.0.7.tgz",
+      "integrity": "sha512-VHC7XAEjqQwBzP1PbCRVOhGo4QFQTVuV93m8Ul3flzJt77WQWU6XPitXUPOT+LZ8yrObMXHzlt/ZheP3Ypwi4g==",
+      "dependencies": {
+        "@libp2p/crypto": "^2.0.3",
+        "@libp2p/interface": "^0.1.2",
+        "@libp2p/logger": "^3.0.2",
+        "@libp2p/peer-id": "^3.0.2",
+        "cborg": "^4.0.1",
+        "err-code": "^3.0.1",
+        "interface-datastore": "^8.1.0",
+        "multiformats": "^12.0.1",
+        "protons-runtime": "^5.0.0",
+        "timestamp-nano": "^1.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/ipns/node_modules/@libp2p/crypto": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-2.0.6.tgz",
+      "integrity": "sha512-SK2nOsXsM/9Urtipw1C+KJ2e2PU+Z0AxBWiQti9oC+2mFXOy7erry2n2wH3aCTpajQX6D+Erm39yaS55w4AVLw==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.4",
+        "@noble/curves": "^1.1.0",
+        "@noble/hashes": "^1.3.1",
+        "multiformats": "^12.0.1",
+        "node-forge": "^1.1.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
+      }
+    },
+    "node_modules/ipns/node_modules/@libp2p/logger": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.4.tgz",
+      "integrity": "sha512-MF42c7SOJIx5YmHhIsFaSYfaC266YYmMbAJHjjH8Zl5unFsqW82M+Xr7sGVj9/WXrWAd37ts8xJaQrkIXc3OZQ==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.4",
+        "@multiformats/multiaddr": "^12.1.5",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/ipns/node_modules/@libp2p/peer-id": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-3.0.4.tgz",
+      "integrity": "sha512-qqg/zlFFVrIV80KhRTeajRwbtolOC2UCQ33w0XcXNxVVseFLxcw1pQ05Yn3x5zjzKIl3M04XxFCNkagWqGXD1A==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.4",
+        "multiformats": "^12.0.1",
+        "uint8arrays": "^4.0.6"
+      }
+    },
+    "node_modules/ipns/node_modules/cborg": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.5.tgz",
+      "integrity": "sha512-q8TAjprr8pn9Fp53rOIGp/UFDdFY6os2Nq62YogPSIzczJD9M6g2b6igxMkpCiZZKJ0kn/KzDLDvG+EqBIEeCg==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/ipns/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/ipns/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/ipns/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipns/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
       }
     },
     "node_modules/is-absolute": {
@@ -25344,6 +28367,11 @@
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
+    },
+    "node_modules/is-loopback-addr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-loopback-addr/-/is-loopback-addr-2.0.2.tgz",
+      "integrity": "sha512-26POf2KRCno/KTNL5Q0b/9TYnL00xEsSaLfiFRmjM7m7Lw7ZMmFybzzuX4CcsLAluZGd+niLUiMRxEooVE3aqg=="
     },
     "node_modules/is-lower-case": {
       "version": "2.0.2",
@@ -25874,10 +28902,61 @@
       "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
       "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
     },
+    "node_modules/it-batched-bytes": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-2.0.4.tgz",
+      "integrity": "sha512-n4V19XACvFG+b8lCkuvidYvwpyz3++DAolqZGI+9AcDvIPMAhVwwtFCe9SiDIz45OzQnnNYwBgBxbIinHPgraA==",
+      "dependencies": {
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.4.1"
+      }
+    },
+    "node_modules/it-batched-bytes/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/it-drain": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.3.tgz",
+      "integrity": "sha512-l4s+izxUpFAR2axprpFiCaq0EtxK1QMd0LWbEtau5b+OegiZ5xdRtz35iJyh6KZY9QtuwEiQxydiOfYJc7stoA=="
+    },
+    "node_modules/it-filter": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.0.3.tgz",
+      "integrity": "sha512-2zXUrJuuV6QHM21ahc8NqVUUxkLMVDWXBoUBcj9GCQLQez2OXmddTHN0r0F5B+TkNTpeL618yIgXi1HNPJOxow==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/it-filter/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+    },
     "node_modules/it-first": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
       "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "node_modules/it-foreach": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-2.0.4.tgz",
+      "integrity": "sha512-txxcoc09g+KdLyOapxAuB12H9zUb2FuZC/TqSXRT+YR0T5fHnvcDIhspgvx/e/HiPKlKjOR8onA0qtuiAtcXqg==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/it-foreach/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
     },
     "node_modules/it-glob": {
       "version": "1.0.2",
@@ -25888,20 +28967,266 @@
         "minimatch": "^3.0.4"
       }
     },
+    "node_modules/it-handshake": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-4.1.3.tgz",
+      "integrity": "sha512-V6Lt9A9usox9iduOX+edU1Vo94E6v9Lt9dOvg3ubFaw1qf5NCxXLi93Ao4fyCHWDYd8Y+DUhadwNtWVyn7qqLg==",
+      "dependencies": {
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-handshake/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/it-last": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
       "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+    },
+    "node_modules/it-length": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-length/-/it-length-3.0.3.tgz",
+      "integrity": "sha512-aLoeonDJV6wMgT1ElEruc61c3FYxGa3yymujfZ0Uk4Up7mUJ15xl1ixxPnGbm+BnMkEQylJXjzp1vNYEY9blvg=="
+    },
+    "node_modules/it-length-prefixed": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.3.tgz",
+      "integrity": "sha512-YAu424ceYpXctxtjcLOqn7vJq082CaoP8J646ZusYISfQc3bpzQErgTUqMFj81V262KG2W9/YMBHsy6A/4yvmg==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-length-prefixed/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-length-prefixed/node_modules/uint8-varint": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.2.tgz",
+      "integrity": "sha512-LZXmBT0jiHR7J4oKM1GUhtdLFW1yPauzI8NjJlotXn92TprO9u8VMvEVR4QMk8xhUVUd+2fqfU2/kGbVHYSSWw==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/it-length-prefixed/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
     },
     "node_modules/it-map": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
       "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
     },
+    "node_modules/it-merge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.2.tgz",
+      "integrity": "sha512-bMk2km8lTz+Rwv30hzDUdGIcqQkOemFJqmGT2wqQZ6/zHKCsYqdRunPrteCqHLV/nIVhUK8nZZkDA2eJ4MJZiA==",
+      "dependencies": {
+        "it-pushable": "^3.2.0"
+      }
+    },
+    "node_modules/it-pair": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.6.tgz",
+      "integrity": "sha512-5M0t5RAcYEQYNG5BV7d7cqbdwbCAp5yLdzvkxsZmkuZsLbTdZzah6MQySYfaAQjNDCq6PUnDt0hqBZ4NwMfW6g==",
+      "dependencies": {
+        "it-stream-types": "^2.0.1",
+        "p-defer": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pair/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/it-parallel": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.4.tgz",
+      "integrity": "sha512-fuA+SysGxbZc+Yl7EUvzQqZ8bNYQghZ0Mq9zA+fxMQ5eQYzatNg6oJk1y1PvPvNqLgKJMzEInpRO6PbLC3hGAg==",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      }
+    },
+    "node_modules/it-parallel/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/it-pb-stream": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-4.0.2.tgz",
+      "integrity": "sha512-wZ4Bvx2MfwamZTeyFQdX1SnD97hqdhpnaQwmbHqX4eT0pNWFPZ0mkKXbUkhLw2M0UNQNkEGN4wxljMod95c/ig==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^1.0.6",
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/it-peekable": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
       "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
+    },
+    "node_modules/it-pipe": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+      "dependencies": {
+        "it-merge": "^3.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pushable": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.1.tgz",
+      "integrity": "sha512-sLFz2Q0oyDCJpTciZog7ipP4vSftfPy3e6JnH6YyztRa1XqkpGQaafK3Jw/JlfEBtCXfnX9uVfcpu3xpSAqCVQ==",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pushable/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/it-reader": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.4.tgz",
+      "integrity": "sha512-XCWifEcNFFjjBHtor4Sfaj8rcpt+FkY0L6WdhD578SCDhV4VUm7fCkF3dv5a+fTcfQqvN9BsxBTvWbYO6iCjTg==",
+      "dependencies": {
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-sort": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-3.0.3.tgz",
+      "integrity": "sha512-9BuQc5Y2fmBUNhevQBUDHfItrQmzWoZcnzydJl91V6na6M+RkbNj71UtCPPNIpOt/SQG+va0pe1wMQJ9lP2Oew==",
+      "dependencies": {
+        "it-all": "^3.0.0"
+      }
+    },
+    "node_modules/it-sort/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-take": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-3.0.3.tgz",
+      "integrity": "sha512-Ay5SXEyrBKD0tO8PQif2QjrStImIsLIg0F50Uu4EeXOw8C9DfVIGfsGL3X9s65F2I9skDp9mLgBzl71IToMxNw=="
+    },
+    "node_modules/it-to-buffer": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-4.0.3.tgz",
+      "integrity": "sha512-/xdI2hD/LvK7tzS/9DY9oKATmUZ9rg9uG7IfQRBAokM/LLujJ179fqRGneluqwKpXOtCpMRo43LJZXr8aibv6Q==",
+      "dependencies": {
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/it-to-buffer/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-to-buffer/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
     },
     "node_modules/it-to-stream": {
       "version": "1.0.0",
@@ -25914,6 +29239,68 @@
         "p-defer": "^3.0.0",
         "p-fifo": "^1.0.0",
         "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/it-ws": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-6.0.5.tgz",
+      "integrity": "sha512-xp7tF4fHgx8+vN3Qy/8wGiWUKbC9E1U1g9PwtlbdxD7pY4zld71ZyWZVFHLxnxxg14T9mVNK5uO7U9HK11VQ5g==",
+      "dependencies": {
+        "@types/ws": "^8.2.2",
+        "event-iterator": "^2.0.0",
+        "iso-url": "^1.1.2",
+        "it-stream-types": "^2.0.1",
+        "uint8arrays": "^4.0.2",
+        "ws": "^8.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-ws/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-ws/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/it-ws/node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/iterable-ndjson": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
+      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+      "dependencies": {
+        "string_decoder": "^1.2.0"
       }
     },
     "node_modules/iterator.prototype": {
@@ -27805,6 +31192,213 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/libp2p": {
+      "version": "0.45.9",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.45.9.tgz",
+      "integrity": "sha512-cf2dCf8naZqQoDw3xxSEZ6rKgQ8BBne5iWgtIKHAYrCvL+ulshz72jNgeAG0FQ/jjRD3yzmUuwoMaLHj6gf7Bw==",
+      "dependencies": {
+        "@achingbrain/nat-port-mapper": "^1.0.9",
+        "@libp2p/crypto": "^1.0.17",
+        "@libp2p/interface-address-manager": "^3.0.0",
+        "@libp2p/interface-connection": "^5.1.1",
+        "@libp2p/interface-connection-encrypter": "^4.0.0",
+        "@libp2p/interface-connection-gater": "^3.0.0",
+        "@libp2p/interface-connection-manager": "^3.0.0",
+        "@libp2p/interface-content-routing": "^2.1.0",
+        "@libp2p/interface-keychain": "^2.0.4",
+        "@libp2p/interface-libp2p": "^3.2.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-discovery": "^2.0.0",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-routing": "^1.1.0",
+        "@libp2p/interface-peer-store": "^2.0.4",
+        "@libp2p/interface-pubsub": "^4.0.0",
+        "@libp2p/interface-record": "^2.0.6",
+        "@libp2p/interface-registrar": "^2.0.3",
+        "@libp2p/interface-stream-muxer": "^4.0.0",
+        "@libp2p/interface-transport": "^4.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/keychain": "^2.0.0",
+        "@libp2p/logger": "^2.1.1",
+        "@libp2p/multistream-select": "^3.1.8",
+        "@libp2p/peer-collections": "^3.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-id-factory": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@libp2p/peer-store": "^8.2.0",
+        "@libp2p/topology": "^4.0.1",
+        "@libp2p/tracked-map": "^3.0.0",
+        "@libp2p/utils": "^3.0.10",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "datastore-core": "^9.0.0",
+        "interface-datastore": "^8.0.0",
+        "it-all": "^3.0.1",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.1",
+        "it-first": "^3.0.1",
+        "it-handshake": "^4.1.3",
+        "it-length-prefixed": "^9.0.1",
+        "it-map": "^3.0.2",
+        "it-merge": "^3.0.0",
+        "it-pair": "^2.0.2",
+        "it-parallel": "^3.0.0",
+        "it-pb-stream": "^4.0.1",
+        "it-pipe": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "merge-options": "^3.0.4",
+        "multiformats": "^11.0.0",
+        "p-defer": "^4.0.0",
+        "p-queue": "^7.3.4",
+        "p-retry": "^5.0.0",
+        "private-ip": "^3.0.0",
+        "protons-runtime": "^5.0.0",
+        "rate-limiter-flexible": "^2.3.11",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2",
+        "wherearewe": "^2.0.0",
+        "xsalsa20": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/libp2p/node_modules/interface-datastore": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
+      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/libp2p/node_modules/interface-store": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+    },
+    "node_modules/libp2p/node_modules/it-all": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A=="
+    },
+    "node_modules/libp2p/node_modules/it-first": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+      "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw=="
+    },
+    "node_modules/libp2p/node_modules/it-map": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.0.4.tgz",
+      "integrity": "sha512-h5zCxovJQ+mzJT75xP4GkJuFrJQ5l7IIdhZ6AOWaE02g5F7T1k1j4CB/uKSRR05LLLOi1LqG+7CrH9bi8GIXYA==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA=="
+    },
+    "node_modules/libp2p/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/libp2p/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/libp2p/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/libp2p/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/libp2p/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/libp2p/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
@@ -28112,6 +31706,19 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
+    "node_modules/longbits": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/longbits/-/longbits-1.1.0.tgz",
+      "integrity": "sha512-22U2exkkYy7sr7nuQJYx2NEZ2kEMsC69+BxM5h8auLvkVIJa+LwAB5mFIExnuW2dFuYXFOWsFMKXjaWiq/htYQ==",
+      "dependencies": {
+        "byte-access": "^1.0.1",
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -28416,6 +32023,18 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/matchit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/matchit/-/matchit-1.1.0.tgz",
+      "integrity": "sha512-+nGYoOlfHmxe5BW5tE0EMJppXEwdSf8uBA1GTZC7Q77kbT35+VKLYJMzVNWCHSsga1ps1tPYFtFyvxvKzWVmMA==",
+      "dev": true,
+      "dependencies": {
+        "@arr/every": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mcl-wasm": {
@@ -30519,6 +34138,80 @@
         "node": ">=10"
       }
     },
+    "node_modules/mortice": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.1.tgz",
+      "integrity": "sha512-eyDUsl1nCR9+JtNksKnaESLP9MgAXCA4w1LTtsmOSQNsThnv++f36rrBu5fC/fdGIwTJZmbiaR/QewptH93pYA==",
+      "dependencies": {
+        "nanoid": "^4.0.0",
+        "observable-webworkers": "^2.0.1",
+        "p-queue": "^7.2.0",
+        "p-timeout": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/mortice/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/mortice/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/mortice/node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mortice/node_modules/p-queue/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mortice/node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/motion": {
       "version": "10.16.2",
       "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
@@ -30538,6 +34231,15 @@
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -30599,6 +34301,18 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
       }
     },
     "node_modules/multicodec": {
@@ -30785,6 +34499,14 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/next": {
       "version": "13.5.6",
       "resolved": "https://registry.npmjs.org/next/-/next-13.5.6.tgz",
@@ -30877,6 +34599,14 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp": {
@@ -32450,6 +36180,15 @@
         "http-https": "^1.0.0"
       }
     },
+    "node_modules/observable-webworkers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-2.0.1.tgz",
+      "integrity": "sha512-JI1vB0u3pZjoQKOK1ROWzp0ygxSi7Yb0iR+7UNsw4/Zn4cQ0P3R7XL38zac/Dy2tEA7Lg88/wIJTjF8vYXZ0uw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
@@ -32583,6 +36322,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-event": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.0.tgz",
+      "integrity": "sha512-Xbfxd0CfZmHLGKXH32k1JKjQYX6Rkv0UtQdaFJ8OyNcf+c0oWCeXHc1C4CX/IESZLmcvfPa5aFIO/vCr5gqtag==",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-event/node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-fifo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
@@ -32687,6 +36451,29 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "dependencies": {
+        "@types/retry": "0.12.1",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/p-timeout": {
@@ -33491,6 +37278,55 @@
         "node": ">=8"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
+    },
+    "node_modules/playwright": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.39.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -33505,6 +37341,16 @@
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/polka": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/polka/-/polka-0.5.2.tgz",
+      "integrity": "sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^0.5.0",
+        "trouter": "^2.0.1"
       }
     },
     "node_modules/postcss": {
@@ -33690,6 +37536,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/private-ip": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.1.tgz",
+      "integrity": "sha512-Ezc16ANuhSHmWAE6lbXUKburNzGpR0J5X0Zh5Um/PZ/s57Fp+HYqYe6BYPH2QbqKr/5WebfzJQ1jq6Kj5dbRmA==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "ip-regex": "^5.0.0",
+        "ipaddr.js": "^2.1.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/private-ip/node_modules/ip-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/private-ip/node_modules/ipaddr.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/proc-log": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
@@ -33716,6 +37595,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
       "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
+    "node_modules/progress-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.0.tgz",
+      "integrity": "sha512-zIB6QDrSbPfRg+33FZalluFIowkbV5Xh1xSuetjG+rlC5he6u2dc6VQJ0TbMdlN3R1RHdpOqxEFMKTnQ+itUwA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/promise": {
       "version": "7.3.1",
@@ -33832,6 +37720,32 @@
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
       "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
       "dev": true
+    },
+    "node_modules/protons-runtime": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.2.0.tgz",
+      "integrity": "sha512-jL3VSbXllgm17zurKQ/z+Ath0w+4BknJ+l/NLocfjAB8hbeASOZTNtb7zK3nDsKq2pHK9YFumNQvpkZ6gFfWhA==",
+      "dependencies": {
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -34103,6 +38017,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/race-signal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.0.1.tgz",
+      "integrity": "sha512-a5un4dInIWoB7+76DieVE+Xv+wmyochKJ3P2GVs9dUKIzGuPyFR5iU3gEWJvztde/15fSOGkslbIsPxi+Loosw=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -34128,6 +38047,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/rate-limiter-flexible": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.2.tgz",
+      "integrity": "sha512-rMATGGOdO1suFyf/mI5LYhts71g1sbdhmd6YvdiXO2gJnd42Tt6QS4JUKJKSWVVkMtBacm6l40FR7Trjo6Iruw=="
     },
     "node_modules/raw-body": {
       "version": "2.5.2",
@@ -35834,6 +39758,14 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "node_modules/sass": {
       "version": "1.69.5",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
@@ -35856,6 +39788,11 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
       "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
       "devOptional": true
+    },
+    "node_modules/sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
     },
     "node_modules/sc-istanbul": {
       "version": "0.4.6",
@@ -36724,6 +40661,26 @@
         "qs": "^6.3.0"
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
+      "integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/sirv/node_modules/@polka/url": {
+      "version": "1.0.0-next.23",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
+      "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==",
+      "dev": true
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -37451,6 +41408,16 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
       }
     },
     "node_modules/stream-browserify": {
@@ -38438,6 +42405,196 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-ipfs-example": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/test-ipfs-example/-/test-ipfs-example-1.1.0.tgz",
+      "integrity": "sha512-CjWxjhOQ8ydtyH8S+GnWwQ9my8MnDooCmtPoZBQU8aw86gcBZ9+uGqvmJrFoTrCOEZfGqMeiPKH+SST0LH4brg==",
+      "dev": true,
+      "dependencies": {
+        "@playwright/test": "^1.33.0",
+        "@types/polka": "^0.5.4",
+        "@types/stoppable": "^1.1.1",
+        "execa": "^8.0.1",
+        "p-defer": "^4.0.0",
+        "polka": "^0.5.2",
+        "sirv": "^2.0.2",
+        "stoppable": "^1.1.0",
+        "uint8arrays": "^4.0.3"
+      },
+      "bin": {
+        "test-browser-example": "bin/test-browser-example.js",
+        "test-node-example": "bin/test-node-example.js"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-ipfs-example/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
     "node_modules/text-encoding-utf-8": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
@@ -38609,6 +42766,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
     "node_modules/tildify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
@@ -38631,6 +42793,14 @@
       "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
       "dependencies": {
         "retimer": "^3.0.0"
+      }
+    },
+    "node_modules/timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
+      "engines": {
+        "node": ">= 4.5.0"
       }
     },
     "node_modules/tiny-invariant": {
@@ -38729,6 +42899,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -38794,6 +42973,26 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trouter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/trouter/-/trouter-2.0.1.tgz",
+      "integrity": "sha512-kr8SKKw94OI+xTGOkfsvwZQ8mWoikZDd2n8XZHjJVZUARZT+4/VV6cacRS6CLsH9bNm+HFIPU1Zx4CnNnb4qlQ==",
+      "dev": true,
+      "dependencies": {
+        "matchit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
       }
     },
     "node_modules/ts-command-line-args": {
@@ -39676,6 +43875,63 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uint8-varint": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.8.tgz",
+      "integrity": "sha512-QS03THS87Wlc0fBCC3xP5sqScDwfvVZLUrTCeMAQbQxQUWJosPC7C8uTNhpVUEgpTbV1Ut2Fer9Se3kI1KbnlQ==",
+      "dependencies": {
+        "byte-access": "^1.0.0",
+        "longbits": "^1.1.0",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "node_modules/uint8-varint/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/uint8-varint/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
+      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
+      "dependencies": {
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
     "node_modules/uint8arrays": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
@@ -40178,6 +44434,11 @@
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -40319,6 +44580,23 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+    },
+    "node_modules/varint-decoder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-1.0.0.tgz",
+      "integrity": "sha512-JkOvdztASWGUAsXshCFHrB9f6AgR2Q8W08CEyJ+43b1qtFocmI8Sp1R/M0E/hDOY2FzVIqk63tOYLgDYWuJ7IQ==",
+      "dependencies": {
+        "varint": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0",
+        "npm": ">=3.0.0"
+      }
+    },
+    "node_modules/varint-decoder/node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -40951,6 +45229,18 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/wherearewe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
+      "dependencies": {
+        "is-electron": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -41322,6 +45612,26 @@
         "cookiejar": "^2.1.1"
       }
     },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -41339,6 +45649,11 @@
       "engines": {
         "node": ">=0.6.0"
       }
+    },
+    "node_modules/xsalsa20": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
+      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -42095,6 +46410,30 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "packages/repo": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "helia": "^1.0.0"
+      },
+      "devDependencies": {
+        "test-ipfs-example": "^1.0.0",
+        "typescript": "^5.1.6"
+      }
+    },
+    "packages/repo/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/website": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46413,6 +46413,7 @@
       }
     },
     "packages/repo": {
+      "name": "@usecannon/repo",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -64,7 +64,7 @@ export class InMemoryRegistry extends CannonRegistry {
     return 'in memory';
   }
 
-  async publish(packagesNames: string[], variant: string, url: string, meta: string): Promise<string[]> {
+  async publish(packagesNames: string[], variant: string, url: string, meta?: string): Promise<string[]> {
     const receipts: string[] = [];
     for (const name of packagesNames) {
       if (!this.pkgs[name]) {
@@ -75,7 +75,9 @@ export class InMemoryRegistry extends CannonRegistry {
       }
 
       this.pkgs[name][variant] = url;
-      this.metas[name][variant] = meta;
+      if (meta) {
+        this.metas[name][variant] = meta;
+      }
       receipts.push((++this.count).toString());
     }
 
@@ -102,10 +104,12 @@ export class InMemoryRegistry extends CannonRegistry {
 }
 
 export class FallbackRegistry extends EventEmitter implements CannonRegistry {
+  readonly memoryCacheRegistry: InMemoryRegistry;
   readonly registries: any[];
 
   constructor(registries: any[]) {
     super();
+    this.memoryCacheRegistry = new InMemoryRegistry();
     this.registries = registries;
   }
 
@@ -114,7 +118,7 @@ export class FallbackRegistry extends EventEmitter implements CannonRegistry {
   }
 
   async getUrl(packageRef: string, variant: string): Promise<string | null> {
-    for (const registry of this.registries) {
+    for (const registry of [this.memoryCacheRegistry, ...this.registries]) {
       try {
         const result = await registry.getUrl(packageRef, variant);
 
@@ -170,7 +174,10 @@ export class FallbackRegistry extends EventEmitter implements CannonRegistry {
   async publish(packagesNames: string[], variant: string, url: string, metaUrl?: string): Promise<string[]> {
     debug('publish to fallback database: ', packagesNames);
     // try to publish to any of the registries
-    // first one to succeed
+    await this.memoryCacheRegistry.publish(packagesNames, variant, url, metaUrl);
+
+    // now push to other registries.
+    // first one to succeed is fine.
     const errors = [];
     for (const registry of this.registries) {
       try {

--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -174,6 +174,7 @@ export class FallbackRegistry extends EventEmitter implements CannonRegistry {
     const errors = [];
     for (const registry of this.registries) {
       try {
+        debug('try publish to registry', registry.getLabel());
         return await registry.publish(packagesNames, variant, url, metaUrl);
       } catch (err: any) {
         debug('error caught in registry while publishing (may be normal):', err);

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -159,7 +159,6 @@ export async function createDefaultReadRegistry(
 ): Promise<FallbackRegistry> {
   const { provider } = await resolveRegistryProvider(settings);
 
-  const inMemoryRegistry = new InMemoryRegistry();
   const localRegistry = new LocalRegistry(settings.cannonDirectory);
   const onChainRegistry = new OnChainRegistry({ signerOrProvider: provider, address: settings.registryAddress });
 
@@ -167,18 +166,13 @@ export async function createDefaultReadRegistry(
     debug('not connected to internet, using local registry only');
     // When not connected to the internet, we don't want to check the on-chain registry version to not throw an error
     console.log(yellowBright('⚠️  You are not connected to the internet. Using local registry only'));
-    return new FallbackRegistry([inMemoryRegistry, ...additionalRegistries, localRegistry]);
+    return new FallbackRegistry([...additionalRegistries, localRegistry]);
   } else if (settings.registryPriority === 'local') {
     debug('local registry is the priority, using local registry first');
-    return new FallbackRegistry([inMemoryRegistry, ...additionalRegistries, localRegistry, onChainRegistry]);
+    return new FallbackRegistry([...additionalRegistries, localRegistry, onChainRegistry]);
   } else {
     debug('on-chain registry is the priority, using on-chain registry first');
-    const fallbackRegistry = new FallbackRegistry([
-      inMemoryRegistry,
-      ...additionalRegistries,
-      onChainRegistry,
-      localRegistry,
-    ]);
+    const fallbackRegistry = new FallbackRegistry([...additionalRegistries, onChainRegistry, localRegistry]);
 
     if (!settings.quiet) {
       fallbackRegistry.on('getUrl', checkLocalRegistryOverride).catch((err: Error) => {

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -159,6 +159,7 @@ export async function createDefaultReadRegistry(
 ): Promise<FallbackRegistry> {
   const { provider } = await resolveRegistryProvider(settings);
 
+  const inMemoryRegistry = new InMemoryRegistry();
   const localRegistry = new LocalRegistry(settings.cannonDirectory);
   const onChainRegistry = new OnChainRegistry({ signerOrProvider: provider, address: settings.registryAddress });
 
@@ -166,13 +167,18 @@ export async function createDefaultReadRegistry(
     debug('not connected to internet, using local registry only');
     // When not connected to the internet, we don't want to check the on-chain registry version to not throw an error
     console.log(yellowBright('⚠️  You are not connected to the internet. Using local registry only'));
-    return new FallbackRegistry([...additionalRegistries, localRegistry]);
+    return new FallbackRegistry([inMemoryRegistry, ...additionalRegistries, localRegistry]);
   } else if (settings.registryPriority === 'local') {
     debug('local registry is the priority, using local registry first');
-    return new FallbackRegistry([...additionalRegistries, localRegistry, onChainRegistry]);
+    return new FallbackRegistry([inMemoryRegistry, ...additionalRegistries, localRegistry, onChainRegistry]);
   } else {
     debug('on-chain registry is the priority, using on-chain registry first');
-    const fallbackRegistry = new FallbackRegistry([...additionalRegistries, onChainRegistry, localRegistry]);
+    const fallbackRegistry = new FallbackRegistry([
+      inMemoryRegistry,
+      ...additionalRegistries,
+      onChainRegistry,
+      localRegistry,
+    ]);
 
     if (!settings.quiet) {
       fallbackRegistry.on('getUrl', checkLocalRegistryOverride).catch((err: Error) => {


### PR DESCRIPTION
as mostly a side effect of the change to use , combined with the lack of deployments until recently, there was a regression introduced for packages importing recently deployed packages in the same build which caused the just-deployed build to not be utilized by the imported package.

to resolve this issue, ensure that there is a `InMemoryRegistry` included with every fallback registry. this will ensure that the fallback registry, in and of itself, fulfills the registry mandate of returning the same output after putting an artifact into it.

fixes https://linear.app/usecannon/issue/CAN-104/usage-in-memory-during-build