### PR TITLE
fix(cli): cannon should exit with same code as forge

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -645,11 +645,11 @@ applyCommandsConfig(program.command('test'), commandsConfig.test).action(async f
     process.stderr.write(data);
   });
 
-  await new Promise((resolve) => {
+  await new Promise(() => {
     forgeProcess.on('close', (code: number) => {
       console.log(`forge exited with code ${code}`);
       node?.kill();
-      resolve({});
+      process.exit(code);
     });
   });
 });

--- a/packages/cli/test/e2e/scripts/non-interactive/test.sh
+++ b/packages/cli/test/e2e/scripts/non-interactive/test.sh
@@ -7,4 +7,7 @@ output=$($CANNON test cannonfile.toml)
 [[ ! "$output" = "0 failed, 0 skipped" ]]
 
 # test running on a fork
-$CANNON test --provider-url https://ethereum-rpc.publicnode.com
+output=$($CANNON test --provider-url https://ethereum-rpc.publicnode.com || true)
+
+# test is expected to fail, but it should run
+[[ ! "$output" = "1 failed, 0 skipped" ]]


### PR DESCRIPTION
otherwise it throws off CI and tests etc.