### PR TITLE
fix(cli): fixing registry provider prompt bug

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -354,7 +354,7 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
     pickedRegistryProvider = (
       await prompts.prompt([
         {
-          type: 'multiselect',
+          type: 'select',
           name: 'pickedRegistryProvider',
           message: 'Please choose a registry to deploy to:',
           choices: registryProviders.map((p) => ({ title: p.provider.chain?.name ?? 'Unknown Network', value: p })),


### PR DESCRIPTION
Changes the prompt for registry provider selection on publish to a single select. Fixes a bug with the pickedRegistryProviders coming back as undefined which causes a breaking error on publish.