### PR TITLE
fix(cli): prevent name/version remote registry match on build

### DIFF
--- a/examples/sample-hardhat-project/test/Greeter.test.ts
+++ b/examples/sample-hardhat-project/test/Greeter.test.ts
@@ -7,7 +7,7 @@ describe('Greeter', function () {
   let Greeter: Greeter;
 
   before('load', async function () {
-    const { outputs, signers } = await hre.run('cannon:build');
+    const { outputs, signers } = await hre.run('cannon:build --ignore-pkgref-check');
     const { address, abi } = outputs.contracts.Greeter;
     Greeter = new Contract(address, abi, signers[0]) as Greeter;
   });

--- a/examples/sample-hardhat-project/test/Greeter.test.ts
+++ b/examples/sample-hardhat-project/test/Greeter.test.ts
@@ -7,7 +7,7 @@ describe('Greeter', function () {
   let Greeter: Greeter;
 
   before('load', async function () {
-    const { outputs, signers } = await hre.run('cannon:build --ignore-pkgref-check');
+    const { outputs, signers } = await hre.run('cannon:build', { ignorePkgrefCheck: "true" });
     const { address, abi } = outputs.contracts.Greeter;
     Greeter = new Contract(address, abi, signers[0]) as Greeter;
   });

--- a/examples/sample-hardhat-project/test/Greeter.test.ts
+++ b/examples/sample-hardhat-project/test/Greeter.test.ts
@@ -7,7 +7,7 @@ describe('Greeter', function () {
   let Greeter: Greeter;
 
   before('load', async function () {
-    const { outputs, signers } = await hre.run('cannon:build', { ignorePkgrefCheck: "true" });
+    const { outputs, signers } = await hre.run('cannon:build', { ignorePkgrefCheck: 'true' });
     const { address, abi } = outputs.contracts.Greeter;
     Greeter = new Contract(address, abi, signers[0]) as Greeter;
   });

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -52,7 +52,7 @@ interface Params {
   priorityGasFee?: string;
   writeScript?: string;
   writeScriptFormat?: WriteScriptFormat;
-  skipReference: boolean;
+  ignorePkgrefCheck: boolean;
 }
 
 export async function build({
@@ -77,7 +77,7 @@ export async function build({
   priorityGasFee,
   writeScript,
   writeScriptFormat = 'ethers',
-  skipReference = false,
+  ignorePkgrefCheck = false,
 }: Params) {
   if (wipe && upgradeFrom) {
     throw new Error('wipe and upgradeFrom are mutually exclusive. Please specify one or the other');
@@ -151,9 +151,9 @@ export async function build({
   const resolver = overrideResolver || (await createDefaultReadRegistry(cliSettings));
 
   const uri = await resolver.getUrl(fullPackageRef, chainId);
-  if (uri != null && !skipReference) {
+  if (uri != null && !ignorePkgrefCheck) {
     throw new Error(
-      `Package name ${name} with version ${version} already exists on remote registry\n You can surpass this by using the --skip-reference flag`
+      `Package name ${name} with version ${version} already exists on remote registry\n You can surpass this by using the --ignore-pkgref-check flag`
     );
   }
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -77,7 +77,7 @@ export async function build({
   priorityGasFee,
   writeScript,
   writeScriptFormat = 'ethers',
-  skipReference = false
+  skipReference = false,
 }: Params) {
   if (wipe && upgradeFrom) {
     throw new Error('wipe and upgradeFrom are mutually exclusive. Please specify one or the other');
@@ -152,7 +152,9 @@ export async function build({
 
   const uri = await resolver.getUrl(fullPackageRef, chainId);
   if (uri != null && !skipReference) {
-    throw new Error(`Package name ${name} with version ${version} already exists on remote registry\n You can surpass this by using the --skip-reference flag`);
+    throw new Error(
+      `Package name ${name} with version ${version} already exists on remote registry\n You can surpass this by using the --skip-reference flag`
+    );
   }
 
   const runtime = new ChainBuilderRuntime(runtimeOptions, resolver, getMainLoader(cliSettings), 'ipfs');

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -52,6 +52,7 @@ interface Params {
   priorityGasFee?: string;
   writeScript?: string;
   writeScriptFormat?: WriteScriptFormat;
+  skipReference: boolean;
 }
 
 export async function build({
@@ -76,6 +77,7 @@ export async function build({
   priorityGasFee,
   writeScript,
   writeScriptFormat = 'ethers',
+  skipReference = false
 }: Params) {
   if (wipe && upgradeFrom) {
     throw new Error('wipe and upgradeFrom are mutually exclusive. Please specify one or the other');
@@ -147,6 +149,11 @@ export async function build({
   };
 
   const resolver = overrideResolver || (await createDefaultReadRegistry(cliSettings));
+
+  const uri = await resolver.getUrl(fullPackageRef, chainId);
+  if (uri != null && !skipReference) {
+    throw new Error(`Package name ${name} with version ${version} already exists on remote registry\n You can surpass this by using the --skip-reference flag`);
+  }
 
   const runtime = new ChainBuilderRuntime(runtimeOptions, resolver, getMainLoader(cliSettings), 'ipfs');
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -124,7 +124,7 @@ export async function run(packages: PackageSpecification[], options: RunOptions)
         overrideResolver: resolver,
         upgradeFrom: options.upgradeFrom,
         persist: false,
-        skipReference: true,
+        ignorePkgrefCheck: true,
       });
 
       buildOutputs.push({ pkg, outputs });

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -124,7 +124,7 @@ export async function run(packages: PackageSpecification[], options: RunOptions)
         overrideResolver: resolver,
         upgradeFrom: options.upgradeFrom,
         persist: false,
-        skipReference: true
+        skipReference: true,
       });
 
       buildOutputs.push({ pkg, outputs });

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -124,6 +124,7 @@ export async function run(packages: PackageSpecification[], options: RunOptions)
         overrideResolver: resolver,
         upgradeFrom: options.upgradeFrom,
         persist: false,
+        skipReference: true
       });
 
       buildOutputs.push({ pkg, outputs });

--- a/packages/cli/src/commandsConfig.ts
+++ b/packages/cli/src/commandsConfig.ts
@@ -294,6 +294,10 @@ const commandsConfig = {
         defaultValue: 'ethers',
       },
       {
+        flags: '-sr --skip-reference',
+        description: 'Skip checking the name/version package being built on the remote registry'
+      },
+      {
         flags: '-q --quiet',
         description: 'Suppress extra logging',
       },

--- a/packages/cli/src/commandsConfig.ts
+++ b/packages/cli/src/commandsConfig.ts
@@ -294,7 +294,7 @@ const commandsConfig = {
         defaultValue: 'ethers',
       },
       {
-        flags: '-sr --skip-reference',
+        flags: '-igc --ignore-pkgref-check',
         description: 'Skip checking the name/version package being built on the remote registry',
       },
       {

--- a/packages/cli/src/commandsConfig.ts
+++ b/packages/cli/src/commandsConfig.ts
@@ -295,7 +295,7 @@ const commandsConfig = {
       },
       {
         flags: '-sr --skip-reference',
-        description: 'Skip checking the name/version package being built on the remote registry'
+        description: 'Skip checking the name/version package being built on the remote registry',
       },
       {
         flags: '-q --quiet',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -307,6 +307,7 @@ async function doBuild(
     gasPrice: opts.gasPrice,
     gasFee: opts.maxGasFee,
     priorityGasFee: opts.maxPriorityGasFee,
+    skipReference: opts.skipReference
   });
 
   return [node, pkgSpec, outputs, runtime];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -307,7 +307,7 @@ async function doBuild(
     gasPrice: opts.gasPrice,
     gasFee: opts.maxGasFee,
     priorityGasFee: opts.maxPriorityGasFee,
-    skipReference: opts.skipReference,
+    ignorePkgrefCheck: opts.ignorePkgrefCheck,
   });
 
   return [node, pkgSpec, outputs, runtime];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -307,7 +307,7 @@ async function doBuild(
     gasPrice: opts.gasPrice,
     gasFee: opts.maxGasFee,
     priorityGasFee: opts.maxPriorityGasFee,
-    skipReference: opts.skipReference
+    skipReference: opts.skipReference,
   });
 
   return [node, pkgSpec, outputs, runtime];

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -39,7 +39,10 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
     'writeScriptFormat',
     '(Experimental) Format in which to write the actions script (Options: json, ethers)'
   )
-  .addOptionalParam('ignorePkgrefCheck', '(Optional) Skip checking the name/version package being built on the remote registry')
+  .addOptionalParam(
+    'ignorePkgrefCheck',
+    '(Optional) Skip checking the name/version package being built on the remote registry'
+  )
   .addFlag('noCompile', 'Do not execute hardhat compile before build')
   .setAction(
     async (

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -39,6 +39,10 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
     'writeScriptFormat',
     '(Experimental) Format in which to write the actions script (Options: json, ethers)'
   )
+  .addOptionalParam(
+    'skipReference',
+    '(Optional) Skip checking the name/version package being built on the remote registry'
+  )
   .addFlag('noCompile', 'Do not execute hardhat compile before build')
   .setAction(
     async (
@@ -56,6 +60,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
         impersonate,
         writeScript,
         writeScriptFormat,
+        skipReference
       },
       hre
     ) => {
@@ -190,6 +195,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
         publicSourceCode: hre.config.cannon.publicSourceCode,
         writeScript,
         writeScriptFormat,
+        skipReference
       } as const;
 
       const { outputs } = await build(params);

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -39,10 +39,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
     'writeScriptFormat',
     '(Experimental) Format in which to write the actions script (Options: json, ethers)'
   )
-  .addOptionalParam(
-    'skipReference',
-    '(Optional) Skip checking the name/version package being built on the remote registry'
-  )
+  .addOptionalParam('skipReference', '(Optional) Skip checking the name/version package being built on the remote registry')
   .addFlag('noCompile', 'Do not execute hardhat compile before build')
   .setAction(
     async (
@@ -60,7 +57,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
         impersonate,
         writeScript,
         writeScriptFormat,
-        skipReference
+        skipReference,
       },
       hre
     ) => {
@@ -195,7 +192,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
         publicSourceCode: hre.config.cannon.publicSourceCode,
         writeScript,
         writeScriptFormat,
-        skipReference
+        skipReference,
       } as const;
 
       const { outputs } = await build(params);

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -39,7 +39,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
     'writeScriptFormat',
     '(Experimental) Format in which to write the actions script (Options: json, ethers)'
   )
-  .addOptionalParam('skipReference', '(Optional) Skip checking the name/version package being built on the remote registry')
+  .addOptionalParam('ignorePkgrefCheck', '(Optional) Skip checking the name/version package being built on the remote registry')
   .addFlag('noCompile', 'Do not execute hardhat compile before build')
   .setAction(
     async (
@@ -57,7 +57,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
         impersonate,
         writeScript,
         writeScriptFormat,
-        skipReference,
+        ignorePkgrefCheck,
       },
       hre
     ) => {
@@ -192,7 +192,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
         publicSourceCode: hre.config.cannon.publicSourceCode,
         writeScript,
         writeScriptFormat,
-        skipReference,
+        ignorePkgrefCheck,
       } as const;
 
       const { outputs } = await build(params);


### PR DESCRIPTION
Prevent name/version remote registry match on build
Create --skip-reference to skip the check