### PR TITLE
feat(build): offline mode

### DIFF
--- a/.changeset/cuddly-impalas-drum.md
+++ b/.changeset/cuddly-impalas-drum.md
@@ -1,8 +1,0 @@
----
-'@usecannon/builder': minor
-'@usecannon/cli': minor
-'hardhat-cannon': minor
-'indexer': minor
----
-
-Add ipfs objects to MFS

--- a/.changeset/slow-bottles-brake.md
+++ b/.changeset/slow-bottles-brake.md
@@ -1,6 +1,0 @@
----
-'hardhat-cannon': minor
-'@usecannon/cli': minor
----
-
-add offline mode for registry priority

--- a/.changeset/slow-bottles-brake.md
+++ b/.changeset/slow-bottles-brake.md
@@ -1,0 +1,6 @@
+---
+'hardhat-cannon': minor
+'@usecannon/cli': minor
+---
+
+add offline mode for registry priority

--- a/examples/sample-hardhat-project/package-lock.json
+++ b/examples/sample-hardhat-project/package-lock.json
@@ -28,13 +28,13 @@
       }
     },
     "../../packages/hardhat-cannon": {
-      "version": "2.12.2-alpha.1",
+      "version": "2.12.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
-        "@usecannon/builder": "2.12.2-alpha.1",
-        "@usecannon/cli": "2.12.2-alpha.1",
+        "@usecannon/builder": "2.12.4",
+        "@usecannon/cli": "2.12.4",
         "chalk": "^4.1.2",
         "debug": "^4.3.3",
         "fs-extra": "^10.0.1",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -47,7 +47,7 @@ interface Params {
   plugins?: boolean;
   publicSourceCode?: boolean;
   providerUrl?: string;
-  registryPriority?: 'local' | 'onchain';
+  registryPriority?: 'local' | 'onchain' | 'offline';
   gasPrice?: string;
   gasFee?: string;
   priorityGasFee?: string;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -40,7 +40,7 @@ export interface RunOptions {
   privateKey?: viem.Hash;
   upgradeFrom?: string;
   getArtifact?: (name: string) => Promise<ContractArtifact>;
-  registryPriority: 'local' | 'onchain';
+  registryPriority: 'local' | 'onchain' | 'offline';
   fundAddresses?: string[];
   helpInformation?: string;
   build?: boolean;

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -192,7 +192,10 @@ export async function createDefaultReadRegistry(
     (p, i) => new ReadOnlyOnChainRegistry({ provider: p.provider, address: settings.registries[i].address })
   );
 
-  if (!(await isConnectedToInternet())) {
+  if (settings.registryPriority === 'offline') {
+    debug('running in offline mode, using local registry only');
+    return new FallbackRegistry([...additionalRegistries, localRegistry]);
+  } else if (!(await isConnectedToInternet())) {
     debug('not connected to internet, using local registry only');
     // When not connected to the internet, we don't want to check the on-chain registry version to not throw an error
     console.log(yellowBright('⚠️  You are not connected to the internet. Using local registry only'));

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -76,7 +76,7 @@ export type CliSettings = {
   /**
    * Which registry to read from first. Defaults to `onchain`
    */
-  registryPriority: 'local' | 'onchain';
+  registryPriority: 'local' | 'onchain' | 'offline';
 
   /**
    * Directory to load configurations from and for local registry
@@ -166,7 +166,7 @@ function cannonSettingsSchema(fileSettings: Omit<CliSettings, 'cannonDirectory'>
       .optional()
       .refine((v) => !v || viem.isAddress(v), 'must be address')
       .default(fileSettings.registryAddress || DEFAULT_REGISTRY_CONFIG[0].address),
-    CANNON_REGISTRY_PRIORITY: z.enum(['onchain', 'local']).default(fileSettings.registryPriority || 'onchain'),
+    CANNON_REGISTRY_PRIORITY: z.enum(['onchain', 'local', 'offline']).default(fileSettings.registryPriority || 'onchain'),
     CANNON_ETHERSCAN_API_URL: z
       .string()
       .url()

--- a/packages/cli/test/e2e/config/settings.json
+++ b/packages/cli/test/e2e/config/settings.json
@@ -1,6 +1,6 @@
 {
-  "publishIpfsUrl": "https://repo.usecannon.com",
-  "ipfsUrl": "https://repo.usecannon.com",
+  "publishIpfsUrl": "https://us-east.repo.usecannon.com",
+  "ipfsUrl": "https://us-east.repo.usecannon.com",
   "providerUrl": "http://127.0.0.1:9545",
   "privateKey": "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
   "registryProviderUrl": "http://127.0.0.1:9545",

--- a/packages/hardhat-cannon/src/internal/cannon.ts
+++ b/packages/hardhat-cannon/src/internal/cannon.ts
@@ -17,7 +17,7 @@ interface BuildOptions {
   cannonfile: string;
   preset: string;
   settings: PackageSettings;
-  registryPriority?: 'local' | 'onchain';
+  registryPriority?: 'local' | 'onchain' | 'offline';
 }
 
 export async function cannonBuild(options: BuildOptions) {


### PR DESCRIPTION
## Motivation

When doing local development, it is sometimes preferred to not use IPFS or the on-chain registry and only rely on the local registry. 

When checking out a repository, the `builder` will always first obtain the [`oldDeployData`](https://github.com/usecannon/cannon/blob/b60540a70ce5e44926ae775ee4eb7fdfbb384ded/packages/cli/src/commands/build.ts#L170) from IPFS when building for the first time (populate the local registry/cache). However, if the IPFS endpoint is unreachable it will throw an uncaught exception and fail the build. 

```
 Error: could not download cannon package data from "QmeHoNyUA38JUKPPcFPxiAYsDBUnCiHagzvFrYbryrP4XN": Error: connect ECONNREFUSED 0.0.0.0:5001
```

This is likely the preferred behavior, as if a deployment is notarized on the on-chain registry we expect it to be available on IPFS. 

There are numerous causes for IPFS requests to timeout/fail. Some cases I have personally encountered are networks where non-standard ports are filtered, containerized environments and buggy IPFS Desktop versions.

## Solution

Add `CANNON_REGISTRY_PRIORITY=offline` to ensure that we do not try and resolve packages using the on-chain registry and by extension don't try and fetch `oldDeployData` from IPFS. This has the added benefit of increasing the speed of the first checkout build but will cause errors if the package is unavailable locally (can build locally if needed).