### PR TITLE
fix(builder): rebuild `clone` ops on snapshots

### DIFF
--- a/packages/builder/src/steps/clone.ts
+++ b/packages/builder/src/steps/clone.ts
@@ -130,7 +130,9 @@ const cloneSpec = {
     // if all else fails, we can load from scratch (aka this is first deployment)
     let prevState: DeploymentState = {};
     let prevMiscUrl = null;
-    if (ctx.imports[importLabel]?.url) {
+
+    // also do not restore previous state for any network that snapshots--its not possible to restore state snapshots, so we have to rebuild
+    if (!runtime.snapshots && ctx.imports[importLabel]?.url) {
       const prevUrl = ctx.imports[importLabel].url!;
       debug(`[clone.${importLabel}]`, `using state from previous deploy: ${prevUrl}`);
       const prevDeployInfo = await runtime.readBlob(prevUrl);


### PR DESCRIPTION
its not possible to restore a `clone` state cleanly if it chooses not to rebuild, so we force full rebuild every time.