### PR TITLE
fix(builder): default to repo url if ipfs urls are empty while parsing settings

### DIFF
--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -111,7 +111,6 @@ export type CliSettings = {
  */
 
 function cannonSettingsSchema(fileSettings: Omit<CliSettings, 'cannonDirectory'>) {
-  const repoUrl = getCannonRepoRegistryUrl();
   return {
     CANNON_DIRECTORY: z.string().default(DEFAULT_CANNON_DIRECTORY),
     CANNON_SETTINGS: z.string().optional(),
@@ -132,12 +131,12 @@ function cannonSettingsSchema(fileSettings: Omit<CliSettings, 'cannonDirectory'>
       .string()
       .url()
       .optional()
-      .default(fileSettings.ipfsUrl || repoUrl),
+      .default(fileSettings.ipfsUrl || getCannonRepoRegistryUrl()),
     CANNON_PUBLISH_IPFS_URL: z
       .string()
       .url()
       .optional()
-      .default(fileSettings.publishIpfsUrl || repoUrl),
+      .default(fileSettings.publishIpfsUrl as string),
     CANNON_REGISTRY_PROVIDER_URL: z.string().optional(),
     CANNON_REGISTRY_CHAIN_ID: z.string().optional(),
     CANNON_REGISTRY_ADDRESS: z

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -9,6 +9,7 @@ import untildify from 'untildify';
 
 import { CLI_SETTINGS_STORE, DEFAULT_CANNON_DIRECTORY, DEFAULT_REGISTRY_CONFIG } from './constants';
 import { filterSettings, checkAndNormalizePrivateKey } from './helpers';
+import { getCannonRepoRegistryUrl } from '@usecannon/builder';
 
 const debug = Debug('cannon:cli:settings');
 
@@ -110,6 +111,7 @@ export type CliSettings = {
  */
 
 function cannonSettingsSchema(fileSettings: Omit<CliSettings, 'cannonDirectory'>) {
+  const repoUrl = getCannonRepoRegistryUrl();
   return {
     CANNON_DIRECTORY: z.string().default(DEFAULT_CANNON_DIRECTORY),
     CANNON_SETTINGS: z.string().optional(),
@@ -130,12 +132,12 @@ function cannonSettingsSchema(fileSettings: Omit<CliSettings, 'cannonDirectory'>
       .string()
       .url()
       .optional()
-      .default(fileSettings.ipfsUrl as string),
+      .default(fileSettings.ipfsUrl || repoUrl),
     CANNON_PUBLISH_IPFS_URL: z
       .string()
       .url()
       .optional()
-      .default(fileSettings.publishIpfsUrl as string),
+      .default(fileSettings.publishIpfsUrl || repoUrl),
     CANNON_REGISTRY_PROVIDER_URL: z.string().optional(),
     CANNON_REGISTRY_CHAIN_ID: z.string().optional(),
     CANNON_REGISTRY_ADDRESS: z


### PR DESCRIPTION
Fixes `Missing IPFS loader` bug appearing when ipfs urls aren't explicitly set in settings