### PR TITLE
fix(website): prevent inclusion of bogus execution hashes

### DIFF
--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -46,7 +46,7 @@ export type ContractMap = {
 
 export type TransactionMap = {
   [label: string]: {
-    hash: Hash;
+    hash: Hash | '';
     events: EventMap;
     deployedOn: string;
     gasUsed: number;

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -151,6 +151,12 @@ export function useCannonBuild(safe: SafeDefinition | null, def?: ChainDefinitio
         addLog(
           `cannon.ts: on Events.PostStepExecute operation ${stepType}.${stepLabel} output: ${JSON.stringify(stepOutput)}`
         );
+
+        for (const txn in stepOutput.txns || {}) {
+          // clean out txn hash
+          stepOutput.txns![txn].hash = '';
+        }
+
         simulatedSteps.push(stepOutput);
         setBuildStatus(`Building ${stepType}.${stepLabel}...`);
       }


### PR DESCRIPTION
fixes https://linear.app/usecannon/issue/CAN-281/remove-bogus-transaction-hashes-from-web-app-deployments