### PR TITLE
fix(cli): cannon test command completely regressioned

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -609,7 +609,7 @@ applyCommandsConfig(program.command('test'), commandsConfig.test).action(async f
   await writeModuleDeployments(path.join(process.cwd(), 'deployments/test'), '', outputs);
 
   // after the build is done we can run the forge tests for the user
-  const forgeCmd = spawn('forge', ['test', '--fork-url', 'http://localhost:8545', ...forgeOpts]);
+  const forgeCmd = spawn('forge', ['test', '--fork-url', node!.host, ...forgeOpts]);
 
   forgeCmd.stdout.on('data', (data: Buffer) => {
     process.stdout.write(data);

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -100,9 +100,8 @@ export class CliLoader implements CannonLoader {
   }
 
   async read(url: string) {
-    debug(`cli ipfs read ${url}`);
-
     const cacheFile = this.getCacheFilePath(url);
+    debug(`cli ipfs read ${url} ${cacheFile}`);
 
     // Check if we already have the file cached locally
     if (isFile(cacheFile)) {

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -21,6 +21,7 @@ const ANVIL_OP_TIMEOUT = 10000;
 
 export type CannonRpcNode = ChildProcess &
   RpcOptions & {
+    host: string;
     port: number;
     chainId: number;
   };
@@ -125,6 +126,7 @@ For more info, see https://book.getfoundry.sh/getting-started/installation.html
           state = 'listening';
           console.log(gray('Anvil instance running on:', host, '\n'));
           anvilProvider = new CannonWrapperGenericProvider({}, new ethers.providers.JsonRpcProvider(host));
+          anvilInstance!.host = host;
           resolve(anvilInstance!);
         }
 


### PR DESCRIPTION
does not use correct port for internal anvil instance. very disappointing. also added a change to make it easier to tell what file is being accessed by ipfs cli resolver