### PR TITLE
fix: signer address comparison on build

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -199,6 +199,7 @@ async function doBuild(cannonfile: string, settings: string[], opts: any): Promi
     } else {
       chainId = opts.chainId;
     }
+
     const p = await resolveWriteProvider(cliSettings, chainId as number);
 
     if (opts.dryRun) {
@@ -226,7 +227,9 @@ async function doBuild(cannonfile: string, settings: string[], opts: any): Promi
     } else {
       provider = p.provider;
 
-      getSigner = async (s) => {
+      getSigner = async (address) => {
+        const s = ethers.utils.getAddress(address);
+
         for (const signer of p.signers) {
           if ((await signer.getAddress()) === s) {
             return signer;
@@ -274,6 +277,7 @@ async function doBuild(cannonfile: string, settings: string[], opts: any): Promi
 
   return [node, outputs];
 }
+
 applyCommandsConfig(program.command('build'), commandsConfig.build)
   .showHelpAfterError('Use --help for more information.')
   .action(async (cannonfile, settings, opts) => {

--- a/packages/cli/src/util/provider.ts
+++ b/packages/cli/src/util/provider.ts
@@ -1,13 +1,10 @@
-import { ethers } from 'ethers';
-
-import provider from 'eth-provider';
 import { CannonWrapperGenericProvider } from '@usecannon/builder';
-import { DEFAULT_REGISTRY_PROVIDER_URL } from '../constants';
-
 import { bold } from 'chalk';
-
 import Debug from 'debug';
+import provider from 'eth-provider';
+import { ethers } from 'ethers';
 import os from 'os';
+import { DEFAULT_REGISTRY_PROVIDER_URL } from '../constants';
 import { CliSettings } from '../settings';
 
 const debug = Debug('cannon:cli:provider');

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -119,11 +119,12 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
 
       const signers = getHardhatSigners(hre, provider);
 
-      const getSigner = async (addr: string) => {
-        addr = addr.toLowerCase();
+      const getSigner = async (address: string) => {
+        const addr = ethers.utils.getAddress(address);
         for (const signer of signers) {
-          const signerAddr = await signer.getAddress();
-          if (addr === signerAddr.toLowerCase()) return signer.connect(provider);
+          if (addr === (await signer.getAddress())) {
+            return signer.connect(provider);
+          }
         }
       };
 


### PR DESCRIPTION
This PR fixes the signers fetch on build command, which in some cases was causing an error.

For example, when building the synthetix-sandbox cannonfile with using the `--private-key` param, tried to compare this two addresses, which are not the same:

```json
[
  "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
  "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
]
```