### PR TITLE
fix(builder): checking for contract value does not support interpolation

### DIFF
--- a/examples/sample-foundry-project/cannonfile.toml
+++ b/examples/sample-foundry-project/cannonfile.toml
@@ -3,6 +3,9 @@ version = "<%= package.version %>"
 description = "Simple project to verify the functionality of cannon"
 keywords = ["sample", "greeter"]
 
+[setting.value]
+defaultValue = "15"
+
 [setting.salt]
 defaultValue = "greeter"
 
@@ -12,9 +15,11 @@ description="The greeting passed to the constructor"
 
 [contract.library]
 artifact = "Library"
+value = "2929372"
 
 [contract.greeter]
 artifact = "Greeter"
 args = ["<%= settings.msg %>"]
+value = "<%= settings.value %>"
 libraries.Library = "<%= contracts.library.address %>"
 salt = "<%= settings.salt %>"

--- a/packages/builder/src/schemas.zod.ts
+++ b/packages/builder/src/schemas.zod.ts
@@ -138,7 +138,7 @@ export const contractSchema = z
          */
         value: z
           .string()
-          .refine((val) => val.startsWith('<%') || !!ethers.utils.parseEther(val), {
+          .refine((val) => !!val.match(interpolatedRegex) || !!ethers.utils.parseEther(val), {
             message: 'Field value must be of numeric value',
           })
           .describe('Native currency value to send in the transaction'),
@@ -289,7 +289,7 @@ export const invokeSchema = z
          */
         value: z
           .string()
-          .refine((val) => !!ethers.utils.parseEther(val), {
+          .refine((val) => !!val.match(interpolatedRegex) || !!ethers.utils.parseEther(val), {
             message: 'Field must be of numeric value',
           })
           .describe('The amount of ether/wei to send in the transaction.'),

--- a/packages/builder/src/schemas.zod.ts
+++ b/packages/builder/src/schemas.zod.ts
@@ -138,7 +138,7 @@ export const contractSchema = z
          */
         value: z
           .string()
-          .refine((val) => !!ethers.utils.parseEther(val), {
+          .refine((val) => val.startsWith('<%') || !!ethers.utils.parseEther(val), {
             message: 'Field value must be of numeric value',
           })
           .describe('Native currency value to send in the transaction'),


### PR DESCRIPTION
interpolation on value fields wasnt working because the validation was getting in the way

fixes https://linear.app/usecannon/issue/CAN-167/value-attribute-on-[contract]-steps-does-not-use-templating