### PR TITLE
feat(builder): support for deployment through alternative address

### DIFF
--- a/packages/builder/src/constants.ts
+++ b/packages/builder/src/constants.ts
@@ -7,8 +7,6 @@ const debug = Debug('cannon:builder:constants');
 export const CANNON_CHAIN_ID = 13370;
 export const BUILD_VERSION = 6;
 
-export const ARACHNID_CREATE2_PROXY: Address = '0x4e59b44847b379578588920ca78fbf26c0b4956c';
-
 export function getCannonRepoRegistryUrl() {
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 

--- a/packages/builder/src/create2.test.ts
+++ b/packages/builder/src/create2.test.ts
@@ -1,9 +1,15 @@
-import { ARACHNID_CREATE2_PROXY } from './constants';
-import { ARACHNID_DEPLOY_ADDR, ARACHNID_DEPLOY_TXN, ensureArachnidCreate2Exists, makeArachnidCreate2Txn } from './create2';
+import {
+  ARACHNID_DEFAULT_DEPLOY_ADDR,
+  ARACHNID_DEPLOY_TXN,
+  ensureArachnidCreate2Exists,
+  makeArachnidCreate2Txn,
+} from './create2';
 
 import { fakeRuntime, makeFakeSigner } from './steps/utils.test.helper';
 
 import * as viem from 'viem';
+
+const DEFAULT_ARACHNID_ADDRESS = '0x4e59b44847b379578588920cA78FbF26c0B4956C';
 
 describe('util.ts', () => {
   describe('ensureArachnidCreate2Exists()', () => {
@@ -11,7 +17,7 @@ describe('util.ts', () => {
       jest.mocked(fakeRuntime.provider.getBytecode).mockResolvedValue('0x1234');
 
       // if it tries to do get a signer that function isnt defined so it will fail
-      await ensureArachnidCreate2Exists(fakeRuntime);
+      expect(await ensureArachnidCreate2Exists(fakeRuntime, ARACHNID_DEFAULT_DEPLOY_ADDR)).toEqual(DEFAULT_ARACHNID_ADDRESS);
     });
 
     it('fails if deploy signer is not defined', async () => {
@@ -20,7 +26,7 @@ describe('util.ts', () => {
         throw new Error('no signer');
       };
 
-      await expect(() => ensureArachnidCreate2Exists(fakeRuntime)).rejects.toThrowError(
+      await expect(() => ensureArachnidCreate2Exists(fakeRuntime, ARACHNID_DEFAULT_DEPLOY_ADDR)).rejects.toThrowError(
         'could not populate arachnid signer address'
       );
     });
@@ -28,13 +34,13 @@ describe('util.ts', () => {
     it('calls sendTransaction to create aracnid contract if not deployed', async () => {
       jest.mocked(fakeRuntime.provider.getBytecode).mockResolvedValue('0x');
 
-      const fakeSigner = makeFakeSigner(ARACHNID_DEPLOY_ADDR);
+      const fakeSigner = makeFakeSigner(ARACHNID_DEFAULT_DEPLOY_ADDR);
 
       (fakeRuntime.getSigner as any) = async () => fakeSigner;
 
       //jest.mocked((fakeRuntime.provider as unknown as viem.WalletClient).sendRawTransaction).mockResolvedValue({ wait: jest.fn() } as any);
 
-      await ensureArachnidCreate2Exists(fakeRuntime);
+      await ensureArachnidCreate2Exists(fakeRuntime, ARACHNID_DEFAULT_DEPLOY_ADDR);
 
       expect((fakeRuntime.provider as unknown as viem.WalletClient).sendRawTransaction).toBeCalledWith({
         serializedTransaction: ARACHNID_DEPLOY_TXN,
@@ -56,10 +62,11 @@ describe('util.ts', () => {
     it('returns the correct txn', async () => {
       const [txn] = makeArachnidCreate2Txn(
         '0x0987654321000000000000000000000000000000000000000000000000000000',
-        '0x1234567890'
+        '0x1234567890',
+        DEFAULT_ARACHNID_ADDRESS
       );
 
-      expect(txn.to).toEqual(ARACHNID_CREATE2_PROXY);
+      expect(txn.to).toEqual(DEFAULT_ARACHNID_ADDRESS);
       expect(txn.data).toEqual('0x09876543210000000000000000000000000000000000000000000000000000001234567890');
     });
 

--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -80,7 +80,11 @@ export const contractSchema = z
         /**
          *    Determines whether to deploy the contract using create2
          */
-        create2: z.boolean().describe('Determines whether to deploy the contract using create2'),
+        create2: z
+          .union([z.boolean(), z.string().refine((val) => viem.isAddress(val))])
+          .describe(
+            'Determines whether to deploy the contract using create2. If an address is specified, the arachnid create2 contract will be deployed/used from this address.'
+          ),
         /**
          *    Contract deployer address.
          *    Must match the ethereum address format

--- a/packages/builder/src/steps/contract.test.ts
+++ b/packages/builder/src/steps/contract.test.ts
@@ -1,12 +1,13 @@
 import * as viem from 'viem';
 import { fixtureTransactionReceipt } from '../../test/fixtures';
-import { ARACHNID_CREATE2_PROXY } from '../constants';
 import { makeArachnidCreate2Txn } from '../create2';
 import { encodeDeployData } from '../helpers';
 import { ContractArtifact } from '../types';
 import action from './contract';
 import { fakeCtx, fakeRuntime, makeFakeSigner } from './utils.test.helper';
 import '../actions';
+
+const DEFAULT_ARACHNID_ADDRESS = '0x4e59b44847b379578588920cA78FbF26c0B4956C';
 
 describe('steps/contract.ts', () => {
   const fakeAbi = [
@@ -203,7 +204,7 @@ describe('steps/contract.ts', () => {
 
       it('works if contract needs to be deployed', async () => {
         jest.mocked(fakeRuntime.provider.getBytecode).mockImplementation(async ({ address }) => {
-          if (address === ARACHNID_CREATE2_PROXY) {
+          if (address === DEFAULT_ARACHNID_ADDRESS) {
             return '0xabcd';
           }
 
@@ -252,7 +253,8 @@ describe('steps/contract.ts', () => {
               bytecode: '0xabcd',
               abi: fakeAbi,
               args: [viem.stringToHex('one', { size: 32 }), viem.stringToHex('two', { size: 32 }), { three: 'four' }],
-            })
+            }),
+            DEFAULT_ARACHNID_ADDRESS
           )[0],
           account: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
         });

--- a/packages/builder/src/steps/contract.ts
+++ b/packages/builder/src/steps/contract.ts
@@ -286,7 +286,7 @@ const contractSpec = {
 
       debug('performing arachnid create2');
       const [create2Txn, addr] = makeArachnidCreate2Txn(config.salt || '', txn.data!, arachnidDeployerAddress);
-      debug('create2 address is', addr);
+      debug(`create2: deploy ${addr} by ${arachnidDeployerAddress}`);
 
       const bytecode = await runtime.provider.getBytecode({ address: addr });
 
@@ -298,9 +298,10 @@ const contractSpec = {
           ? await runtime.getSigner(config.from as viem.Address)
           : await runtime.getDefaultSigner!(txn, config.salt);
 
-        const hash = await signer.wallet.sendTransaction(
-          _.assign(create2Txn, overrides, { account: signer.wallet.account || signer.address })
-        );
+        const fullCreate2Txn = _.assign(create2Txn, overrides, { account: signer.wallet.account || signer.address });
+        debug('final create2 txn', fullCreate2Txn);
+
+        const hash = await signer.wallet.sendTransaction(fullCreate2Txn);
 
         receipt = await runtime.provider.waitForTransactionReceipt({ hash });
         debug('arachnid create2 complete', receipt);

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -161,7 +161,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
           if (impersonate || hre.network.name === 'cannon' || hre.network.name === 'hardhat') {
             // on test network any user can be conjured
             await provider.impersonateAccount({ address: addr });
-            await provider.setBalance({ address: addr, value: BigInt(1e22) });
+            await provider.setBalance({ address: addr, value: viem.parseEther('10000') });
             return { address: addr, wallet: provider };
           } else {
             // return the actual signer with private key


### PR DESCRIPTION
for some reason gnosis safe uses their own address that they deployed of arachnid create2 for deploying their contracts.