### PR TITLE
fix(website): show queue drawer on queueing action

### DIFF
--- a/packages/website/src/app/deploy/layout.tsx
+++ b/packages/website/src/app/deploy/layout.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import { ReactNode, Suspense } from 'react';
-import { Box, Flex, Spinner } from '@chakra-ui/react';
+import { Box, Flex, Spinner, useDisclosure } from '@chakra-ui/react';
 import { usePathname } from 'next/navigation';
 import { links } from '@/constants/links';
 import { NavLink } from '@/components/NavLink';
@@ -15,6 +15,7 @@ const NoSSRWithSafe = dynamic(() => import('@/features/Deploy/WithSafe'), {
 
 export default function DeployLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <Flex flexDir="column" width="100%">
@@ -59,7 +60,7 @@ export default function DeployLayout({ children }: { children: ReactNode }) {
       </Box>
       <NoSSRWithSafe>
         {children}
-        <QueueDrawer />
+        <QueueDrawer isOpen={isOpen} onClose={onClose} onOpen={onOpen} />
       </NoSSRWithSafe>
     </Flex>
   );

--- a/packages/website/src/features/Deploy/QueueDrawer.tsx
+++ b/packages/website/src/features/Deploy/QueueDrawer.tsx
@@ -163,6 +163,7 @@ const QueuedTxns = ({ onDrawerClose }: { onDrawerClose: () => void }) => {
     setQueuedIdentifiableTxns(
       queuedIdentifiableTxns.filter((_, index) => index !== i)
     );
+    setLastQueuedTxnsId(lastQueuedTxnsId - 1);
   };
 
   const addQueuedTxn = () => {

--- a/packages/website/src/features/Deploy/QueueDrawer.tsx
+++ b/packages/website/src/features/Deploy/QueueDrawer.tsx
@@ -28,7 +28,6 @@ import {
   DrawerCloseButton,
   DrawerHeader,
   DrawerBody,
-  useDisclosure,
   Button,
   Icon,
 } from '@chakra-ui/react';
@@ -415,8 +414,15 @@ const QueuedTxns = ({ onDrawerClose }: { onDrawerClose: () => void }) => {
   );
 };
 
-const QueueDrawer = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+const QueueDrawer = ({
+  isOpen,
+  onOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+}) => {
   return (
     <>
       <IconButton

--- a/packages/website/src/features/Packages/Abi.tsx
+++ b/packages/website/src/features/Packages/Abi.tsx
@@ -23,7 +23,15 @@ export const Abi: FC<{
   cannonOutputs: ChainArtifacts;
   chainId: number;
   contractSource?: string;
-}> = ({ abi, contractSource, address, cannonOutputs, chainId }) => {
+  onDrawerOpen?: () => void;
+}> = ({
+  abi,
+  contractSource,
+  address,
+  cannonOutputs,
+  chainId,
+  onDrawerOpen,
+}) => {
   const functions = useMemo<AbiFunction[]>(
     () => abi?.filter((a) => a.type === 'function') as AbiFunction[],
     [abi]
@@ -193,6 +201,7 @@ export const Abi: FC<{
               cannonOutputs={cannonOutputs}
               chainId={chainId}
               contractSource={contractSource}
+              onDrawerOpen={onDrawerOpen}
             />
           ))}
         </Box>

--- a/packages/website/src/features/Packages/FunctionInput/AddressInput.tsx
+++ b/packages/website/src/features/Packages/FunctionInput/AddressInput.tsx
@@ -2,13 +2,21 @@ import { isAddress } from 'viem';
 import { Input } from '@chakra-ui/react';
 import { FC, useEffect, useMemo, useState } from 'react';
 
+// This function is used to check if the value is an address or an array of addresses
+const isValidArrayOrAddress = (value: any | any[]): boolean => {
+  if (Array.isArray(value)) {
+    return value.every((v) => isValidArrayOrAddress(v));
+  }
+  return isAddress(value);
+};
+
 export const AddressInput: FC<{
   handleUpdate: (value: string) => void;
   value?: string;
 }> = ({ handleUpdate, value = '' }) => {
   const [updateValue, setUpdateValue] = useState<string>(value);
   const isInvalid = useMemo(() => {
-    return updateValue?.length > 0 && !isAddress(updateValue);
+    return updateValue?.length > 0 && !isValidArrayOrAddress(updateValue);
   }, [updateValue]);
   useEffect(() => handleUpdate(updateValue), [updateValue]);
 

--- a/packages/website/src/features/Packages/Interact.tsx
+++ b/packages/website/src/features/Packages/Interact.tsx
@@ -13,6 +13,7 @@ import {
   Link,
   Text,
   useBreakpointValue,
+  useDisclosure,
 } from '@chakra-ui/react';
 import { ChainArtifacts, ContractData } from '@usecannon/builder/src';
 import { FC, useContext, useEffect, useState } from 'react';
@@ -28,6 +29,7 @@ export const Interact: FC<{
   contractName: string;
   contractAddress: Address;
 }> = ({ name, tag, variant, moduleName, contractName, contractAddress }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const { data } = useQueryCannonSubgraphData<any, any>(GET_PACKAGE, {
     variables: { name },
   });
@@ -190,8 +192,9 @@ export const Interact: FC<{
             address={contractAddress}
             cannonOutputs={cannonOutputs}
             chainId={currentVariant?.chain_id}
+            onDrawerOpen={onOpen}
           />
-          <QueueDrawer />
+          <QueueDrawer isOpen={isOpen} onClose={onClose} onOpen={onOpen} />
         </>
       )}
     </>


### PR DESCRIPTION
This PR aims to enhance the behavior of the queue drawer. With the proposed changes, the drawer will be displayed on every queuing action, regardless of whether the transaction is successfully added or encounters an error.

https://github.com/usecannon/cannon/assets/3952453/36d57fbd-3aa8-4485-a16a-5e675c19b34f

This PR also fixes the issue with the `Address[]` type, and other array params


https://github.com/usecannon/cannon/assets/3952453/419e1f50-ee6c-4dcb-9228-8aff8b4f1723



