### PR TITLE
fix(website): rainbow 2.x.x migration - Wallet getting disconnected

### DIFF
--- a/packages/website/src/providers/walletProvider.tsx
+++ b/packages/website/src/providers/walletProvider.tsx
@@ -1,50 +1,44 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { getDefaultConfig } from '@rainbow-me/rainbowkit';
 import { supportedChains, useProviders } from '@/hooks/providers';
-import {
-  darkTheme,
-  getDefaultWallets,
-  RainbowKitProvider,
-} from '@rainbow-me/rainbowkit';
-import { createConfig } from '@wagmi/core';
+import { darkTheme, RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import { ReactNode } from 'react';
 import { WagmiProvider } from 'wagmi';
 import '@rainbow-me/rainbowkit/styles.css';
 
-const { connectors } = getDefaultWallets({
+const config = getDefaultConfig({
   appName: 'Cannon',
   projectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID || '',
+  chains: [...supportedChains],
 });
+
+const queryClient = new QueryClient();
 
 interface IWalletProvider {
   children: ReactNode;
 }
 
 function WalletProvider({ children }: IWalletProvider) {
-  const { transports } = useProviders();
-
-  const wagmiConfig = createConfig({
-    chains: supportedChains,
-    connectors,
-    transports,
-  });
-
   // NOTE: have to hack the style below becuase otherwise it overflows the page.
   // hopefully the class name doesnt change from compile to compile lol
   // related issue: https://github.com/rainbow-me/rainbowkit/issues/1007
   return (
-    <WagmiProvider config={wagmiConfig}>
-      <RainbowKitProvider theme={darkTheme()}>
-        <style
-          dangerouslySetInnerHTML={{
-            __html: `
+    <WagmiProvider config={config}>
+      <QueryClientProvider client={queryClient}>
+        <RainbowKitProvider theme={darkTheme()}>
+          <style
+            dangerouslySetInnerHTML={{
+              __html: `
              div.ju367v1i {
                max-height: 90vh;
                overflow: auto;
              }
            `,
-          }}
-        />
-        {children}
-      </RainbowKitProvider>
+            }}
+          />
+          {children}
+        </RainbowKitProvider>
+      </QueryClientProvider>
     </WagmiProvider>
   );
 }


### PR DESCRIPTION
According to the migration guide found at [RainbowKit's documentation](https://www.rainbowkit.com/docs/migration-guide), we previously lacked the correct configuration for Rainbow version 2.x.x. This oversight led to the wallet being repeatedly disconnected and reconnected, forcing users to reconnect their wallets multiple times. With the recent fix, this issue has been resolved. As demonstrated in the video, users can now navigate and reload the page without losing their wallet connection.

https://github.com/usecannon/cannon/assets/3952453/f8c60a86-8cf7-4eca-b8a4-302f0b6f0462

