### PR TITLE
fix: "unknown signer" errors occuring during certain build configurations

### DIFF
--- a/packages/builder/src/steps/contract.ts
+++ b/packages/builder/src/steps/contract.ts
@@ -319,7 +319,9 @@ const contractSpec = {
         const signer = config.from
           ? await runtime.getSigner(config.from as viem.Address)
           : await runtime.getDefaultSigner!(txn, config.salt);
-        const hash = await signer.wallet.sendTransaction(_.assign(txn, overrides, { account: signer.address }));
+        const hash = await signer.wallet.sendTransaction(
+          _.assign(txn, overrides, { account: signer.wallet.account || signer.address })
+        );
         receipt = await runtime.provider.waitForTransactionReceipt({ hash });
       }
     }

--- a/packages/builder/src/steps/invoke.ts
+++ b/packages/builder/src/steps/invoke.ts
@@ -143,7 +143,7 @@ async function runTxn(
       address: contract.address,
       abi: [neededFuncAbi],
       functionName: neededFuncAbi.name,
-      account: callSigner.address,
+      account: callSigner.wallet.account || callSigner.address,
       args: config.args,
       ...overrides,
     });
@@ -153,7 +153,7 @@ async function runTxn(
     const txnSimulation = await runtime.provider.simulateContract({
       address: contract.address,
       abi: [neededFuncAbi],
-      account: signer.address,
+      account: signer.wallet.account || signer.address,
       functionName: neededFuncAbi.name,
       args: config.args,
       ...overrides,

--- a/packages/builder/src/steps/router.ts
+++ b/packages/builder/src/steps/router.ts
@@ -142,10 +142,10 @@ const routerStep = {
       ? await runtime.getSigner(config.from as Address)
       : await runtime.getDefaultSigner({ data: solidityInfo.bytecode as Hex }, config.salt);
 
-    debug('using deploy signer with address', await signer.address);
+    debug('using deploy signer with address', signer.address);
 
     const hash = await signer.wallet.deployContract({
-      account: signer.address,
+      account: signer.wallet.account || signer.address,
       bytecode: solidityInfo.bytecode as Hex,
       chain: undefined,
       abi: [],

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -312,7 +312,7 @@ export async function build({
   if (getDefaultSigner) {
     const defaultSigner = await getDefaultSigner!();
     if (defaultSigner) {
-      defaultSignerAddress = await defaultSigner.address;
+      defaultSignerAddress = defaultSigner.address;
       console.log(`Using ${defaultSignerAddress}`);
     } else {
       console.log();


### PR DESCRIPTION
its hard to get viem to recognize the signer that it needs to use is the one thats already sitting in its wallet setup (?)