### PR TITLE
fix(cli): Fix Anvil issue when it tries to fork Arbitrum

### DIFF
--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -81,14 +81,12 @@ export async function runRpc(anvilOptions: AnvilOptions, rpcOptions: RpcOptions 
     ]);
   }
 
-  let opts = {};
+  let opts = toArgs(anvilOptions);
 
-  // Anvil fails to accept the `forkUrl` option and `chainId` on the Arbitrum network.
+  // Anvil fails to accept the `forkUrl` and `chainId` options on the Arbitrum network.
   // Ref: https://github.com/foundry-rs/foundry/issues/4786
   if ('forkUrl' in anvilOptions) {
     opts = toArgs(_.omit(anvilOptions, ['chainId']));
-  } else {
-    opts = toArgs(anvilOptions);
   }
 
   debug('starting anvil instance with options: ', anvilOptions);


### PR DESCRIPTION
When Cannon tries to fork Arbitrum and Arbitrum Goerli via Anvil, there is a known issue where Anvil fails to fork, and all requests fail. This is a workaround to make it work.

Ref: https://github.com/foundry-rs/foundry/issues/4786

```
InvalidInputRpcError: Missing or invalid parameters.
Double check you have provided the correct parameters.

URL: http://127.0.0.1:52513
Request body: {"method":"eth_getCode","params":["0x4e59b44847b379578588920cA78FbF26c0B4956C","latest"]}

Details: Missing or invalid parameters.
Double check you have provided the correct parameters.

URL: https://arbitrum-one-rpc.publicnode.com
Request body: {"method":"eth_getCode","params":["0x4e59b44847b379578588920ca78fbf26c0b4956c","0x127e279"]}

Details: missing trie node 0000000000000000000000000000000000000000000000000000000000000000 (path ) <nil>
Version: viem@2.7.20
Version: viem@2.7.20
```