### PR TITLE
fix: trace not correct output

### DIFF
--- a/packages/builder/src/error/index.ts
+++ b/packages/builder/src/error/index.ts
@@ -181,7 +181,3 @@ export function findContract(
 
   return null;
 }
-
-export function renderResult(result: any) {
-  return '(' + result.map((v: any) => (v.toString ? '"' + v.toString() + '"' : v)).join(', ') + ')';
-}

--- a/packages/builder/src/trace.test.ts
+++ b/packages/builder/src/trace.test.ts
@@ -1,0 +1,191 @@
+import { CONSOLE_LOG_ADDRESS, renderTraceEntry, renderResult, parseContractErrorReason, parseFunctionData } from './trace';
+import * as viem from 'viem';
+
+import chalk from 'chalk';
+
+// disable chalk so we dont have to deal with confusion
+chalk.level = 0;
+
+describe('trace.ts', () => {
+  describe('renderResult()', () => {
+    it('renders objects as expected', () => {
+      expect(renderResult(['wohoo', 1234, { wani: 'kani', swamp: ['world', { of: 'good' }] }])).toEqual(
+        '("wohoo", "1234", {"wani":"kani","swamp":["world",{"of":"good"}]})'
+      );
+    });
+  });
+
+  describe('parseContractErrorReason()', () => {
+    it('decodes solidity tx errors', () => {
+      expect(
+        parseContractErrorReason(null, (viem.toFunctionSelector('Panic(uint256)') + viem.zeroHash.slice(2)) as viem.Hex)
+      ).toEqual('Panic("generic/unknown error")');
+    });
+
+    it('decodes contract errors', () => {
+      expect(
+        parseContractErrorReason(
+          {
+            address: viem.zeroAddress,
+            abi: [
+              {
+                type: 'error',
+                name: 'Hello',
+                inputs: [{ type: 'uint256', name: 'world' }],
+              },
+            ],
+          },
+          (viem.toFunctionSelector('Hello(uint256)') + viem.zeroHash.slice(2)) as viem.Hex
+        )
+      ).toEqual('Hello("0")');
+    });
+  });
+
+  describe('parseFunctionData()', () => {
+    it('parses console log', () => {
+      const functionData = parseFunctionData(
+        {},
+        CONSOLE_LOG_ADDRESS,
+        ('0x' +
+          (3054400204).toString(16) +
+          viem.encodeAbiParameters([{ type: 'string' }, { type: 'uint256' }], ['woot', 1234n]).slice(2)) as viem.Hex,
+        '0x'
+      );
+
+      expect(functionData.contractName).toEqual('console');
+      expect(functionData.isReverted).toEqual(false);
+      expect(functionData.parsedInput).toEqual('log("woot", "1234")');
+      expect(functionData.parsedOutput).toEqual('');
+    });
+
+    it('parses contract call', () => {
+      const testFunc: viem.Abi = [
+        {
+          type: 'function',
+          name: 'testFunc',
+          inputs: [{ type: 'string' }, { type: 'uint256' }],
+          outputs: [{ type: 'bytes32' }],
+          stateMutability: 'payable',
+        },
+        {
+          type: 'error',
+          name: 'FailureToDoAnything',
+          inputs: [],
+        },
+      ];
+
+      const functionData = parseFunctionData(
+        {
+          contracts: {
+            FunTest: {
+              address: viem.zeroAddress,
+              abi: testFunc,
+              deployTxnHash: viem.zeroHash,
+              contractName: 'Fun',
+              sourceName: 'Fun.sol',
+              deployedOn: 'arst.arst',
+              gasUsed: 1234,
+              gasCost: '1234',
+            },
+          },
+        },
+        viem.zeroAddress,
+        viem.encodeFunctionData({ abi: testFunc, functionName: 'testFunc', args: ['woot', 1234] }),
+        viem.encodeFunctionResult({ abi: testFunc, functionName: 'testFunc', result: [viem.zeroHash] })
+      );
+
+      expect(functionData.contractName).toEqual('FunTest');
+      expect(functionData.isReverted).toEqual(false);
+      expect(functionData.parsedInput).toEqual('testFunc("woot", "1234")');
+      expect(functionData.parsedOutput).toEqual(`("${viem.zeroHash}")`);
+
+      // what about revert
+      const errFunctionData = parseFunctionData(
+        {
+          contracts: {
+            FunTest: {
+              address: viem.zeroAddress,
+              abi: testFunc,
+              deployTxnHash: viem.zeroHash,
+              contractName: 'Fun',
+              sourceName: 'Fun.sol',
+              deployedOn: 'arst.arst',
+              gasUsed: 1234,
+              gasCost: '1234',
+            },
+          },
+        },
+        viem.zeroAddress,
+        viem.encodeFunctionData({ abi: testFunc, functionName: 'testFunc', args: ['woot', 1234] }),
+        viem.encodeErrorResult({ abi: testFunc, errorName: 'FailureToDoAnything' })
+      );
+
+      expect(errFunctionData.contractName).toEqual('FunTest');
+      expect(errFunctionData.isReverted).toEqual(true);
+      expect(errFunctionData.parsedInput).toEqual('testFunc("woot", "1234")');
+      expect(errFunctionData.parsedOutput).toContain('FailureToDoAnything()');
+    });
+  });
+
+  describe('renderTraceEntry()', () => {
+    it('renders call entry as expected', () => {
+      const testFunc: viem.Abi = [
+        {
+          type: 'function',
+          name: 'testFunc',
+          inputs: [{ type: 'string' }, { type: 'uint256' }],
+          outputs: [{ type: 'bytes32' }],
+          stateMutability: 'payable',
+        },
+        {
+          type: 'error',
+          name: 'FailureToDoAnything',
+          inputs: [],
+        },
+      ];
+
+      const traceEntryString = renderTraceEntry(
+        {
+          contracts: {
+            FunTest: {
+              address: viem.zeroAddress,
+              abi: testFunc,
+              deployTxnHash: viem.zeroHash,
+              contractName: 'Fun',
+              sourceName: 'Fun.sol',
+              deployedOn: 'arst.arst',
+              gasUsed: 1234,
+              gasCost: '1234',
+            },
+          },
+        },
+        {
+          type: 'call',
+          action: {
+            callType: 'call',
+            from: viem.zeroAddress,
+            gas: '123402',
+            input: viem.encodeFunctionData({ abi: testFunc, functionName: 'testFunc', args: ['woot', 1234] }),
+            to: viem.zeroAddress,
+            value: '1234',
+          },
+          blockHash: '',
+          blockNumber: '',
+          result: {
+            gasUsed: '1234',
+            code: '1',
+            output: viem.encodeFunctionResult({ abi: testFunc, functionName: 'testFunc', result: [viem.zeroHash] }),
+          },
+          subtraces: 0,
+          traceAddress: [5, 2],
+          transactionHash: viem.zeroHash,
+          transactionPosition: 0,
+        }
+      );
+
+      expect(traceEntryString).toContain(
+        `      CALL FunTest.testFunc("woot", "1234") => ("${viem.zeroHash}") (123,402 gas)`
+      );
+    });
+  });
+});

--- a/packages/builder/src/trace.ts
+++ b/packages/builder/src/trace.ts
@@ -4,7 +4,7 @@ import * as viem from 'viem';
 import { Abi, Address, Hash, Hex, decodeAbiParameters } from 'viem';
 import { green, grey, bold, red } from 'chalk';
 
-const CONSOLE_LOG_ADDRESS = '0x000000000000000000636f6e736f6c652e6c6f67';
+export const CONSOLE_LOG_ADDRESS = '0x000000000000000000636f6e736f6c652e6c6f67';
 
 /* eslint-disable no-case-declarations */
 
@@ -45,7 +45,7 @@ export function renderTrace(ctx: ChainArtifacts, traces: TraceEntry[]): string {
   return traces.map((t) => renderTraceEntry(ctx, t)).join('\n');
 }
 
-function renderTraceEntry(ctx: ChainArtifacts, trace: TraceEntry): string {
+export function renderTraceEntry(ctx: ChainArtifacts, trace: TraceEntry): string {
   let str;
 
   switch (trace.type) {
@@ -140,12 +140,12 @@ export function parseFunctionData(
 
         // its actually easier to start by trying to parse the output first
         try {
+          const abiItem = viem.getAbiItem({ ...info.contract, name: decodedInput.functionName }) as viem.AbiFunction;
           const decodedOutput = viem.decodeFunctionResult({
-            ...info.contract,
-            functionName: decodedInput.functionName,
+            abi: [abiItem],
             data: output,
-          })! as any[];
-          parsedOutput = renderResult(decodedOutput);
+          })!;
+          parsedOutput = renderResult(abiItem.outputs.length > 1 ? decodedOutput : [decodedOutput]);
         } catch (err) {
           // if we found an address but the transaction cannot be parsed, it could be decodable error
           try {
@@ -269,7 +269,7 @@ export function renderResult(result: readonly any[]) {
         if (typeof v === 'object') {
           return JSON.stringify(v);
         } else {
-          v.toString ? '"' + v.toString() + '"' : v;
+          return v.toString ? '"' + v.toString() + '"' : v;
         }
       })
       .join(', ') +


### PR DESCRIPTION
some fixes for trace (+ add tests!)

* trace did not include parameters in most cases because of missing `return`
* trace failed to mark function as successful when it only returned one arg because there was an error in the result function