### PR TITLE
fix(build): usage of --preset argument

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -92,7 +92,8 @@ export async function build({
   const packageRef = PackageReference.from(packageDefinition.name, packageDefinition.version, packageDefinition.preset);
 
   const { name, version } = packageRef;
-  let { preset } = packageRef;
+  const preset = presetArg || packageRef.preset;
+  const { fullPackageRef } = PackageReference.from(name, version, preset);
 
   // Handle deprecated preset specification
   if (presetArg) {
@@ -103,13 +104,7 @@ export async function build({
         )
       )
     );
-    preset = presetArg;
   }
-
-  const { fullPackageRef } = packageRef;
-
-  let pkgName = name;
-  let pkgVersion = version;
 
   const cliSettings = resolveCliSettings({ registryPriority });
 
@@ -195,13 +190,8 @@ export async function build({
 
   const initialCtx = await createInitialContext(def, pkgInfo, chainId, resolvedSettings);
 
-  if (!pkgName) {
-    pkgName = def.getName(initialCtx);
-  }
-
-  if (!pkgVersion) {
-    pkgVersion = def.getVersion(initialCtx);
-  }
+  const pkgName = name || def.getName(initialCtx);
+  const pkgVersion = version || def.getVersion(initialCtx);
 
   console.log('');
   if (oldDeployData && wipe) {


### PR DESCRIPTION
This PR includes this fix when generating the `fullPackageRef` variable, which makes it use the given `--preset` arg. Which was missing.

And this is crucial, because afterwards we use it to calculate the previous tag on updates here: https://github.com/usecannon/cannon/pull/887/files#diff-3b0340e6f408eb23ee2bdd40008c9ca70e2f115de9f8369097574ab4c0b67c2fR96