### PR TITLE
fix(website): usage of isIpfsGateway helper on website

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47330,7 +47330,7 @@
         "@types/mocha": "9.1.1",
         "@types/node": "18.0.0",
         "@usecannon/builder": "^2.13.0",
-        "@usecannon/cli": "^2.12.5-alpha.0",
+        "@usecannon/cli": "^2.13.0",
         "chai": "4.3.6",
         "dotenv": "16.0.1",
         "ethers": "5.7.1",
@@ -47414,72 +47414,6 @@
       "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
       "dev": true
     },
-    "packages/registry/node_modules/@usecannon/cli": {
-      "version": "2.12.5-alpha.0",
-      "resolved": "https://registry.npmjs.org/@usecannon/cli/-/cli-2.12.5-alpha.0.tgz",
-      "integrity": "sha512-dkPhNqUELctz7ORr05uK4wW//nhnXSj0y1csQAY8t/8W9aijj9ew9kbZwFSeF7G78THmzHkEsvABvZrERomtdQ==",
-      "dev": true,
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@synthetixio/wei": "^2.74.1",
-        "@usecannon/builder": "2.12.5-alpha.0",
-        "abitype": "^1.0.0",
-        "chalk": "^4.1.2",
-        "commander": "^9.5.0",
-        "debug": "^4.3.4",
-        "eth-provider": "^0.13.6",
-        "fastq": "^1.15.0",
-        "fs-extra": "^10.1.0",
-        "lodash": "^4.17.21",
-        "prompts": "^2.4.2",
-        "semver": "^7.3.7",
-        "table": "^6.8.0",
-        "tildify": "2.0.0",
-        "untildify": "^4.0.0",
-        "viem": "^2.9.3",
-        "znv": "^0.4.0",
-        "zod": "^3.22.4"
-      },
-      "bin": {
-        "cannon": "bin/cannon.js"
-      }
-    },
-    "packages/registry/node_modules/@usecannon/cli/node_modules/@usecannon/builder": {
-      "version": "2.12.5-alpha.0",
-      "resolved": "https://registry.npmjs.org/@usecannon/builder/-/builder-2.12.5-alpha.0.tgz",
-      "integrity": "sha512-L56H8hbrZmIgUjm8bkhGTFkgIMCY7q/zr2ZXxyD2Q0BF5tSJ7mftT6ba0v0IItgTgYtD16jGm09jLwMbHkZC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@synthetixio/router": "^3.3.7",
-        "axios": "^1.6.7",
-        "axios-retry": "^4.0.0",
-        "buffer": "^6.0.3",
-        "debug": "^4.3.4",
-        "form-data": "^4.0.0",
-        "lodash": "^4.17.21",
-        "pako": "^2.1.0",
-        "promise-events": "^0.2.4",
-        "typedoc-plugin-markdown": "^3.17.1",
-        "typestub-ipfs-only-hash": "^4.0.0",
-        "viem": "^2.9.3",
-        "zod": "^3.22.4"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "packages/registry/node_modules/axios-retry": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.1.0.tgz",
-      "integrity": "sha512-svdth4H00yhlsjBbjfLQ/sMLkXqeLxhiFC1nE1JtkN/CIssGxqk0UwTEdrVjwA2gr3yJkAulwvDSIm4z4HyPvg==",
-      "dev": true,
-      "dependencies": {
-        "is-retry-allowed": "^2.2.0"
-      },
-      "peerDependencies": {
-        "axios": "0.x || 1.x"
-      }
-    },
     "packages/registry/node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -47537,33 +47471,6 @@
         "@ethersproject/wordlists": "5.7.0"
       }
     },
-    "packages/registry/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/registry/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/registry/node_modules/ts-node": {
       "version": "10.8.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
@@ -47607,12 +47514,6 @@
         }
       }
     },
-    "packages/registry/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "packages/repo": {
       "version": "2.13.0",
       "license": "GPL-3.0-or-later",
@@ -47652,7 +47553,7 @@
         "@types/react": "18.2.37",
         "@types/react-dom": "18.2.6",
         "@usecannon/builder": "^2.13.0",
-        "@usecannon/cli": "^2.12.5-alpha.0",
+        "@usecannon/cli": "^2.13.0",
         "@vercel/analytics": "^1.1.1",
         "axios": "^1.6.7",
         "browser-level": "^1.0.1",
@@ -47775,73 +47676,10 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
       "integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw=="
     },
-    "packages/website/node_modules/@usecannon/cli": {
-      "version": "2.12.5-alpha.0",
-      "resolved": "https://registry.npmjs.org/@usecannon/cli/-/cli-2.12.5-alpha.0.tgz",
-      "integrity": "sha512-dkPhNqUELctz7ORr05uK4wW//nhnXSj0y1csQAY8t/8W9aijj9ew9kbZwFSeF7G78THmzHkEsvABvZrERomtdQ==",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@synthetixio/wei": "^2.74.1",
-        "@usecannon/builder": "2.12.5-alpha.0",
-        "abitype": "^1.0.0",
-        "chalk": "^4.1.2",
-        "commander": "^9.5.0",
-        "debug": "^4.3.4",
-        "eth-provider": "^0.13.6",
-        "fastq": "^1.15.0",
-        "fs-extra": "^10.1.0",
-        "lodash": "^4.17.21",
-        "prompts": "^2.4.2",
-        "semver": "^7.3.7",
-        "table": "^6.8.0",
-        "tildify": "2.0.0",
-        "untildify": "^4.0.0",
-        "viem": "^2.9.3",
-        "znv": "^0.4.0",
-        "zod": "^3.22.4"
-      },
-      "bin": {
-        "cannon": "bin/cannon.js"
-      }
-    },
-    "packages/website/node_modules/@usecannon/cli/node_modules/@usecannon/builder": {
-      "version": "2.12.5-alpha.0",
-      "resolved": "https://registry.npmjs.org/@usecannon/builder/-/builder-2.12.5-alpha.0.tgz",
-      "integrity": "sha512-L56H8hbrZmIgUjm8bkhGTFkgIMCY7q/zr2ZXxyD2Q0BF5tSJ7mftT6ba0v0IItgTgYtD16jGm09jLwMbHkZC4Q==",
-      "dependencies": {
-        "@synthetixio/router": "^3.3.7",
-        "axios": "^1.6.7",
-        "axios-retry": "^4.0.0",
-        "buffer": "^6.0.3",
-        "debug": "^4.3.4",
-        "form-data": "^4.0.0",
-        "lodash": "^4.17.21",
-        "pako": "^2.1.0",
-        "promise-events": "^0.2.4",
-        "typedoc-plugin-markdown": "^3.17.1",
-        "typestub-ipfs-only-hash": "^4.0.0",
-        "viem": "^2.9.3",
-        "zod": "^3.22.4"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "packages/website/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "packages/website/node_modules/axios-retry": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.1.0.tgz",
-      "integrity": "sha512-svdth4H00yhlsjBbjfLQ/sMLkXqeLxhiFC1nE1JtkN/CIssGxqk0UwTEdrVjwA2gr3yJkAulwvDSIm4z4HyPvg==",
-      "dependencies": {
-        "is-retry-allowed": "^2.2.0"
-      },
-      "peerDependencies": {
-        "axios": "0.x || 1.x"
-      }
     },
     "packages/website/node_modules/eslint": {
       "version": "8.43.0",
@@ -47967,17 +47805,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/website/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/website/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -48006,20 +47833,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/website/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/website/node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -48030,11 +47843,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "packages/website/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -19,11 +19,9 @@ export * from './types';
 };
 
 export { CannonRegistry, OnChainRegistry, InMemoryRegistry, FallbackRegistry } from './registry';
-
 export { publishPackage, PackageReference, getProvisionedPackages } from './package';
-
 export { CANNON_CHAIN_ID, getCannonRepoRegistryUrl, BUILD_VERSION } from './constants';
-
+export { isIpfsGateway } from './ipfs';
 export * from './access-recorder';
 export { renderTrace, findContract } from './trace';
 export type { TraceEntry } from './trace';

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -25,7 +25,7 @@
     "@types/mocha": "9.1.1",
     "@types/node": "18.0.0",
     "@usecannon/builder": "^2.13.0",
-    "@usecannon/cli": "^2.12.5-alpha.0",
+    "@usecannon/cli": "^2.13.0",
     "chai": "4.3.6",
     "dotenv": "16.0.1",
     "ethers": "5.7.1",

--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -1,18 +1,17 @@
 'use client';
-import '@/styles/globals.css';
 
-import { Providers } from './providers';
 import GoogleAnalytics from '@/components/GoogleAnalytics';
-import { Miriam_Libre, Inter, Roboto_Mono } from 'next/font/google';
-import { Flex } from '@chakra-ui/react';
-import { Header } from '@/features/Header/Header';
-import { Footer } from '@/features/Footer/Footer';
 import { Console } from '@/features/Console/Console';
-import { Analytics } from '@vercel/analytics/react';
-import { ReactNode, useEffect } from 'react';
-import axios, { AxiosError } from 'axios';
+import { Footer } from '@/features/Footer/Footer';
+import { Header } from '@/features/Header/Header';
 import { useStore } from '@/helpers/store';
-import { parse as parseUrl } from 'simple-url';
+import { Flex } from '@chakra-ui/react';
+import { isIpfsGateway } from '@usecannon/builder';
+import { Analytics } from '@vercel/analytics/react';
+import { Inter, Miriam_Libre, Roboto_Mono } from 'next/font/google';
+import { ReactNode, useEffect } from 'react';
+import { Providers } from './providers';
+import '@/styles/globals.css';
 
 const miriam = Miriam_Libre({
   subsets: ['latin'],
@@ -30,43 +29,14 @@ const mono = Roboto_Mono({
   display: 'swap',
 });
 
-async function isIpfsGateway(ipfsUrl: string) {
-  let isGateway = true;
-  try {
-    ipfsUrl = ipfsUrl.endsWith('/') ? ipfsUrl : ipfsUrl + '/';
-    const parsedUrl = parseUrl(ipfsUrl);
-    const headers: { [k: string]: string } = {};
-
-    if (parsedUrl.auth) {
-      const [username, password] = parsedUrl.auth.split(':');
-      headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
-    }
-    await axios.post(ipfsUrl + 'api/v0/cat', null, {
-      headers,
-      timeout: 15 * 1000,
-    });
-  } catch (err: unknown) {
-    if (
-      err instanceof AxiosError &&
-      err.response?.status === 400 &&
-      err.response?.data.includes('argument "ipfs-path" is required')
-    ) {
-      isGateway = false;
-    }
-  }
-
-  return isGateway;
-}
-
 export default function RootLayout({ children }: { children: ReactNode }) {
   const settings = useStore((s) => s.settings);
   const setSettings = useStore((s) => s.setSettings);
 
   useEffect(() => {
     async function fetch() {
-      setSettings({
-        isIpfsGateway: await isIpfsGateway(settings.ipfsApiUrl),
-      });
+      const isGateway = await isIpfsGateway(settings.ipfsApiUrl);
+      setSettings({ isIpfsGateway: isGateway });
     }
 
     void fetch();


### PR DESCRIPTION
This PR removes the custom `isIpfsGateway` helper on the website, and just uses the one from `@usecannon/builder`.