### PR TITLE
fix(website): refetch signatures data every 10 sec

### DIFF
--- a/packages/website/src/hooks/backend.ts
+++ b/packages/website/src/hooks/backend.ts
@@ -20,6 +20,7 @@ export function useSafeTransactions(safe?: SafeDefinition) {
       if (!safe) return;
       return axios.get(`${stagingUrl}/${safe.chainId}/${safe.address}`);
     },
+    refetchInterval: 10000,
   });
 
   const nonceQuery = useReadContract({


### PR DESCRIPTION
This PR introduces a small fix aimed at enhancing the user experience within our web application by ensuring that pending signature transactions are automatically refreshed every 10 seconds. 

The attached vide demonstrates the fix. It showcases two browser windows side-by-side: the window on the right is used to perform a signature, and the window on the left automatically refreshes to reflect the completed signature without any user intervention. 


https://github.com/usecannon/cannon/assets/3952453/3b8c2a33-3836-4fe7-bb40-7ecb4fa9b091

