### PR TITLE
fix: cannon prune facelift

### DIFF
--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -50,7 +50,7 @@ export async function inspect(
     );
   }
 
-  const deployData = await loader[deployUrl.split(':')[0] as 'ipfs' | 'file'].read(deployUrl);
+  const deployData = await loader[deployUrl.split(':')[0] as 'ipfs'].read(deployUrl);
 
   if (!deployData) {
     throw new Error(`deployment data could not be downloaded for ${deployUrl} from ${fullPackageRef}.`);

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -70,12 +70,11 @@ export async function prune(
   for (const url of loaderUrls) {
     try {
       const deployInfo = (await storage.readBlob(url)) as DeploymentInfo;
-      console.log('deploy info', deployInfo);
 
-      /*if (!deployInfo.generator || !deployInfo.generator.startsWith('cannon ')) {
-        debug(`${url}: not cannon package`);
+      if (!deployInfo.generator || !deployInfo.generator.startsWith('cannon ')) {
+        debug(`${url}: parsed, but not cannon package`);
         pruneStats.notCannonPackage++;
-      } else*/ if (deployInfo.timestamp && deployInfo.timestamp >= now - keepAge) {
+      } else if (deployInfo.timestamp && deployInfo.timestamp >= now - keepAge) {
         debug(`${url}: not expired (${deployInfo.timestamp}, ${now - keepAge})`);
         pruneStats.notExpired++;
         keepUrls.add(normalizeMiscUrl(deployInfo.miscUrl));

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -28,6 +28,10 @@ export async function prune(
   }
 
   const registryUrls: Set<string> = new Set();
+  if (!packageFilters) {
+    debug('load all urls from registry');
+    (await storage.registry.getAllUrls()).forEach(registryUrls.add, registryUrls);
+  }
   for (const packageFilter of packageFilters) {
     debug('load urls from registry', packageFilter);
     if (!chainIds.length) {

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -154,6 +154,5 @@ export function getMainLoader(cliSettings: CliSettings) {
       new IPFSLoader(getCannonRepoRegistryUrl()),
       path.join(cliSettings.cannonDirectory, 'ipfs_cache')
     ),
-    file: new LocalLoader(path.join(cliSettings.cannonDirectory, 'blobs')),
   };
 }


### PR DESCRIPTION
this command was first introduced a few months ago, but it hasnt really been used for anything official until now.

implement:
* support for specifying no `packageSpec` to filter by, aollowing for the entire registry to be scanned
* support for `getAllUrls` on registry with viem (it actually was supported)