### PR TITLE
fix(cli): includeProvisioned by default

### DIFF
--- a/packages/cli/src/commandsConfig.ts
+++ b/packages/cli/src/commandsConfig.ts
@@ -451,8 +451,8 @@ const commandsConfig = {
         description: '(DEPRECATED) Includes provisioned packages when publishing to the registry',
       },
       {
-        flags: '--exclude-provisioned',
-        description: 'Excludes provisioned packages when publishing to the registry',
+        flags: '--exclude-cloned',
+        description: 'Excludes cloned packages when publishing to the registry',
       },
       {
         flags: '--skip-confirm',

--- a/packages/cli/src/commandsConfig.ts
+++ b/packages/cli/src/commandsConfig.ts
@@ -448,7 +448,11 @@ const commandsConfig = {
       },
       {
         flags: '--include-provisioned',
-        description: 'Includes provisioned packages when publishing to the registry',
+        description: '(DEPRECATED) Includes provisioned packages when publishing to the registry',
+      },
+      {
+        flags: '--exclude-provisioned',
+        description: 'Excludes provisioned packages when publishing to the registry',
       },
       {
         flags: '--skip-confirm',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -473,7 +473,7 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
     chainId: options.chainId ? options.chainId : undefined,
     presetArg: options.preset ? (options.preset as string) : undefined,
     quiet: options.quiet,
-    includeProvisioned: options.includeProvisioned,
+    includeProvisioned: !options.excludeProvisioned,
     skipConfirm: options.skipConfirm,
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -473,7 +473,7 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
     chainId: options.chainId ? options.chainId : undefined,
     presetArg: options.preset ? (options.preset as string) : undefined,
     quiet: options.quiet,
-    includeProvisioned: !options.excludeProvisioned,
+    includeProvisioned: !options.excludeCloned,
     skipConfirm: options.skipConfirm,
   });
 });


### PR DESCRIPTION
we do this by deprecating includeProvisioned and adding a new option (excludeProvisioned)

includeProvisioned now has no effect