### PR TITLE
fix(website): ability load cannonfile from hash or tag

### DIFF
--- a/packages/website/src/constants/deployChains.ts
+++ b/packages/website/src/constants/deployChains.ts
@@ -8,12 +8,6 @@ export const chains = [
     serviceUrl: 'https://safe-transaction-mainnet.safe.global',
   },
   {
-    id: 5,
-    name: 'Goerli Testnet',
-    shortName: 'gor',
-    serviceUrl: 'https://safe-transaction-goerli.safe.global',
-  },
-  {
     id: 10,
     name: 'Optimism',
     shortName: 'oeth',
@@ -60,12 +54,6 @@ export const chains = [
     name: 'Avalanche',
     shortName: 'avax',
     serviceUrl: 'https://safe-transaction-avalanche.safe.global',
-  },
-  {
-    id: 84531,
-    name: 'Base Goerli Testnet',
-    shortName: 'basegor',
-    serviceUrl: 'https://safe-transaction-base-testnet.safe.global',
   },
   {
     id: 11155111,

--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -96,7 +96,7 @@ function QueueFromGitOps() {
     return cannonfileUrlInput.split('/blob/')[0];
   }, [cannonfileUrlInput]);
 
-  const gitBranch = useMemo(() => {
+  const gitRef = useMemo(() => {
     if (!cannonfileUrlRegex.test(cannonfileUrlInput)) {
       return '';
     }
@@ -115,7 +115,7 @@ function QueueFromGitOps() {
       return '';
     }
 
-    return `refs/heads/${branchName}`;
+    return branchName;
   }, [cannonfileUrlInput]);
 
   const gitFile = useMemo(() => {
@@ -137,7 +137,7 @@ function QueueFromGitOps() {
     return urlComponents.join('/');
   }, [cannonfileUrlInput]);
 
-  const cannonDefInfo = useLoadCannonDefinition(gitUrl, gitBranch, gitFile);
+  const cannonDefInfo = useLoadCannonDefinition(gitUrl, gitRef, gitFile);
 
   const cannonDefInfoError: string = gitUrl
     ? (cannonDefInfo.error as any)?.toString()
@@ -255,7 +255,12 @@ function QueueFromGitOps() {
   }, [buildInfo.buildResult?.steps]);
 
   const refsInfo = useGitRefsList(gitUrl);
-  const gitHash = refsInfo.refs?.find((r) => r.ref === gitBranch)?.oid;
+  const foundRef = refsInfo.refs?.find(
+    (r) =>
+      (r.ref.startsWith('refs/heads/') || r.ref.startsWith('refs/tags/')) &&
+      r.ref.endsWith(gitRef)
+  )?.oid;
+  const gitHash = gitRef.match(/^[0-9a-f]+$/) ? foundRef || gitRef : foundRef;
 
   const prevInfoQuery = useGetPreviousGitInfoQuery(
     currentSafe as any,


### PR DESCRIPTION
any git ref should be usable in the cannonfile queue page

additionally, removed unsupported chains from gnosis safe server querying thing

btw, I couldn't get the git-proxy to work on my end for some reason. I wonder if this is just a local thing?