### PR TITLE
fix: cache saving order

### DIFF
--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -84,16 +84,19 @@ export class CliLoader implements CannonLoader {
   async put(misc: any): Promise<string> {
     const data = JSON.stringify(misc);
 
-    const url = this.ipfs
-      ? await this.ipfs.put(misc) // if configured, write to settings ipfs
-      : await getContentCID(Buffer.from(compress(data))); // if not, calculate CID to save to file;
+    const cid = await getContentCID(Buffer.from(compress(data)));
+    const url = IPFSLoader.PREFIX + cid;
 
     debug(`cli ipfs put ${url}`);
 
     await fs.mkdirp(this.dir);
     await fs.writeFile(this.getCacheFilePath(url), data);
 
-    return this.ipfs ? url : IPFSLoader.PREFIX + url;
+    if (this.ipfs) {
+      await this.ipfs.put(misc);
+    }
+
+    return url;
   }
 
   async read(url: string) {


### PR DESCRIPTION
Before trying to upload to the configured ipfs node, save it to file system cache to make sure we don't lose the build.