### PR TITLE
fix(cli): run command supports private key

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -25,6 +25,7 @@ import onKeypress from '../util/on-keypress';
 import { build } from './build';
 import { interact } from './interact';
 import { TraceEntry } from '@usecannon/builder/src';
+import { normalizePrivateKey } from '../util/provider';
 
 export interface RunOptions {
   node: CannonRpcNode;
@@ -77,7 +78,10 @@ export async function run(packages: PackageSpecification[], options: RunOptions)
 
   // set up signers
   const accounts = options.privateKey
-    ? options.privateKey.split(',').map((pk) => privateKeyToAccount(pk as viem.Hex).address)
+    ? options.privateKey
+        .split(',')
+        .map((pk) => normalizePrivateKey(pk))
+        .map((pk) => privateKeyToAccount(pk as viem.Hex).address)
     : (options.impersonate || '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266').split(',');
 
   for (const addr of accounts) {

--- a/packages/cli/src/util/provider.ts
+++ b/packages/cli/src/util/provider.ts
@@ -10,7 +10,7 @@ import { CliSettings } from '../settings';
 
 const debug = Debug('cannon:cli:provider');
 
-function normalizePrivateKey(pkey: string): viem.Hash {
+export function normalizePrivateKey(pkey: string): viem.Hash {
   return (pkey.startsWith('0x') ? pkey : `0x${pkey}`) as viem.Hash;
 }
 


### PR DESCRIPTION
This PR aims to fix an issue on the run command but also on the build command when it's executed with `--keep-alive`. Both commands were using `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266` ignoring the account behind the private key.

Command examples to reproduce the issue and check the fix:

> `cannon package-name --provider-url <RPC> --private-key <PK>`

> `cannon build something.toml --provider-url <RPC> --private-key <PK> --dry-run --keep-alive`


Closes https://linear.app/usecannon/issue/CAN-247/run-command-should-support-private-key



