### PR TITLE
fix: stacktrace for CLI errors

### DIFF
--- a/packages/cli/bin/cannon.js
+++ b/packages/cli/bin/cannon.js
@@ -10,7 +10,8 @@ cli.default
   })
   .catch((err) => {
     if (err.message && process.env.TRACE !== 'true') {
-      console.error(red('Error: ' + err.message));
+      err.message = red(err.message);
+      console.error(err);
     } else {
       console.error(err);
     }


### PR DESCRIPTION
We were removing stack traces from all errors, this PR re adds them.

Something to take into account is that we will now show **all** stacktraces, for example even if the user writes incorrectly the package name:
<img width="913" alt="Screenshot 2023-11-14 at 12 50 24" src="https://github.com/usecannon/cannon/assets/558901/7f7cf97d-ad3d-4e68-94c2-4f7baf24197c">

