### PR TITLE
fix(registry): enforcement of read only registry usage on build

### DIFF
--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -5,6 +5,7 @@ import { yellowBright } from 'chalk';
 import Debug from 'debug';
 import fs from 'fs-extra';
 import _ from 'lodash';
+import * as viem from 'viem';
 import { CliSettings } from './settings';
 import { isConnectedToInternet } from './util/is-connected-to-internet';
 import { resolveRegistryProviders } from './util/provider';
@@ -143,6 +144,20 @@ export class LocalRegistry extends CannonRegistry {
   }
 }
 
+export class ReadOnlyOnChainRegistry extends OnChainRegistry {
+  async publish(): Promise<string[]> {
+    throw new Error('Cannot execute write operations on ReadOnlyOnChainRegistry');
+  }
+
+  async publishMany(): Promise<string[]> {
+    throw new Error('Cannot execute write operations on ReadOnlyOnChainRegistry');
+  }
+
+  async setPackageOwnership(): Promise<viem.Hash> {
+    throw new Error('Cannot execute write operations on ReadOnlyOnChainRegistry');
+  }
+}
+
 async function checkLocalRegistryOverride({
   fullPackageRef,
   chainId,
@@ -174,7 +189,7 @@ export async function createDefaultReadRegistry(
 
   const localRegistry = new LocalRegistry(settings.cannonDirectory);
   const onChainRegistries = registryProviders.map(
-    (p, i) => new OnChainRegistry({ provider: p.provider, address: settings.registries[i].address })
+    (p, i) => new ReadOnlyOnChainRegistry({ provider: p.provider, address: settings.registries[i].address })
   );
 
   if (!(await isConnectedToInternet())) {


### PR DESCRIPTION
Currently, on the cli when executing the build command, it was being initialized with a FallbackLoader that included a OnChainRegistry, the problem with that is that when using a `clone` step that deploys a new package it's publishing to the registry [here](https://github.com/usecannon/cannon/blob/d0743d225b4d7fcc2ad1c9456d81107b1dc2e911/packages/builder/src/steps/clone.ts/#L215-L220), instead of failing and Fallbacking to the LocalRegistry.

This PR adds a ReadOnlyOnChainRegistry that fails in case we unknowingly do that.