### PR TITLE
feat: better handling of contract source codes omission

### DIFF
--- a/examples/sample-foundry-project/cannonfile.toml
+++ b/examples/sample-foundry-project/cannonfile.toml
@@ -3,6 +3,7 @@ version = "<%= package.version %>"
 description = "Simple project to verify the functionality of cannon"
 keywords = ["sample", "greeter"]
 
+publicSourceCode = false
 
 [var.main]
 salt = "greeter"

--- a/examples/sample-foundry-project/cannonfile.toml
+++ b/examples/sample-foundry-project/cannonfile.toml
@@ -3,7 +3,7 @@ version = "<%= package.version %>"
 description = "Simple project to verify the functionality of cannon"
 keywords = ["sample", "greeter"]
 
-publicSourceCode = false
+privateSourceCode = true
 
 [var.main]
 salt = "greeter"

--- a/examples/sample-hardhat-project/package-lock.json
+++ b/examples/sample-hardhat-project/package-lock.json
@@ -28,17 +28,17 @@
       }
     },
     "../../packages/hardhat-cannon": {
-      "version": "2.11.19",
+      "version": "2.11.21",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
-        "@usecannon/builder": "2.11.19",
-        "@usecannon/cli": "2.11.19",
+        "@usecannon/builder": "2.11.21",
+        "@usecannon/cli": "2.11.21",
         "chalk": "^4.1.2",
         "debug": "^4.3.3",
         "fs-extra": "^10.0.1",
-        "viem": "^2.6.1"
+        "viem": "^2.9.3"
       },
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.2.3",

--- a/packages/builder/src/builder.test.ts
+++ b/packages/builder/src/builder.test.ts
@@ -53,7 +53,6 @@ describe('builder.ts', () => {
         allowPartialDeploy: true,
         provider: provider,
         chainId: 1234,
-        publicSourceCode: true,
         snapshots: false,
         getSigner,
         getDefaultSigner,

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -73,6 +73,9 @@ ${printChainDefinitionProblems(problems)}`);
   const name = def.getName(initialCtx);
   const version = def.getVersion(initialCtx);
 
+  // whether or not source code is included in deployment artifacts or not is controlled by cannonfile config, so we set it here
+  runtime.setPublicSourceCode(def.isPublicSourceCode());
+
   try {
     if (runtime.snapshots) {
       debug('building by layer');

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -189,6 +189,10 @@ export class ChainDefinition {
     return _.template(this.raw.preset)(ctx) || 'main';
   }
 
+  isPublicSourceCode() {
+    return this.raw.publicSourceCode ?? true;
+  }
+
   getConfig(n: string, ctx: ChainBuilderContext) {
     if (_.sortedIndexOf(this.allActionNames, n) === -1) {
       throw new Error(`getConfig step name not found: ${n}`);

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -190,7 +190,7 @@ export class ChainDefinition {
   }
 
   isPublicSourceCode() {
-    return this.raw.publicSourceCode ?? true;
+    return !this.raw.privateSourceCode;
   }
 
   getConfig(n: string, ctx: ChainBuilderContext) {

--- a/packages/builder/src/runtime.test.ts
+++ b/packages/builder/src/runtime.test.ts
@@ -38,7 +38,6 @@ describe('runtime.ts', () => {
           allowPartialDeploy: true,
           provider,
           chainId: 1234,
-          publicSourceCode: true,
           snapshots: true,
           getSigner,
           getDefaultSigner,
@@ -58,7 +57,6 @@ describe('runtime.ts', () => {
         expect(runtime.getSigner).toBe(getSigner);
         expect(runtime.loaders.ipfs).toBe(loader);
         expect(runtime.provider).toBe(provider);
-        expect(runtime.publicSourceCode).toBe(true);
         expect(runtime.snapshots).toBe(true);
       });
     });

--- a/packages/builder/src/runtime.ts
+++ b/packages/builder/src/runtime.ts
@@ -112,7 +112,7 @@ export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRu
   readonly getArtifact: (name: string) => Promise<ContractArtifact>;
   readonly snapshots: boolean;
   readonly allowPartialDeploy: boolean;
-  readonly publicSourceCode: boolean | undefined;
+  private publicSourceCode: boolean | undefined;
   private signals: { cancelled: boolean } = { cancelled: false };
   private _gasPrice: string | undefined;
   private _gasFee: string | undefined;
@@ -156,8 +156,6 @@ export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRu
     this.snapshots = info.snapshots;
 
     this.allowPartialDeploy = info.allowPartialDeploy;
-
-    this.publicSourceCode = info.publicSourceCode;
 
     this.misc = { artifacts: {} };
 
@@ -263,6 +261,10 @@ export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRu
 
   updateProviderArtifacts(artifacts: ChainArtifacts) {
     this.provider = this.provider.extend(traceActions(artifacts) as any);
+  }
+
+  setPublicSourceCode(isPublic: boolean) {
+    this.publicSourceCode = isPublic;
   }
 
   derive(overrides: Partial<ChainBuilderRuntimeInfo>): ChainBuilderRuntime {

--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -615,9 +615,10 @@ export const chainDefinitionSchema = z
       .optional(),
     /**
      * Whether or not source code from local package should be bundled in the package.
-     * NOTE: If this is set to false, it will not be possible to verify your contracts with cannon
+     * NOTE: If this is set to true, it will not be possible to verify your contracts on etherscan with cannon
+     * If not specified, the value is treated as `false` (ie contract source codes included)
      */
-    publicSourceCode: z.boolean().default(true),
+    privateSourceCode: z.boolean().optional(),
   })
   .merge(
     z

--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -613,6 +613,11 @@ export const chainDefinitionSchema = z
       })
       .describe('Preset of the package')
       .optional(),
+    /**
+     * Whether or not source code from local package should be bundled in the package.
+     * NOTE: If this is set to false, it will not be possible to verify your contracts with cannon
+     */
+    publicSourceCode: z.boolean().default(true),
   })
   .merge(
     z

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -31,8 +31,6 @@ export type ContractData = {
   abi: Abi;
   constructorArgs?: any[]; // only needed for external verification
   linkedLibraries?: { [sourceName: string]: { [libName: string]: string } }; // only needed for external verification
-  // only should be supplied when generated solidity as a single file
-  sourceCode?: string;
   deployTxnHash: string;
   contractName: string;
   sourceName: string;
@@ -181,9 +179,6 @@ export interface ChainBuilderRuntimeInfo {
 
   // Should gracefully continue after failures and return a partial release?
   allowPartialDeploy: boolean;
-
-  // Should publish contract sources along with bytecode?
-  publicSourceCode?: boolean;
 
   // Gas price to use for transactions
   gasPrice?: string;

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { ContractData, ChainArtifacts, ChainDefinition, DeploymentState } from '@usecannon/builder';
 import { bold, cyan, green, yellow } from 'chalk';
 import { PackageReference } from '@usecannon/builder/dist/package';
@@ -85,6 +86,8 @@ export async function inspect(
     const ipfsUrl = resolveCliSettings().ipfsUrl;
     const ipfsAvailabilityScore = await fetchIPFSAvailability(ipfsUrl, deployUrl.replace('ipfs://', ''));
     const contractsAndDetails = getContractsAndDetails(deployData.state);
+    const miscData = await loader.ipfs.read(deployData.miscUrl);
+    const contractSources = _listSourceCodeContracts(miscData);
 
     console.log(green(bold(`\n=============== ${fullPackageRef} ===============`)));
     console.log();
@@ -104,8 +107,12 @@ export async function inspect(
     console.log('     Package URL:', deployUrl);
     console.log('        Misc URL:', deployData.miscUrl);
     console.log('Package Info URL:', metaUrl || '(none)');
-    console.log('Cannon generator:', deployData.generator);
-    console.log('       timestamp:', deployData.timestamp);
+    console.log('Cannon Generator:', deployData.generator);
+    console.log('       Timestamp:', new Date(deployData.timestamp * 1000).toLocaleString());
+    console.log(
+      'Contract Sources:',
+      bold((contractSources.length ? yellow : green)(contractSources.length + ' sources included'))
+    );
     console.log();
     console.log('IPFS Availability Score(# of nodes): ', ipfsAvailabilityScore || 'Run IPFS Locally to get this score');
     console.log();
@@ -121,7 +128,7 @@ export async function inspect(
     console.log('-------------------');
     console.log();
     if (sources) {
-      console.log('Contract Sources:');
+      console.log('Contract Info:');
       console.log('-------------------');
       for (const contractName in contractsAndDetails) {
         const { sourceName, highlight } = contractsAndDetails[contractName];
@@ -131,11 +138,6 @@ export async function inspect(
         }
       }
       console.log('-------------------');
-    } else {
-      const hasContractSources = Object.values(contractsAndDetails).some((contract) => 'sourceName' in contract);
-      if (hasContractSources) {
-        console.log('Contract sources are available. Run inspect command with --sources flag to display');
-      }
     }
     console.log();
     console.log(cyan(bold('Cannonfile Topology')));
@@ -168,4 +170,9 @@ function _getNestedStateFiles(artifacts: ChainArtifacts, pathname: string, resul
   }
 
   return result;
+}
+
+// TODO: types
+function _listSourceCodeContracts(miscData: any) {
+  return Object.keys(_.pickBy(miscData.artifacts, (v) => v.source));
 }

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -399,12 +399,10 @@ export function getContractsAndDetails(state: {
   const contractsAndDetails: { [contractName: string]: ContractData } = {};
 
   for (const key in state) {
-    if (key.startsWith('contract.')) {
-      const contracts = state[key]?.artifacts?.contracts;
-      if (contracts) {
-        for (const contractName in contracts) {
-          contractsAndDetails[contractName] = contracts[contractName];
-        }
+    const contracts = state[key]?.artifacts?.contracts;
+    if (contracts) {
+      for (const contractName in contracts) {
+        contractsAndDetails[contractName] = contracts[contractName];
       }
     }
   }

--- a/packages/cli/src/util/build.ts
+++ b/packages/cli/src/util/build.ts
@@ -251,7 +251,6 @@ async function prepareBuildConfig(
     wipe: opts.wipe,
     persist: !opts.dryRun,
     overrideResolver,
-    publicSourceCode: true, // TODO: foundry doesn't really have a way to specify whether the contract sources should be public or private
     providerUrl: cliSettings.providerUrl,
     writeScript: opts.writeScript,
     writeScriptFormat: opts.writeScriptFormat,

--- a/packages/cli/test/e2e/scripts/non-interactive/build-foundry.sh
+++ b/packages/cli/test/e2e/scripts/non-interactive/build-foundry.sh
@@ -7,3 +7,11 @@ output=$($CANNON build $CANNON_REPO_DIR/examples/sample-foundry-project/cannonfi
 
 # test building the package again with no private key supplied
 $CANNON build $CANNON_REPO_DIR/examples/sample-foundry-project/cannonfile.toml
+
+# inspect, verify that some important properties of the build are preserved
+inspectResult=$($CANNON inspect greeter-foundry:latest)
+
+# deploy status is complete
+[[ "$inspectResult" =~ "Deploy Status: complete" ]]
+# no source codes should have been included
+[[ "$inspectResult" =~ "0 sources included" ]]

--- a/packages/cli/test/e2e/scripts/non-interactive/build-hardhat.sh
+++ b/packages/cli/test/e2e/scripts/non-interactive/build-hardhat.sh
@@ -3,3 +3,11 @@ npm i
 npx hardhat cannon:build
 # npx hardhat cannon:build --network mainnet # Needs fixing
 cd -
+
+# inspect, verify that some important properties of the build are preserved
+inspectResult=$($CANNON inspect greeter:latest)
+
+# deploy status is complete
+[[ "$inspectResult" =~ "Deploy Status: complete" ]]
+# some source codes should have been included
+[[ ! "$inspectResult" =~ "0 sources included" ]]

--- a/packages/hardhat-cannon/src/index.ts
+++ b/packages/hardhat-cannon/src/index.ts
@@ -11,9 +11,7 @@ import './subtasks/run-anvil-node';
 import './type-extensions';
 
 extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
-  config.cannon = {
-    publicSourceCode: userConfig.cannon?.publicSourceCode || false,
-  };
+  config.cannon = {};
 
   config.networks.cannon = {
     port: 8545,

--- a/packages/hardhat-cannon/src/type-extensions.ts
+++ b/packages/hardhat-cannon/src/type-extensions.ts
@@ -5,9 +5,7 @@ import type * as viem from 'viem';
 
 declare module 'hardhat/types/config' {
   export interface HardhatUserConfig {
-    cannon?: {
-      publicSourceCode: boolean;
-    };
+    cannon?: Record<string, never>;
   }
 
   export interface NetworksConfig {
@@ -26,9 +24,7 @@ declare module 'hardhat/types/config' {
   }
 
   export interface HardhatConfig {
-    cannon: {
-      publicSourceCode: boolean;
-    };
+    cannon: Record<string, never>;
   }
 }
 


### PR DESCRIPTION
previously, we used envvars/cannon config to decide whether or not to include contract source codes in the cannon data.

instead, now the storage of cannon source codes is determined by a global property in the cannonfile. this should solve all cases of determining whether or not to deploy contract sources safely, in roughly the same way that the npm package.json `private` key works