### PR TITLE
fix(build): update build command to not write to remote ipfs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47025,7 +47025,7 @@
     },
     "packages/cli": {
       "name": "@usecannon/cli",
-      "version": "2.12.1",
+      "version": "2.12.1-alpha.19+f8a4e83d",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -47104,12 +47104,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/hardhat-cannon": {
-      "version": "2.12.1",
+      "version": "2.12.1-alpha.19+f8a4e83d",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
         "@usecannon/builder": "2.12.1",
-        "@usecannon/cli": "2.12.1",
+        "@usecannon/cli": "2.12.1-alpha.19+f8a4e83d",
         "chalk": "^4.1.2",
         "debug": "^4.3.3",
         "fs-extra": "^10.0.1",
@@ -47701,6 +47701,35 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
       "integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw=="
     },
+    "packages/website/node_modules/@usecannon/cli": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@usecannon/cli/-/cli-2.12.1.tgz",
+      "integrity": "sha512-rB2TB+1B1/72LBgRcZOwXRTQT0/sWmoH/1+KvfxLZLOia4kNtLNO0e92wlS/RHRn+VFVZlPID1Omoj8JX7Ummw==",
+      "dependencies": {
+        "@iarna/toml": "^3.0.0",
+        "@synthetixio/wei": "^2.74.1",
+        "@usecannon/builder": "2.12.1",
+        "abitype": "^1.0.0",
+        "chalk": "^4.1.2",
+        "commander": "^9.5.0",
+        "debug": "^4.3.4",
+        "eth-provider": "^0.13.6",
+        "fastq": "^1.15.0",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "prompts": "^2.4.2",
+        "semver": "^7.3.7",
+        "table": "^6.8.0",
+        "tildify": "2.0.0",
+        "untildify": "^4.0.0",
+        "viem": "^2.9.3",
+        "znv": "^0.4.0",
+        "zod": "^3.22.4"
+      },
+      "bin": {
+        "cannon": "bin/cannon.js"
+      }
+    },
     "packages/website/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -47830,6 +47859,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/website/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "packages/website/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -47858,6 +47898,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/website/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "packages/website/node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -47868,6 +47922,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/website/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usecannon/cli",
-  "version": "2.12.1-alpha.18+95929f8d",
+  "version": "2.12.1-alpha.19+f8a4e83d",
   "description": "Utility for instantly loading cannon packages in standalone contexts",
   "main": "dist/src/index.js",
   "scripts": {
@@ -75,5 +75,5 @@
     "znv": "^0.4.0",
     "zod": "^3.22.4"
   },
-  "gitHead": "95929f8dcc33f12a663092fd2aa32af866b3dbda"
+  "gitHead": "f8a4e83d010696c5f1939bf4aeb53e86038d6915"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usecannon/cli",
-  "version": "2.12.1",
+  "version": "2.12.1-alpha.18+95929f8d",
   "description": "Utility for instantly loading cannon packages in standalone contexts",
   "main": "dist/src/index.js",
   "scripts": {
@@ -75,5 +75,5 @@
     "znv": "^0.4.0",
     "zod": "^3.22.4"
   },
-  "gitHead": "a20d4d65cbeb3e9ebf23da3ba411d33c1a6a20f5"
+  "gitHead": "95929f8dcc33f12a663092fd2aa32af866b3dbda"
 }

--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -79,7 +79,8 @@ describe('build', () => {
   });
 
   describe('provider', () => {
-    let provider: viem.PublicClient;
+    let provider: viem.PublicClient & viem.WalletClient & viem.TestClient;
+
     beforeEach(() => {
       jest.spyOn(helpers, 'loadCannonfile').mockResolvedValue({} as any);
       provider = makeFakeProvider();

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -130,9 +130,11 @@ export async function build({
     getSigner:
       getSigner ||
       async function (addr: viem.Address) {
+        const client = provider as unknown as viem.TestClient;
+
         // on test network any user can be conjured
-        await (provider as unknown as viem.TestClient).impersonateAccount({ address: addr });
-        await (provider as unknown as viem.TestClient).setBalance({ address: addr, value: viem.parseEther('10000') });
+        await client.impersonateAccount({ address: addr });
+        await client.setBalance({ address: addr, value: viem.parseEther('10000') });
 
         return {
           address: addr,
@@ -156,7 +158,12 @@ export async function build({
 
   const resolver = overrideResolver || (await createDefaultReadRegistry(cliSettings));
 
-  const runtime = new ChainBuilderRuntime(runtimeOptions, resolver, getMainLoader(cliSettings), 'ipfs');
+  const runtime = new ChainBuilderRuntime(
+    runtimeOptions,
+    resolver,
+    getMainLoader(cliSettings, { writeToIpfs: false }),
+    'ipfs'
+  );
 
   const dump = writeScript ? await createWriteScript(runtime, writeScript, writeScriptFormat) : null;
 
@@ -240,7 +247,7 @@ export async function build({
 
   let defaultSignerAddress: string;
   if (getDefaultSigner) {
-    const defaultSigner = await getDefaultSigner!();
+    const defaultSigner = await getDefaultSigner();
     if (defaultSigner) {
       defaultSignerAddress = defaultSigner.address;
       console.log(`Using ${defaultSignerAddress}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import {
@@ -17,6 +16,7 @@ import {
 import { blueBright, bold, gray, green, red, yellow } from 'chalk';
 import { Command } from 'commander';
 import Debug from 'debug';
+import _ from 'lodash';
 import prompts from 'prompts';
 import * as viem from 'viem';
 import pkg from '../package.json';
@@ -24,11 +24,11 @@ import { interact } from './commands/interact';
 import commandsConfig from './commandsConfig';
 import {
   checkAndNormalizePrivateKey,
-  normalizePrivateKey,
   checkCannonVersion,
   checkForgeAstSupport,
   ensureChainIdConsistency,
   isPrivateKey,
+  normalizePrivateKey,
 } from './helpers';
 import { getMainLoader } from './loader';
 import { installPlugin, listInstalledPlugins, removePlugin } from './plugins';
@@ -40,7 +40,7 @@ import { pickAnvilOptions } from './util/anvil';
 import { doBuild } from './util/build';
 import { getContractsRecursive } from './util/contracts-recursive';
 import { parsePackageArguments, parsePackagesArguments } from './util/params';
-import { resolveRegistryProviders, resolveWriteProvider, getChainIdFromProviderUrl, isURL } from './util/provider';
+import { getChainIdFromProviderUrl, isURL, resolveRegistryProviders, resolveWriteProvider } from './util/provider';
 import { writeModuleDeployments } from './util/write-deployments';
 import './custom-steps/run';
 
@@ -216,14 +216,16 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
           } else {
             console.log(red('forge build failed'));
             console.log(red('Make sure "forge build" runs successfully or use the --skip-compile flag.'));
-            reject(new Error(`forge build failed with exit code "${code}"`));
+            return reject(new Error(`forge build failed with exit code "${code}"`));
           }
+
           resolve(null);
         });
       });
     } else {
       console.log(yellow('Skipping forge build...'));
     }
+
     console.log(''); // Linebreak in CLI to signify end of compilation.
 
     // Override options with CLI settings

--- a/packages/cli/src/loader.test.ts
+++ b/packages/cli/src/loader.test.ts
@@ -1,16 +1,13 @@
-import fs from 'fs-extra';
 import crypto from 'crypto';
+import fs from 'fs-extra';
 import path from 'path';
-import { CliLoader, LocalLoader, getMainLoader } from './loader'; // assuming the module's name is "module.ts"
+import { CliLoader, getMainLoader, LocalLoader } from './loader'; // assuming the module's name is "module.ts"
 import { CliSettings } from './settings';
 
 jest.mock('fs-extra');
 jest.mock('crypto');
 
-describe('LocalLoader', LocalLoaderTestCases);
-describe('getMainLoader', getMainLoaderTestCases);
-
-function LocalLoaderTestCases() {
+describe('LocalLoader', function LocalLoaderTestCases() {
   const dir = 'directory';
   const loader = new LocalLoader(dir);
 
@@ -45,12 +42,13 @@ function LocalLoaderTestCases() {
     expect(fs.writeFile).toHaveBeenCalledWith(path.join(dir, `${hash}.json`), json);
     expect(result).toEqual(`file://${hash}.json`);
   });
-}
+});
 
-function getMainLoaderTestCases() {
+describe('getMainLoader', function getMainLoaderTestCases() {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   it('should return object with instances of loaders', () => {
     const settings: CliSettings = {
       providerUrl: '',
@@ -84,4 +82,4 @@ function getMainLoaderTestCases() {
     const loaders = getMainLoader(settings);
     expect(loaders.ipfs).toBeInstanceOf(CliLoader); // Changed this line
   });
-}
+});

--- a/packages/hardhat-cannon/package.json
+++ b/packages/hardhat-cannon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-cannon",
-  "version": "2.12.1",
+  "version": "2.12.1-alpha.18+95929f8d",
   "description": "Agnostic chain construction. Select the protocols and configuration you need to quickly and easily verify your project",
   "repository": "github:usecannon/cannon",
   "author": "Synthetix",
@@ -43,11 +43,11 @@
   "dependencies": {
     "@iarna/toml": "^3.0.0",
     "@usecannon/builder": "2.12.1",
-    "@usecannon/cli": "2.12.1",
+    "@usecannon/cli": "2.12.1-alpha.18+95929f8d",
     "chalk": "^4.1.2",
     "debug": "^4.3.3",
     "fs-extra": "^10.0.1",
     "viem": "^2.9.3"
   },
-  "gitHead": "a20d4d65cbeb3e9ebf23da3ba411d33c1a6a20f5"
+  "gitHead": "95929f8dcc33f12a663092fd2aa32af866b3dbda"
 }

--- a/packages/hardhat-cannon/package.json
+++ b/packages/hardhat-cannon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-cannon",
-  "version": "2.12.1-alpha.18+95929f8d",
+  "version": "2.12.1-alpha.19+f8a4e83d",
   "description": "Agnostic chain construction. Select the protocols and configuration you need to quickly and easily verify your project",
   "repository": "github:usecannon/cannon",
   "author": "Synthetix",
@@ -43,11 +43,11 @@
   "dependencies": {
     "@iarna/toml": "^3.0.0",
     "@usecannon/builder": "2.12.1",
-    "@usecannon/cli": "2.12.1-alpha.18+95929f8d",
+    "@usecannon/cli": "2.12.1-alpha.19+f8a4e83d",
     "chalk": "^4.1.2",
     "debug": "^4.3.3",
     "fs-extra": "^10.0.1",
     "viem": "^2.9.3"
   },
-  "gitHead": "95929f8dcc33f12a663092fd2aa32af866b3dbda"
+  "gitHead": "f8a4e83d010696c5f1939bf4aeb53e86038d6915"
 }


### PR DESCRIPTION
This PR makes sure that the `Loader` used in the `publish` command does not write to remote ipfs node. On a future PR we can update all the other commands to not write to IPFS by default, except for publish, which is the only one that should do it.

Sorry for not adding a proper test case here, there are not tests on build command yet and it would take some time.