### PR TITLE
fix(website): current safe chainId - queue cannon

### DIFF
--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -52,12 +52,7 @@ import {
   TransactionRequestBase,
   zeroAddress,
 } from 'viem';
-import {
-  useChainId,
-  useEstimateGas,
-  useSendTransaction,
-  useWriteContract,
-} from 'wagmi';
+import { useEstimateGas, useSendTransaction, useWriteContract } from 'wagmi';
 import NoncePicker from './NoncePicker';
 import { TransactionDisplay } from './TransactionDisplay';
 import 'react-diff-view/style/index.css';
@@ -162,7 +157,7 @@ function QueueFromGitOps() {
   };
 
   const settings = useStore((s) => s.settings);
-  const chainId = useChainId();
+  const chainId = currentSafe?.chainId;
 
   const previousName = useMemo(() => {
     if (previousPackageInput) {


### PR DESCRIPTION
The main purpose of this PR is to make sure to use the current safe chainId to look up for previous published package instead of using the current wallet provider chainId

https://github.com/usecannon/cannon/assets/3952453/a77d2370-f7bf-4c0f-9ded-3307ce25105b

