### PR TITLE
fix(website): prevent breaking safes query - Safe selector Fix

### DIFF
--- a/packages/website/src/hooks/safe.ts
+++ b/packages/website/src/hooks/safe.ts
@@ -143,10 +143,19 @@ export function useWalletPublicSafes() {
         supportedChains.map(async (chain) => {
           const safeService = _createSafeApiKit(chain.id);
           if (!safeService) return;
-          const res = await safeService.getSafesByOwner(address);
-          if (!Array.isArray(res.safes)) return;
-          for (const safe of res.safes) {
-            results.push({ chainId: chain.id, address: safe as Address });
+          // This in order to avoid breaking the whole query if any chain fails
+          try {
+            const res = await safeService.getSafesByOwner(address);
+            if (!Array.isArray(res.safes)) return;
+            for (const safe of res.safes) {
+              results.push({ chainId: chain.id, address: safe as Address });
+            }
+          } catch (e) {
+            console.error(
+              `Error fetching safes for chain ${chain.id}
+            `,
+              e
+            );
           }
         })
       );

--- a/packages/website/src/hooks/safe.ts
+++ b/packages/website/src/hooks/safe.ts
@@ -151,6 +151,7 @@ export function useWalletPublicSafes() {
               results.push({ chainId: chain.id, address: safe as Address });
             }
           } catch (e) {
+            // eslint-disable-next-line no-console
             console.error(
               `Error fetching safes for chain ${chain.id}
             `,


### PR DESCRIPTION
The main goal of this PR is to ensure that safes are properly loaded for the connected wallet. Currently, we are encountering issues with some safe API requests failing, particularly on the Goerli and base-Goerli chains. This failure leads to the safe selector not offering any options. To address this, we are catching the errors in order to avoid breaking the whole query. This approach ensures that, despite failures on specific chains, the functionality for other chains remains working as expected.

This video demonstrates how the errors caught are associated with the Goerli and base-Goerli chains. However, it also shows that the safe selector is functioning correctly for other networks.


https://github.com/usecannon/cannon/assets/3952453/1f0d6ef5-065d-4ba0-9b71-0e921c6f4bb0





