### PR TITLE
feat(registry): add `register` command for creating packages

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  test-e2e:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-snx-ci.yml
+++ b/.github/workflows/test-snx-ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  test-snx-ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -20,7 +20,7 @@ export * from './types';
 
 export { CannonRegistry, OnChainRegistry, InMemoryRegistry, FallbackRegistry } from './registry';
 
-export { publishPackage, PackageReference } from './package';
+export { publishPackage, PackageReference, getProvisionedPackages } from './package';
 
 export { CANNON_CHAIN_ID, getCannonRepoRegistryUrl } from './constants';
 

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -20,7 +20,7 @@ export * from './types';
 
 export { CannonRegistry, OnChainRegistry, InMemoryRegistry, FallbackRegistry } from './registry';
 
-export { publishPackage, PackageReference, PKG_REG_EXP } from './package';
+export { publishPackage, PackageReference } from './package';
 
 export { CANNON_CHAIN_ID, getCannonRepoRegistryUrl } from './constants';
 

--- a/packages/builder/src/multicall.ts
+++ b/packages/builder/src/multicall.ts
@@ -3,7 +3,7 @@ import MulticallABI from './abis/Multicall';
 
 const MULTICALL_ADDRESS = '0xE2C5658cC5C448B48141168f3e475dF8f65A1e3e';
 
-export interface txData {
+export interface TxData {
   abi: viem.Abi;
   address: viem.Address;
   functionName: string;
@@ -11,7 +11,7 @@ export interface txData {
   args?: any[];
 }
 
-export function prepareMulticall(txns: txData[]) {
+export function prepareMulticall(txns: TxData[]) {
   const value = txns.reduce((val, txn) => {
     return val + (BigInt(txn.value || 0) || BigInt(0));
   }, BigInt(0));

--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -30,6 +30,8 @@ export const PKG_REG_EXP = /^(?<name>@?[a-z0-9][A-Za-z0-9-]{1,29}[a-z0-9])(?::(?
  * Used to format any reference to a cannon package and split it into it's core parts
  */
 export class PackageReference {
+  static DEFAULT_PRESET = 'main';
+
   /**
    * Anything before the colon or an @ (if no version is present) is the package name.
    */

--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -24,13 +24,13 @@ export type CopyPackageOpts = {
   includeProvisioned?: boolean;
 };
 
-export const PKG_REG_EXP = /^(?<name>@?[a-z0-9][A-Za-z0-9-]{1,29}[a-z0-9])(?::(?<version>[^@]+))?(@(?<preset>[^\s]+))?$/;
-
 /**
  * Used to format any reference to a cannon package and split it into it's core parts
  */
 export class PackageReference {
+  static DEFAULT_TAG = 'latest';
   static DEFAULT_PRESET = 'main';
+  static PACKAGE_REGEX = /^(?<name>@?[a-z0-9][A-Za-z0-9-]{1,29}[a-z0-9])(?::(?<version>[^@]+))?(@(?<preset>[^\s]+))?$/;
 
   /**
    * Anything before the colon or an @ (if no version is present) is the package name.
@@ -65,7 +65,7 @@ export class PackageReference {
    * Parse package reference without normalizing it
    */
   static parse(ref: string) {
-    const match = ref.match(PKG_REG_EXP);
+    const match = ref.match(PackageReference.PACKAGE_REGEX);
 
     if (!match || !match.groups?.name) {
       throw new Error(
@@ -82,18 +82,18 @@ export class PackageReference {
   }
 
   static isValid(ref: string) {
-    return !!PKG_REG_EXP.test(ref);
+    return !!PackageReference.PACKAGE_REGEX.test(ref);
   }
 
   static from(name: string, version?: string, preset?: string) {
-    version = version || 'latest';
-    preset = preset || 'main';
+    version = version || PackageReference.DEFAULT_TAG;
+    preset = preset || PackageReference.DEFAULT_PRESET;
     return new PackageReference(`${name}:${version}@${preset}`);
   }
 
   constructor(ref: string) {
     const parsed = PackageReference.parse(ref);
-    const { name, version = 'latest', preset = 'main' } = parsed;
+    const { name, version = PackageReference.DEFAULT_TAG, preset = PackageReference.DEFAULT_PRESET } = parsed;
 
     this.name = name;
     this.version = version;

--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -268,14 +268,7 @@ export class OnChainRegistry extends CannonRegistry {
    * @returns Boolean
    */
   private async _isPackageRegistered(packageName: string) {
-    const packageHash = viem.stringToHex(packageName, { size: 32 });
-
-    const packageOwner: viem.Address = await this.provider!.readContract({
-      ...this.contract,
-      functionName: 'getPackageOwner',
-      args: [packageHash],
-    });
-
+    const packageOwner = await this.getPackageOwner(packageName);
     return !viem.isAddressEqual(packageOwner, viem.zeroAddress);
   }
 

--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -549,7 +549,7 @@ export class OnChainRegistry extends CannonRegistry {
     const params = {
       abi: this.contract.abi,
       address: this.contract.address,
-      functionName: 'publish',
+      functionName: 'setPackageOwnership',
       value: registerFee,
       args: [packageHash, owner],
       account: this.signer.wallet.account || this.signer.address,
@@ -563,7 +563,9 @@ export class OnChainRegistry extends CannonRegistry {
 
     if (cost > userBalance) {
       throw new Error(
-        `Account "${this.signer.address}" does not have the required ${viem.formatEther(cost)} ETH for gas and fee`
+        `Account "${this.signer.address}" does not have the required ${viem.formatEther(
+          cost
+        )} ETH for gas and registration fee`
       );
     }
 

--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -267,7 +267,7 @@ export class OnChainRegistry extends CannonRegistry {
    * @param packageName
    * @returns Boolean
    */
-  private async _isPackageRegistered(packageName: string) {
+  async _isPackageRegistered(packageName: string) {
     const packageOwner = await this.getPackageOwner(packageName);
     return !viem.isAddressEqual(packageOwner, viem.zeroAddress);
   }

--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -333,7 +333,7 @@ export class OnChainRegistry extends CannonRegistry {
     if (preset !== PackageReference.DEFAULT_PRESET) {
       console.log(`Preset: ${preset}`);
     }
-    console.log(`Tags: ${tags}`);
+    console.log(`Tags: ${tags.join(', ')}`);
     console.log(`Package URL: ${url}`);
     if (metaUrl) {
       console.log(`Metadata URL: ${metaUrl}`);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -97,7 +97,7 @@ export async function publish({
   }
 
   // Select screen for when a user is looking for all the local deploys
-  if (!skipConfirm) {
+  if (!skipConfirm && deploys.length > 1) {
     const prompt = await prompts({
       type: 'select',
       message: 'Select the package you want to publish:\n',
@@ -173,7 +173,7 @@ export async function publish({
       parentPackages.forEach((deploy) => {
         console.log(blueBright(`This will publish ${bold(deploy.name)} to the registry:`));
         deploy.versions.concat(tags).map((version) => {
-          console.log(`- ${version} (preset: ${deploy.preset})`);
+          console.log(` - ${version} (preset: ${deploy.preset})`);
         });
       });
       console.log('\n');
@@ -181,22 +181,22 @@ export async function publish({
       subPackages!.forEach((pkg: SubPackage, index) => {
         console.log(
           blueBright(
-            `This will publish ${bold(pkg.packagesNames[index].split(':')[0])} ${bold(
+            `This will publish ${bold(new PackageReference(pkg.packagesNames[index]).name)} ${bold(
               italic('(Provisioned)')
             )} to the registry:`
           )
         );
         pkg.packagesNames.forEach((pkgName) => {
           const { version, preset } = new PackageReference(pkgName);
-          console.log(`- ${version} (preset: ${preset})`);
+          console.log(` - ${version} (preset: ${preset})`);
         });
       });
       console.log('\n');
     } else {
       parentPackages.forEach((deploy) => {
-        console.log(blueBright(`This will publish ${bold(deploy.name)} to the registry:`));
+        console.log(blueBright(`This will publish ${bold(deploy.name)}@${deploy.preset} to the registry:`));
         deploy.versions.concat(tags).forEach((version) => {
-          console.log(`- ${version} (preset: ${deploy.preset})`);
+          console.log(` - ${version}`);
         });
       });
       console.log('\n');

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,5 +1,11 @@
-import { CannonStorage, IPFSLoader, OnChainRegistry, publishPackage } from '@usecannon/builder';
-import { getProvisionedPackages, PackageReference } from '@usecannon/builder/dist/package';
+import {
+  CannonStorage,
+  getProvisionedPackages,
+  IPFSLoader,
+  OnChainRegistry,
+  PackageReference,
+  publishPackage,
+} from '@usecannon/builder';
 import { blueBright, bold, gray, italic, yellow } from 'chalk';
 import prompts from 'prompts';
 import { getMainLoader } from '../loader';

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -1,0 +1,21 @@
+import { OnChainRegistry, PackageReference } from '@usecannon/builder';
+import * as viem from 'viem';
+
+interface Params {
+  packageRef: string;
+  mainRegistry: OnChainRegistry;
+  skipConfirm?: boolean;
+}
+
+export async function register({ packageRef, mainRegistry }: Params) {
+  const packageName = new PackageReference(packageRef).name;
+  const packageOwner = await mainRegistry.getPackageOwner(packageName);
+
+  if (!viem.isAddressEqual(packageOwner, viem.zeroAddress)) {
+    throw new Error(`The package "${packageName}" is already owned by "${packageOwner}".`);
+  }
+
+  const hash = await mainRegistry.setPackageOwnership(packageName);
+
+  return hash;
+}

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -12,7 +12,7 @@ export async function register({ packageRef, mainRegistry }: Params) {
   const packageOwner = await mainRegistry.getPackageOwner(packageName);
 
   if (!viem.isAddressEqual(packageOwner, viem.zeroAddress)) {
-    throw new Error(`The package "${packageName}" is already owned by "${packageOwner}".`);
+    throw new Error(`The package "${packageName}" is already registered by "${packageOwner}".`);
   }
 
   const hash = await mainRegistry.setPackageOwnership(packageName);

--- a/packages/cli/src/commandsConfig.ts
+++ b/packages/cli/src/commandsConfig.ts
@@ -446,6 +446,41 @@ const commandsConfig = {
       },
     ],
   },
+  register: {
+    description: 'Register a Cannon package on the main registry',
+    arguments: [
+      {
+        flags: '<packageRef>',
+        description: 'Name, version and preset of the Cannon package to publish (name:version@preset)',
+      },
+    ],
+    options: [
+      {
+        flags: '-n --registry-provider-url [url]',
+        description: 'RPC endpoint to publish to',
+      },
+      {
+        flags: '--private-key <key>',
+        description: 'Private key to use for publishing the registry package',
+      },
+      {
+        flags: '--gas-limit <gasLimit>',
+        description: 'The maximum units of gas spent for the registration transaction',
+      },
+      {
+        flags: '--value <value>',
+        description: 'Value in wei to send with the transaction (defaults to registerFee)',
+      },
+      {
+        flags: '--max-fee-per-gas <maxFeePerGas>',
+        description: 'The maximum value (in gwei) for the base fee when submitting the registry transaction',
+      },
+      {
+        flags: '--max-priority-fee-per-gas <maxPriorityFeePerGas>',
+        description: 'The maximum value (in gwei) for the miner tip when submitting the registry transaction',
+      },
+    ],
+  },
   inspect: {
     description: 'Inspect the details of a Cannon package',
     arguments: [

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -351,13 +351,18 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
   let pickedRegistryProvider = registryProviders[0];
 
   if (registryProviders.length > 1) {
+    const choices = registryProviders.map((p) => ({
+      title: `${p.provider.chain?.name ?? 'Unknown Network'} (Chain ID: ${p.provider.chain?.id})`,
+      value: p,
+    }));
+
     pickedRegistryProvider = (
       await prompts.prompt([
         {
           type: 'select',
           name: 'pickedRegistryProvider',
           message: 'Please choose a registry to deploy to:',
-          choices: registryProviders.map((p) => ({ title: p.provider.chain?.name ?? 'Unknown Network', value: p })),
+          choices,
         },
       ])
     ).pickedRegistryProvider;

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -1,14 +1,13 @@
 import Debug from 'debug';
-import { z } from 'zod';
-import { parseEnv } from 'znv';
 import fs from 'fs-extra';
 import _ from 'lodash';
 import path from 'path';
 import untildify from 'untildify';
+import * as viem from 'viem';
+import { parseEnv } from 'znv';
+import { z } from 'zod';
 import { CLI_SETTINGS_STORE, DEFAULT_CANNON_DIRECTORY, DEFAULT_REGISTRY_CONFIG } from './constants';
 import { filterSettings } from './helpers';
-import * as viem from 'viem';
-import { Address, Hash } from 'viem';
 
 const debug = Debug('cannon:cli:settings');
 
@@ -24,7 +23,7 @@ export type CliSettings = {
   /**
    * private key(s) of default signer that should be used for build, comma separated
    */
-  privateKey?: Hash;
+  privateKey?: viem.Hash;
 
   /**
    * The amount of times ipfs should retry requests (applies to read and write)
@@ -42,12 +41,14 @@ export type CliSettings = {
   publishIpfsUrl?: string;
 
   /**
-   * List of registries that should be read from to find packages. Earlier registries in the array get priority for resolved packages over later ones.
+   * List of registries that should be read from to find packages.
+   * Earlier registries in the array get priority for resolved packages over later ones.
+   * First registry on the list is the one that handles setPackageOwnership() calls to create packages.
    */
   registries: {
     chainId: number;
     providerUrl: string[];
-    address: Address;
+    address: viem.Address;
   }[];
 
   /**
@@ -195,7 +196,7 @@ function _resolveCliSettings(overrides: Partial<CliSettings> = {}): CliSettings 
     finalSettings.registries.push({
       providerUrl: [CANNON_REGISTRY_PROVIDER_URL],
       chainId: parseInt(CANNON_REGISTRY_CHAIN_ID),
-      address: CANNON_REGISTRY_ADDRESS as Address,
+      address: CANNON_REGISTRY_ADDRESS as viem.Address,
     });
   } else {
     finalSettings.registries = DEFAULT_REGISTRY_CONFIG;

--- a/packages/registry/test/contracts/CannonRegistry.test.ts
+++ b/packages/registry/test/contracts/CannonRegistry.test.ts
@@ -1,9 +1,8 @@
-import { Signer, BigNumber } from 'ethers';
-import { ok, equal, deepEqual } from 'assert/strict';
+import { deepEqual, equal, ok } from 'assert/strict';
+import { BigNumber, Signer } from 'ethers';
 import { ethers } from 'hardhat';
 import { CannonRegistry as TCannonRegistry } from '../../typechain-types/contracts/CannonRegistry';
 import { MockOptimismBridge as TMockOptimismBridge } from '../../typechain-types/contracts/MockOptimismBridge';
-
 import assertRevert from '../helpers/assert-revert';
 
 const toBytes32 = ethers.utils.formatBytes32String;
@@ -98,12 +97,15 @@ describe('CannonRegistry', function () {
 
   describe('setPackageOwnership()', () => {
     let snapshotId: number;
+
     before('snapshot', async () => {
       snapshotId = await ethers.provider.send('evm_snapshot', []);
     });
+
     before('nominate', async () => {
       await CannonRegistry.nominatePackageOwner(toBytes32('some-module'), await user2.getAddress());
     });
+
     it('should not allow invalid name', async function () {
       await assertRevert(async () => {
         await CannonRegistry.setPackageOwnership(toBytes32('some-module-'), await user2.getAddress());


### PR DESCRIPTION
This PR adds the new `cannon register <packageName>` command to register for the first time on the main registry a new package. This is the first for unlocking new package publications.


**Next steps (on a separate PR):**
1. Merge functionality on `publish` command. This gets tricky as the publish command will have to check if the package is not registered, register it. If not, try to infer on which registry it should be published.
2. Add possibility to migrate packages from main registry to secondary one

**Extra**
* This PR also includes some heavy refactors on builders `registry.ts` file, but functionality is exactly the same.