### PR TITLE
fix(builder): schema should allow for all possible arg types/structures

### DIFF
--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -4,13 +4,7 @@ import { z } from 'zod';
 /// ================================ INPUT CONFIG SCHEMAS ================================ \\\
 
 // Different types that can be passed into the args schema property
-// Basically just a union as follows:
-// string | number | (string | number)[] | Record<string, string | number>
-const argtype = z.union([z.string(), z.number(), z.boolean()]);
-const argtype2 = z.array(argtype);
-const argtype3 = z.record(z.string(), argtype);
-const argtype4 = z.array(argtype3);
-const argsUnion = z.union([argtype, argtype2, argtype3, argtype4]);
+const argtype: z.ZodLazy<any> = z.lazy(() => z.union([z.string(), z.number(), z.boolean(), z.record(z.string(), argtype), z.array(argtype)]));
 
 // Different regular expressions used to validate formats like
 // <%=  string interpolation %>, step.names or property.names, packages:versions
@@ -142,7 +136,7 @@ export const deploySchema = z
         /**
          *  Constructor or initializer args
          */
-        args: z.array(argsUnion).describe('Constructor or initializer args'),
+        args: z.array(argtype).describe('Constructor or initializer args'),
         /**
          *  An array of contract operation names that deploy libraries this contract depends on.
          */
@@ -316,7 +310,7 @@ export const invokeSchema = z
         /**
          *  Arguments to use when invoking this call.
          */
-        args: z.array(argsUnion).describe('Arguments to use when invoking this call.'),
+        args: z.array(argtype).describe('Arguments to use when invoking this call.'),
         /**
          *  The calling address to use when invoking this call.
          */
@@ -342,7 +336,7 @@ export const invokeSchema = z
             /**
              *  The arguments to pass into the function being called.
              */
-            args: z.array(argsUnion).optional().describe('The arguments to pass into the function being called.'),
+            args: z.array(argtype).optional().describe('The arguments to pass into the function being called.'),
           })
           .describe("Specify a function to use as the 'from' value in a function call. Example `owner()`."),
         /**
@@ -433,7 +427,7 @@ export const invokeSchema = z
               /**
                *   Constructor or initializer args
                */
-              constructorArgs: z.array(argsUnion).optional().describe('Constructor or initializer args'),
+              constructorArgs: z.array(argtype).optional().describe('Constructor or initializer args'),
 
               /**
                *   Bypass error messages if an event is expected in the invoke operation but none are emitted in the transaction.

--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -4,7 +4,9 @@ import { z } from 'zod';
 /// ================================ INPUT CONFIG SCHEMAS ================================ \\\
 
 // Different types that can be passed into the args schema property
-const argtype: z.ZodLazy<any> = z.lazy(() => z.union([z.string(), z.number(), z.boolean(), z.record(z.string(), argtype), z.array(argtype)]));
+const argtype: z.ZodLazy<any> = z.lazy(() =>
+  z.union([z.string(), z.number(), z.boolean(), z.record(z.string(), argtype), z.array(argtype)])
+);
 
 // Different regular expressions used to validate formats like
 // <%=  string interpolation %>, step.names or property.names, packages:versions


### PR DESCRIPTION
nested arrays in objects were not working. it seems the only way to set up types is to use zod lazy.

I punted on the type because it offers very little benefit to check it.