### PR TITLE
fix(hardhat-cannon): fix excluded dist folder from package

### DIFF
--- a/packages/hardhat-cannon/package.json
+++ b/packages/hardhat-cannon/package.json
@@ -21,7 +21,7 @@
     "prepublishOnly": "npm run build"
   },
   "files": [
-    "dist/src/",
+    "dist",
     "src/",
     "LICENSE",
     "README.md",


### PR DESCRIPTION
adds correct dist path to package.json so that the folder is included on publish.