### PR TITLE
fix(cli): update provider resolving configuration

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -368,7 +368,10 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
     options.chainId = chainIdPrompt.value;
   }
 
-  if (!options.privateKey && !process.env.PRIVATE_KEY) {
+  const cliSettings = resolveCliSettings(options);
+  let { signers } = await resolveRegistryProvider(cliSettings);
+
+  if (!signers.length) {
     const validatePrivateKey = (privateKey: string) => {
       if (ethers.utils.isHexString(privateKey)) {
         return true;
@@ -393,11 +396,9 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
       process.exit(1);
     }
 
-    options.privateKey = keyPrompt.value;
+    const p = await resolveRegistryProvider({ ...cliSettings, privateKey: keyPrompt.value });
+    signers = p.signers;
   }
-
-  const cliSettings = resolveCliSettings(options);
-  const p = await resolveRegistryProvider(cliSettings);
 
   const overrides: ethers.PayableOverrides = {};
 
@@ -424,7 +425,7 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
 
   await publish({
     packageRef,
-    signer: p.signers[0],
+    signer: signers[0],
     tags: options.tags ? options.tags.split(',') : [],
     chainId: options.chainId ? Number.parseInt(options.chainId) : undefined,
     presetArg: options.preset ? (options.preset as string) : undefined,

--- a/packages/cli/src/util/provider.ts
+++ b/packages/cli/src/util/provider.ts
@@ -1,5 +1,5 @@
 import { CannonWrapperGenericProvider } from '@usecannon/builder';
-import { bold } from 'chalk';
+import { bold, red } from 'chalk';
 import Debug from 'debug';
 import provider from 'eth-provider';
 import { ethers } from 'ethers';
@@ -66,31 +66,38 @@ export async function resolveProviderAndSigners({
 
   // ensure provider is enabled and on the chain we expect
   try {
-    await rawProvider.setChain(Number.parseInt(chainId.toString())); // its important here we ensure chainId is a number
+    rawProvider.setChain(Number.parseInt(chainId.toString())); // its important here we ensure chainId is a number
   } catch (err) {
     console.error(`Failed to use chain id ${chainId}`, err);
     throw err;
   }
 
-  let ethersProvider;
+  let wrappedEthersProvider: CannonWrapperGenericProvider;
 
   // TODO: if at any point we let users provide multiple urls, this will have to be changed.
   // force provider to use JSON-RPC instead of Web3Provider for local http urls
-  if (checkProviders[0].startsWith('http')) {
-    ethersProvider = new ethers.providers.JsonRpcProvider(checkProviders[0]);
-  } else {
-    // Use eth-provider wrapped in Web3Provider as default
-    ethersProvider = new ethers.providers.Web3Provider(rawProvider as any);
-  }
-
-  const wrappedEthersProvider = new CannonWrapperGenericProvider({}, ethersProvider, false);
-
   const signers = [];
+  if (checkProviders[0].startsWith('http')) {
+    debug('use explicit provider url', checkProviders);
+    wrappedEthersProvider = new CannonWrapperGenericProvider(
+      {},
+      new ethers.providers.JsonRpcProvider(checkProviders[0]),
+      false
+    );
 
-  // Use private key if provided
-  if (privateKey) {
-    signers.push(...privateKey.split(',').map((k: string) => new ethers.Wallet(k).connect(wrappedEthersProvider)));
+    if (privateKey) {
+      signers.push(...privateKey.split(',').map((k: string) => new ethers.Wallet(k).connect(wrappedEthersProvider)));
+    } else {
+      debug('no signer supplied for provider');
+    }
   } else {
+    debug('use frame eth provider');
+    // Use eth-provider wrapped in Web3Provider as default
+    wrappedEthersProvider = new CannonWrapperGenericProvider(
+      {},
+      new ethers.providers.Web3Provider(rawProvider as any),
+      false
+    );
     try {
       // Attempt to load from eth-provider
       await rawProvider.enable();
@@ -98,9 +105,33 @@ export async function resolveProviderAndSigners({
         signers.push(wrappedEthersProvider.getSigner(account));
       }
     } catch (err: any) {
-      debug('Failed to connect signers: ', (err.stack as string)?.replace(os.homedir(), ''));
+      // try to do it with the next provider instead
+      try {
+        if (checkProviders.length <= 1) {
+          throw new Error('no more providers');
+        }
+
+        return await resolveProviderAndSigners({
+          chainId,
+          checkProviders: checkProviders.slice(1),
+          privateKey,
+        });
+      } catch (e: any) {
+        console.error(red('Failed to connect signers: ', (err.stack as string)?.replace(os.homedir(), '')));
+        console.error();
+        console.error(
+          'Please ensure your wallet application is open, a wallet is selected, and the wallet is granting access to cannon.'
+        );
+        console.error();
+        console.error(
+          'Alternatively, you can supply a private key and RPC in the terminal by setting CANNON_PROVIDER_URL and CANNON_PRIVATE_KEY.'
+        );
+        process.exit(1);
+      }
     }
   }
+
+  debug(`returning ${signers.length && (await signers[0].getAddress())} signers`);
 
   return {
     provider: wrappedEthersProvider,


### PR DESCRIPTION
* separate the logic for signers depending on whether its frame or specified wallet
* if frame wallet is unsuccessful, automatically recurse to try the next provider. this works effectively for publishing
* at publish time, rather than checking if user supplied a private key, try to load signers, and if it does not succeed, prompt the user as we are now and then add signer that way

fixes https://linear.app/usecannon/issue/CAN-113
fixes https://linear.app/usecannon/issue/CAN-110: