### PR TITLE
fix(registry): optimism registry has different list of signers from mainnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9201,28 +9201,26 @@
       }
     },
     "node_modules/@nomicfoundation/edr": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.2.1.tgz",
-      "integrity": "sha512-Dleau3ItHJh2n85G2J6AIPBoLgu/mOWkmrh26z3VsJE2tp/e00hUk/dqz85ncsVcBYEc6/YOn/DomWu0wSF9tQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.3.5.tgz",
+      "integrity": "sha512-dPSM9DuI1sr71gqWUMgLo8MjHQWO4+WNDm3iWaT6P4vUFJReZX5qwA5X+3UwIPBry8GvNY084u7yWUvB3/8rqA==",
       "engines": {
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@nomicfoundation/edr-darwin-arm64": "0.2.1",
-        "@nomicfoundation/edr-darwin-x64": "0.2.1",
-        "@nomicfoundation/edr-linux-arm64-gnu": "0.2.1",
-        "@nomicfoundation/edr-linux-arm64-musl": "0.2.1",
-        "@nomicfoundation/edr-linux-x64-gnu": "0.2.1",
-        "@nomicfoundation/edr-linux-x64-musl": "0.2.1",
-        "@nomicfoundation/edr-win32-arm64-msvc": "0.2.1",
-        "@nomicfoundation/edr-win32-ia32-msvc": "0.2.1",
-        "@nomicfoundation/edr-win32-x64-msvc": "0.2.1"
+        "@nomicfoundation/edr-darwin-arm64": "0.3.5",
+        "@nomicfoundation/edr-darwin-x64": "0.3.5",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.3.5",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.3.5",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.3.5",
+        "@nomicfoundation/edr-linux-x64-musl": "0.3.5",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.3.5"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.2.1.tgz",
-      "integrity": "sha512-aMYaRaZVQ/TmyNJIoXf1bU4k0zfinaL9Sy1day4yGlL6eiQPFfRGj9W6TZaZIoYG0XTx/mQWD7dkXJ7LdrleJA==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.5.tgz",
+      "integrity": "sha512-gIXUIiPMUy6roLHpNlxf15DumU7/YhffUf7XIB+WUjMecaySfTGyZsTGnCMJZqrDyiYqWPyPKwCV/2u/jqFAUg==",
       "cpu": [
         "arm64"
       ],
@@ -9236,9 +9234,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-x64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.2.1.tgz",
-      "integrity": "sha512-ma0SLcjHm5L3nPHcKFJB0jv/gKGSKaxr5Z65rurX/eaYUQJ7YGMsb8er9bSCo9rjzOtxf4FoPj3grL3zGpOj8A==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.5.tgz",
+      "integrity": "sha512-0MrpOCXUK8gmplpYZ2Cy0holHEylvWoNeecFcrP2WJ5DLQzrB23U5JU2MvUzOJ7aL76Za1VXNBWi/UeTWdHM+w==",
       "cpu": [
         "x64"
       ],
@@ -9252,9 +9250,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.2.1.tgz",
-      "integrity": "sha512-NX3G4pBhRitWrjSGY3HTyCq3wKSm5YqrKVOCNQGl9/jcjSovqxlgzFMiTx4YZCzGntfJ/1om9AI84OWxYJjoDw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.5.tgz",
+      "integrity": "sha512-aw9f7AZMiY1dZFNePJGKho2k+nEgFgzUAyyukiKfSqUIMXoFXMf1U3Ujv848czrSq9c5XGcdDa2xnEf3daU3xg==",
       "cpu": [
         "arm64"
       ],
@@ -9268,9 +9266,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.2.1.tgz",
-      "integrity": "sha512-gdQ3QHkt9XRkdtOGQ8fMwS11MXdjLeZgLrqoial4V4qtMaamIMMhVczK+VEvUhD8p7G4BVmp6kmkvcsthmndmw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.5.tgz",
+      "integrity": "sha512-cVFRQjyABBlsbDj+XTczYBfrCHprZ6YNzN8gGGSqAh+UGIJkAIRomK6ar27GyJLNx3HkgbuDoi/9kA0zOo/95w==",
       "cpu": [
         "arm64"
       ],
@@ -9284,9 +9282,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.2.1.tgz",
-      "integrity": "sha512-OqabFY37vji6mYbLD9CvG28lja68czeVw58oWByIhFV3BpBu/cyP1oAbhzk3LieylujabS3Ekpvjw2Tkf0A9RQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.5.tgz",
+      "integrity": "sha512-CjOg85DfR1Vt0fQWn5U0qi26DATK9tVzo3YOZEyI0JBsnqvk43fUTPv3uUAWBrPIRg5O5kOc9xG13hSpCBBxBg==",
       "cpu": [
         "x64"
       ],
@@ -9300,9 +9298,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.2.1.tgz",
-      "integrity": "sha512-vHfFFK2EPISuQUQge+bdjXamb0EUjfl8srYSog1qfiwyLwLeuSbpyyFzDeITAgPpkkFuedTfJW553K0Hipspyg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.5.tgz",
+      "integrity": "sha512-hvX8bBGpBydAVevzK8jsu2FlqVZK1RrCyTX6wGHnltgMuBaoGLHYtNHiFpteOaJw2byYMiORc2bvj+98LhJ0Ew==",
       "cpu": [
         "x64"
       ],
@@ -9315,42 +9313,10 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@nomicfoundation/edr-win32-arm64-msvc": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-arm64-msvc/-/edr-win32-arm64-msvc-0.2.1.tgz",
-      "integrity": "sha512-K/mui67RCKxghbSyvhvW3rvyVN1pa9M1Q9APUx1PtWjSSdXDFpqEY1NYsv2syb47Ca8ObJwVMF+LvnB6GvhUOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/edr-win32-ia32-msvc": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-ia32-msvc/-/edr-win32-ia32-msvc-0.2.1.tgz",
-      "integrity": "sha512-HHK0mXEtjvfjJrJlqcYgQCy3lZIXS1KNl2GaP8bwEIuEwx++XxXs/ThLjPepM1nhCGICij8IGy7p3KrkzRelsw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.2.1.tgz",
-      "integrity": "sha512-FY4eQJdj1/y8ST0RyQycx63yr+lvdYNnUkzgWf4X+vPH1lOhXae+L2NDcNCQlTDAfQcD6yz0bkBUkLrlJ8pTww==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.5.tgz",
+      "integrity": "sha512-IJXjW13DY5UPsx/eG5DGfXtJ7Ydwrvw/BTZ2Y93lRLHzszVpSmeVmlxjZP5IW2afTSgMLaAAsqNw4NhppRGN8A==",
       "cpu": [
         "x64"
       ],
@@ -26626,13 +26592,13 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.21.0.tgz",
-      "integrity": "sha512-8DlJAVJDEVHaV1sh9FLuKLLgCFv9EAJ+M+8IbjSIPgoeNo3ss5L1HgGBMfnI88c7OzMEZkdcuyGoobFeK3Orqw==",
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.3.tgz",
+      "integrity": "sha512-k8JV2ECWNchD6ahkg2BR5wKVxY0OiKot7fuxiIpRK0frRqyOljcR2vKwgWSLw6YIeDcNNA4xybj7Og7NSxr2hA==",
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/edr": "^0.2.0",
+        "@nomicfoundation/edr": "^0.3.5",
         "@nomicfoundation/ethereumjs-common": "4.0.4",
         "@nomicfoundation/ethereumjs-tx": "5.0.4",
         "@nomicfoundation/ethereumjs-util": "9.0.4",
@@ -47334,7 +47300,7 @@
         "chai": "4.3.6",
         "dotenv": "16.0.1",
         "ethers": "5.7.1",
-        "hardhat": "^2.12.6",
+        "hardhat": "^2.22.3",
         "hardhat-cannon": "^2.13.0",
         "hardhat-contract-sizer": "^2.7.0",
         "hardhat-gas-reporter": "^1.0.9",

--- a/packages/builder/src/abis/CannonRegistry.ts
+++ b/packages/builder/src/abis/CannonRegistry.ts
@@ -244,8 +244,14 @@ export default [
         name: 'owner',
         type: 'address',
       },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'feePaid',
+        type: 'uint256',
+      },
     ],
-    name: 'PackagePublish',
+    name: 'PackagePublishWithFee',
     type: 'event',
   },
   {
@@ -360,6 +366,37 @@ export default [
     inputs: [
       {
         indexed: true,
+        internalType: 'bytes32',
+        name: 'name',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'variant',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'tag',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'versionOfTag',
+        type: 'bytes32',
+      },
+    ],
+    name: 'TagPublish',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
         internalType: 'address',
         name: 'self',
         type: 'address',
@@ -406,7 +443,7 @@ export default [
     outputs: [
       {
         internalType: 'address[]',
-        name: 'additionalDeployers',
+        name: 'additionalPublishers',
         type: 'address[]',
       },
     ],
@@ -654,7 +691,12 @@ export default [
       },
       {
         internalType: 'address[]',
-        name: '_additionalDeployers',
+        name: '_additionalPublishersEthereum',
+        type: 'address[]',
+      },
+      {
+        internalType: 'address[]',
+        name: '_additionalPublishersOptimism',
         type: 'address[]',
       },
     ],

--- a/packages/registry/contracts/CannonRegistry.sol
+++ b/packages/registry/contracts/CannonRegistry.sol
@@ -199,7 +199,11 @@ contract CannonRegistry is EfficientStorage, OwnedUpgradable {
     emit PackageOwnerChanged(_packageName, _owner);
   }
 
-  function setAdditionalPublishers(bytes32 _packageName, address[] memory _additionalPublishersEthereum, address[] memory _additionalPublishersOptimism) external {
+  function setAdditionalPublishers(
+    bytes32 _packageName,
+    address[] memory _additionalPublishersEthereum,
+    address[] memory _additionalPublishersOptimism
+  ) external {
     Package storage _p = _store().packages[_packageName];
     address owner = _p.owner;
 
@@ -212,14 +216,21 @@ contract CannonRegistry is EfficientStorage, OwnedUpgradable {
 
       _OPTIMISM_MESSENGER.sendMessage(
         address(this),
-        abi.encodeWithSelector(this.setAdditionalPublishers.selector, _packageName, new address[](0), _additionalPublishersOptimism),
+        abi.encodeWithSelector(
+          this.setAdditionalPublishers.selector,
+          _packageName,
+          new address[](0),
+          _additionalPublishersOptimism
+        ),
         uint32(30000 * _additionalPublishersOptimism.length + 200000)
       );
     } else {
       revert Unauthorized();
     }
 
-    address[] memory additionalPublishers = block.chainid == 1 ? _additionalPublishersEthereum : _additionalPublishersOptimism;
+    address[] memory additionalPublishers = block.chainid == 1
+      ? _additionalPublishersEthereum
+      : _additionalPublishersOptimism;
 
     for (uint256 i = 0; i < additionalPublishers.length; i++) {
       _p.additionalPublishers[i] = additionalPublishers[i];

--- a/packages/registry/contracts/CannonRegistry.sol
+++ b/packages/registry/contracts/CannonRegistry.sol
@@ -193,13 +193,13 @@ contract CannonRegistry is EfficientStorage, OwnedUpgradable {
     }
 
     _p.owner = _owner;
-    _p.additionalDeployersLength = 0;
+    _p.additionalPublishersLength = 0;
     _p.nominatedOwner = address(0);
 
     emit PackageOwnerChanged(_packageName, _owner);
   }
 
-  function setAdditionalPublishers(bytes32 _packageName, address[] memory _additionalDeployers) external {
+  function setAdditionalPublishers(bytes32 _packageName, address[] memory _additionalPublishersEthereum, address[] memory _additionalPublishersOptimism) external {
     Package storage _p = _store().packages[_packageName];
     address owner = _p.owner;
 
@@ -212,28 +212,30 @@ contract CannonRegistry is EfficientStorage, OwnedUpgradable {
 
       _OPTIMISM_MESSENGER.sendMessage(
         address(this),
-        abi.encodeWithSelector(this.setAdditionalPublishers.selector, _packageName, _additionalDeployers),
-        uint32(30000 * _additionalDeployers.length + 200000)
+        abi.encodeWithSelector(this.setAdditionalPublishers.selector, _packageName, new address[](0), _additionalPublishersOptimism),
+        uint32(30000 * _additionalPublishersOptimism.length + 200000)
       );
     } else {
       revert Unauthorized();
     }
 
-    for (uint256 i = 0; i < _additionalDeployers.length; i++) {
-      _p.additionalDeployers[i] = _additionalDeployers[i];
+    address[] memory additionalPublishers = block.chainid == 1 ? _additionalPublishersEthereum : _additionalPublishersOptimism;
+
+    for (uint256 i = 0; i < additionalPublishers.length; i++) {
+      _p.additionalPublishers[i] = additionalPublishers[i];
     }
 
-    _p.additionalDeployersLength = _additionalDeployers.length;
+    _p.additionalPublishersLength = additionalPublishers.length;
 
-    emit PackagePublishersChanged(_packageName, _additionalDeployers);
+    emit PackagePublishersChanged(_packageName, additionalPublishers);
   }
 
-  function getAdditionalPublishers(bytes32 _packageName) external view returns (address[] memory additionalDeployers) {
+  function getAdditionalPublishers(bytes32 _packageName) external view returns (address[] memory additionalPublishers) {
     Package storage _p = _store().packages[_packageName];
-    additionalDeployers = new address[](_p.additionalDeployersLength);
+    additionalPublishers = new address[](_p.additionalPublishersLength);
 
-    for (uint256 i = 0; i < additionalDeployers.length; i++) {
-      additionalDeployers[i] = _p.additionalDeployers[i];
+    for (uint256 i = 0; i < additionalPublishers.length; i++) {
+      additionalPublishers[i] = _p.additionalPublishers[i];
     }
   }
 
@@ -299,11 +301,11 @@ contract CannonRegistry is EfficientStorage, OwnedUpgradable {
   }
 
   function _canPublishPackage(Package storage _package, address _publisher) internal view returns (bool) {
-    if (_package.owner == _publisher) return true;
+    if (block.chainid == 1 && _package.owner == _publisher) return true;
 
-    uint256 additionalDeployersLength = _package.additionalDeployersLength;
-    for (uint256 i = 0; i < additionalDeployersLength; i++) {
-      if (_package.additionalDeployers[i] == _publisher) return true;
+    uint256 additionalPublishersLength = _package.additionalPublishersLength;
+    for (uint256 i = 0; i < additionalPublishersLength; i++) {
+      if (_package.additionalPublishers[i] == _publisher) return true;
     }
 
     return false;

--- a/packages/registry/contracts/EfficientStorage.sol
+++ b/packages/registry/contracts/EfficientStorage.sol
@@ -16,8 +16,8 @@ contract EfficientStorage {
     mapping(bytes32 => mapping(bytes32 => CannonDeployInfo)) deployments;
     address owner;
     address nominatedOwner;
-    uint256 additionalDeployersLength;
-    mapping(uint256 => address) additionalDeployers;
+    uint256 additionalPublishersLength;
+    mapping(uint256 => address) additionalPublishers;
   }
 
   struct CannonDeployInfo {

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -29,7 +29,7 @@
     "chai": "4.3.6",
     "dotenv": "16.0.1",
     "ethers": "5.7.1",
-    "hardhat": "^2.12.6",
+    "hardhat": "^2.22.3",
     "hardhat-cannon": "^2.13.0",
     "hardhat-contract-sizer": "^2.7.0",
     "hardhat-gas-reporter": "^1.0.9",


### PR DESCRIPTION
to prevent smart contract wallet which cant necessarily be claimed on all chains from being abused, we allow for setting of separate list of `additionalPublisher`s on optimism and mainnet.

this also furthermore means that publishing by the package `owner` address on optimism is not possible. If the user wants to be able to deploy with the same address on optimism, they need to add their owner to the optimism `additionalPublisher`'s list.

also took the opporitunity to clean up and update the names of all the fields to the `additionalPublishers` instead of deployer.

This is not a perfectly efficient setup, but its functional and the user doesn't have to see it directly.

## TODO
- [ ] Update CLI to set owner as additional publisher on register package / migration
- [ ] Merge graph: https://github.com/usecannon/cannon/pull/932/files