### PR TITLE
fix(cli): verify command should use --api-key flag

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -253,6 +253,9 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
 applyCommandsConfig(program.command('verify'), commandsConfig.verify).action(async function (packageName, options) {
   const { verify } = await import('./commands/verify');
 
+  // Override CLI settings with --api-key value
+  options.etherscanApiKey = options.apiKey;
+
   const cliSettings = resolveCliSettings(options);
 
   await verify(packageName, cliSettings, options.preset, parseInt(options.chainId));


### PR DESCRIPTION
The CLI settings were expecting the flag to be called `--etherscan-api-key`, but it is defined as `--api-key` in the verify command config. Therefore, the Etherscan API keys sent by the flag were never used. To maintain backward compatibility, I think we can't rename the flag, but we can make it work with the current settings logic.