### PR TITLE
feat(cli): allow publish of ipfs hash through `deliver` command

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -414,7 +414,7 @@ export async function build({
       console.log(`- Your partial deployment has been stored to ${deployUrl}`);
       console.log(
         '- Run ' +
-          bold(`cannon publish ${deployUrl}`) +
+          bold(`cannon pin ${deployUrl}`) +
           ' to pin the partial deployment package on IPFS. Then use https://usecannon.com/deploy to collect signatures from a Safe for the skipped steps in the partial deployment package.'
       );
     } else {

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -98,7 +98,10 @@ export async function publish({
   // This works as a catch all to get any deployment stored locally.
   // However if a version is passed, we use the basePackageRef to extrapolate and remove any potential preset in the reference.
   let deploys;
-  if (!version || version.length === 0) {
+  console.log('package ref', packageRef);
+  if (packageRef.startsWith('@')) {
+    deploys = [{ name: packageRef, variant: '13370-main' }];
+  } else if (!version || version.length === 0) {
     deploys = await localRegistry.scanDeploys(packageRef, variantFilter);
   } else {
     deploys = await localRegistry.scanDeploys(basePackageRef, variantFilter);

--- a/packages/cli/src/commandsConfig.ts
+++ b/packages/cli/src/commandsConfig.ts
@@ -385,7 +385,7 @@ const commandsConfig = {
       },
     ],
   },
-  deliver: {
+  pin: {
     description: 'Upload cannon pacakge data to a remote registry by IPFS hash',
     arguments: [
       {

--- a/packages/cli/src/commandsConfig.ts
+++ b/packages/cli/src/commandsConfig.ts
@@ -385,6 +385,15 @@ const commandsConfig = {
       },
     ],
   },
+  deliver: {
+    description: 'Upload cannon pacakge data to a remote registry by IPFS hash',
+    arguments: [
+      {
+        flags: '<ipfsHash>',
+        description: 'IPFS hash to write deployment data for',
+      },
+    ],
+  },
   publish: {
     description: 'Publish a Cannon package to the registry',
     arguments: [

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,9 +6,9 @@ import {
   ChainArtifacts,
   ChainBuilderRuntime,
   ChainDefinition,
-  IPFSLoader,
-  InMemoryRegistry,
   getOutputs,
+  InMemoryRegistry,
+  IPFSLoader,
   publishPackage,
 } from '@usecannon/builder';
 import { bold, gray, green, red, yellow } from 'chalk';
@@ -352,7 +352,7 @@ applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(async
   await fetch(packageName, options.chainId, ipfsHash, options.metaHash);
 });
 
-applyCommandsConfig(program.command('deliver'), commandsConfig.deliver).action(async function (ipfsHash, options) {
+applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async function (ipfsHash, options) {
   const cliSettings = resolveCliSettings(options);
 
   ipfsHash = ipfsHash.replace(/^ipfs:\/\//, '');
@@ -367,7 +367,7 @@ applyCommandsConfig(program.command('deliver'), commandsConfig.deliver).action(a
   await publishPackage({
     packageRef: '@ipfs:' + ipfsHash,
     variant: '13370-main',
-    tags: [],
+    tags: [], // when passing no tags, it will only copy IPFS files, but not publish to registry
     fromStorage,
     toStorage,
   });


### PR DESCRIPTION
ability to upload just IPFS hash.

ex



fixes https://linear.app/usecannon/issue/CAN-112