### PR TITLE
fix(simulation): add polling interval for simulations

### DIFF
--- a/packages/builder/src/error/index.ts
+++ b/packages/builder/src/error/index.ts
@@ -102,10 +102,14 @@ export async function handleTxnError(
         method: 'anvil_setBalance' as any,
         params: [accountAddr, viem.toHex(viem.parseEther('10000'))],
       });
+
       // TODO: reevaluate typings
       txnHash = await fullProvider.sendTransaction(fullTxn as any);
 
-      await fullProvider.waitForTransactionReceipt({ hash: txnHash });
+      await fullProvider.waitForTransactionReceipt({
+        hash: txnHash,
+        pollingInterval: 50,
+      });
     } catch (err) {
       debug('warning: failed to force through transaction:', err);
     }


### PR DESCRIPTION
So, when running simulations, we execute a tx and wait for it, but the `waitForTransactionReceipt` had a default of `4_000ms` (not sure were it comes from): https://viem.sh/docs/actions/public/waitForTransactionReceipt#pollinginterval-optional

Setting that value to something sane appears to fix long waits.