### PR TITLE
fix(cli): incorrect chain id resolution when specifying custom chain id

### DIFF
--- a/packages/cli/src/chains.ts
+++ b/packages/cli/src/chains.ts
@@ -14,9 +14,24 @@ export const cannonChain: Chain = {
 
 export const chains: Chain[] = [cannonChain, ...Object.values(viemChains)];
 
-export function getChainById(id: any) {
-  return extractChain({
+export function getChainById(id: any): Chain {
+  const chain = extractChain({
     chains,
     id: parseInt(id),
   });
+
+  if (chain?.id !== id) {
+    return {
+      id: parseInt(id),
+      name: 'Unknown Network',
+      nativeCurrency: {
+        name: 'Ether',
+        symbol: 'ETH',
+        decimals: 18,
+      },
+      rpcUrls: { default: { http: [] } },
+    };
+  }
+
+  return chain;
 }

--- a/packages/cli/src/chains.ts
+++ b/packages/cli/src/chains.ts
@@ -14,15 +14,15 @@ export const cannonChain: Chain = {
 
 export const chains: Chain[] = [cannonChain, ...Object.values(viemChains)];
 
-export function getChainById(id: any): Chain {
+export function getChainById(id: number): Chain {
   const chain = extractChain({
     chains,
-    id: parseInt(id),
+    id,
   });
 
   if (chain?.id !== id) {
     return {
-      id: parseInt(id),
+      id,
       name: 'Unknown Network',
       nativeCurrency: {
         name: 'Ether',

--- a/packages/cli/src/commands/alter.test.ts
+++ b/packages/cli/src/commands/alter.test.ts
@@ -204,7 +204,7 @@ describe('alter', () => {
 
     await cli.parseAsync(['node', 'cannon.ts', 'alter', packageName, command, ...targets, '-c', String(chainId)]);
 
-    expect(CannonStorage.prototype.readDeploy as jest.Mock<any, any>).toHaveBeenCalledWith(packageName, String(chainId));
+    expect(CannonStorage.prototype.readDeploy as jest.Mock<any, any>).toHaveBeenCalledWith(packageName, chainId);
     expect(CannonStorage.prototype.putDeploy as jest.Mock<any, any>).toHaveBeenCalledWith(testPkgData);
     expect(testPkgData.state['provision.dummyStep'].artifacts.contracts!.TestContract.address).toEqual(targets[1]);
     expect(mockedFallBackRegistry.publish as jest.Mock<any, any>).toHaveBeenCalledWith(

--- a/packages/cli/src/commands/alter.test.ts
+++ b/packages/cli/src/commands/alter.test.ts
@@ -209,7 +209,7 @@ describe('alter', () => {
     expect(testPkgData.state['provision.dummyStep'].artifacts.contracts!.TestContract.address).toEqual(targets[1]);
     expect(mockedFallBackRegistry.publish as jest.Mock<any, any>).toHaveBeenCalledWith(
       [packageName],
-      String(chainId),
+      chainId,
       newUrl,
       metaUrl
     );

--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -117,7 +117,7 @@ describe('build', () => {
       await cli.parseAsync(args);
       // create write provider with expected values
       expect((utilProvider.resolveWriteProvider as jest.Mock).mock.calls[0][0].providerUrl.split(',')[0]).toEqual('frame');
-      expect((utilProvider.resolveWriteProvider as jest.Mock).mock.calls[0][1]).toEqual(String(chainId));
+      expect((utilProvider.resolveWriteProvider as jest.Mock).mock.calls[0][1]).toEqual(chainId);
       expect(utilProvider.resolveWriteProvider).toHaveBeenCalledTimes(1);
 
       // The same provider is passed to build command

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import {
+  CANNON_CHAIN_ID,
   CannonStorage,
   ChainBuilderRuntime,
   ChainDefinition,
@@ -215,7 +216,7 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
 
 applyCommandsConfig(program.command('verify'), commandsConfig.verify).action(async function (packageName, options) {
   const { verify } = await import('./commands/verify');
-  await verify(packageName, options.apiKey, options.preset, options.chainId);
+  await verify(packageName, options.apiKey, options.preset, parseInt(options.chainId));
 });
 
 applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(async function (
@@ -226,7 +227,7 @@ applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(async
 ) {
   const { alter } = await import('./commands/alter');
   // note: for command below, pkgInfo is empty because forge currently supplies no package.json or anything similar
-  await alter(packageName, flags.chainId, flags.preset, {}, command, options, {});
+  await alter(packageName, parseInt(flags.chainId), flags.preset, {}, command, options, {});
 });
 
 applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(async function (packageName, ipfsHash, options) {
@@ -248,7 +249,7 @@ applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(async
     options.chainId = chainIdPrompt.value;
   }
 
-  await fetch(packageName, options.chainId, ipfsHash, options.metaHash);
+  await fetch(packageName, parseInt(options.chainId), ipfsHash, options.metaHash);
 });
 
 applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async function (ipfsHash, options) {
@@ -421,7 +422,7 @@ applyCommandsConfig(program.command('trace'), commandsConfig.trace).action(async
   await trace({
     packageRef,
     data,
-    chainId: options.chainId,
+    chainId: parseInt(options.chainId),
     preset: options.preset,
     providerUrl: options.providerUrl,
     from: options.from,
@@ -438,7 +439,7 @@ applyCommandsConfig(program.command('decode'), commandsConfig.decode).action(asy
   await decode({
     packageRef,
     data,
-    chainId: options.chainId,
+    chainId: parseInt(options.chainId || CANNON_CHAIN_ID),
     presetArg: options.preset,
     json: options.json,
   });

--- a/packages/cli/src/util/build.ts
+++ b/packages/cli/src/util/build.ts
@@ -128,7 +128,7 @@ async function configureProvider(opts: any, cliSettings: CliSettings) {
       chainId = await _provider.getChainId();
     }
   } else {
-    chainId = opts.chainId;
+    chainId = parseInt(opts.chainId);
 
     // use default rpc url for the chain ID if no provider url is specified
     if (opts.privateKey && !opts.providerUrl) {

--- a/packages/cli/src/util/provider.ts
+++ b/packages/cli/src/util/provider.ts
@@ -88,7 +88,7 @@ export async function resolveProviderAndSigners({
       ).extend(traceActions({}));
     } catch (err) {
       if (checkProviders.length <= 1) {
-        throw new Error('no more providers');
+        throw err;
       }
 
       return await resolveProviderAndSigners({

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { CannonSigner } from '@usecannon/builder';
+import { CANNON_CHAIN_ID, CannonSigner } from '@usecannon/builder';
 import { build, createDryRunRegistry, loadCannonfile, parseSettings, resolveCliSettings } from '@usecannon/cli';
 import { getChainById } from '@usecannon/cli/dist/src/chains';
 import { getProvider } from '@usecannon/cli/dist/src/rpc';
@@ -93,7 +93,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
               .extend(viem.publicActions as any)
           : (viem.createTestClient({
               mode: 'anvil',
-              chain: getChainById(hre.network.config.chainId),
+              chain: getChainById(hre.network.config.chainId || CANNON_CHAIN_ID),
               transport: viem.http((hre.network.config as HttpNetworkConfig).url),
             }) as any);
 


### PR DESCRIPTION
test command:

```
xcannon build --chain-id 123420111 --provider-url https://rpc.op-celestia-testnet.gelato.digital/ --dry-run
```