### PR TITLE
fix(website): issues with nonce 0 on safe

### DIFF
--- a/packages/website/src/constants/deployChains.ts
+++ b/packages/website/src/constants/deployChains.ts
@@ -71,7 +71,7 @@ export const chains = [
     id: 11155111,
     name: 'Sepolia',
     shortName: 'sepolia',
-    serviceUrl: '',
+    serviceUrl: 'https://safe-transaction-sepolia.safe.global',
   },
   {
     id: 1313161554,

--- a/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
+++ b/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
@@ -142,6 +142,7 @@ const TransactionDetailsPage: FC<{
   } else {
     prevDeployGitHash =
       prevDeployHashQuery.data &&
+      prevDeployHashQuery.data[0].result &&
       ((prevDeployHashQuery.data[0].result as any).length as number) > 2
         ? ((prevDeployHashQuery.data[0].result as any).slice(2) as any)
         : hintData?.gitRepoHash;

--- a/packages/website/src/features/Deploy/TransactionDisplay.tsx
+++ b/packages/website/src/features/Deploy/TransactionDisplay.tsx
@@ -59,6 +59,7 @@ export function TransactionDisplay(props: {
   } else {
     prevDeployGitHash =
       prevDeployHashQuery.data &&
+      prevDeployHashQuery.data[0].result &&
       ((prevDeployHashQuery.data[0].result as any).length as number) > 2
         ? ((prevDeployHashQuery.data[0].result as any).slice(2) as any)
         : hintData?.gitRepoHash;

--- a/packages/website/src/hooks/backend.ts
+++ b/packages/website/src/hooks/backend.ts
@@ -200,7 +200,7 @@ export function useTxnStager(
 
   // must not have already signed in order to sign
   const existingSigsCount = alreadyStaged ? alreadyStaged.sigs.length : 0;
-  const currentNonce = safeTxn._nonce && nonce == BigInt(safeTxn._nonce);
+  const currentNonce = safeTxn._nonce != null && nonce == BigInt(safeTxn._nonce);
   const isSigner =
     reads.isSuccess && !reads.isFetching && !reads.isRefetching ? (reads.data![2].result as unknown as boolean) : false;
 

--- a/packages/website/src/hooks/safe.ts
+++ b/packages/website/src/hooks/safe.ts
@@ -92,6 +92,12 @@ export function useExecutedTransactions(safe?: SafeDefinition) {
   const txsQuery = useQuery(['safe-service', 'all-txns', safe?.chainId, safe?.address], async () => {
     if (!safe) return null;
     const safeService = _createSafeApiKit(safe.chainId);
+
+    if (!safeService) {
+      console.warn('safe service not initializable for network', safe.chainId);
+      return { count: 0, next: null, previous: null, results: [] };
+    }
+
     const res = await safeService?.getMultisigTransactions(safe.address);
     return {
       count: (res as unknown as { countUniqueNonce: number }).countUniqueNonce || res?.count,


### PR DESCRIPTION
webiset would not sign a transaction for nonce 0 on safe due to erronous comparison

also whilst fixing, found a few other issues with the website which I went ahead and fixed:
* sepolia network gnosis service url not set
* add warning to make it more clear if a service url is not set, prevent returning undefined which should not happen in useQuery
* fix website crashing on my test transaction (/deploy/txn/11155111/0x9A5A33e97A2C3942A3E933DD56E1373c12259345/0/0x2051adb5138a75f6f6938c08e8eaa535d920b88e7a197cf1dc9cf449a815f01c?chainId=11155111&address=0x9A5A33e97A2C3942A3E933DD56E1373c12259345) due to null checks

fixes https://linear.app/usecannon/issue/CAN-160/safe-nonce-0-does-not-work-on-the-website