### PR TITLE
fix(cli): adjust gas estimation shown by the publish command

### DIFF
--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -453,8 +453,17 @@ export class OnChainRegistry extends CannonRegistry {
 
     try {
       console.log(bold(blueBright('\nCalculating Transaction cost...')));
-      const simulatedGas = await this.provider.estimateGas({ functionName: 'multicall', args: [datas], ...this.overrides });
-      console.log(`\nEstimated gas: ${simulatedGas}`);
+
+      const simulatedGas = await this.provider.estimateContractGas({
+        address: this.contract.address,
+        account: this.signer?.wallet.account,
+        abi: this.contract.abi,
+        functionName: 'multicall',
+        args: [datas],
+        ...this.overrides,
+      });
+
+      console.log(`\nEstimated gas: ${simulatedGas} wei`);
       const gasPrice = BigInt(this.overrides.maxFeePerGas || this.overrides.gasPrice || (await this.provider.getGasPrice()));
       console.log(`\nGas price: ${viem.formatEther(gasPrice)} ETH`);
       const transactionFeeWei = simulatedGas * gasPrice;
@@ -463,7 +472,9 @@ export class OnChainRegistry extends CannonRegistry {
 
       console.log(`\nEstimated transaction Fee: ${transactionFeeEther} ETH\n\n`);
 
-      if (this.signer && (await this.provider.getBalance({ address: this.signer.address })) < transactionFeeWei) {
+      const userBalance = await this.provider.getBalance({ address: this.signer!.address });
+
+      if (this.signer && userBalance < transactionFeeWei) {
         console.log(
           bold(
             yellow(


### PR DESCRIPTION
This PR fixes a bug in the CLI's gas estimate for the publish command. The current implementation uses the `estimateGas` function with the wrong parameters, leading to the display of inaccurate gas estimations.