### PR TITLE
fix(website): handle hidden source code

### DIFF
--- a/packages/website/src/features/Packages/CodeExplorer.tsx
+++ b/packages/website/src/features/Packages/CodeExplorer.tsx
@@ -192,7 +192,7 @@ export const CodeExplorer: FC<{
         return {
           key,
           value,
-          sources: JSON.parse(value.source.input).sources,
+          sources: value.source ? JSON.parse(value.source.input).sources : [],
         };
       });
 
@@ -257,18 +257,26 @@ export const CodeExplorer: FC<{
             })
           : [];
 
-        const [sourceKey, sourceValue] = sortedSources[0];
-        setSelectedCode((sourceValue as any)?.content);
-        setSelectedLanguage('sol');
-        setSelectedKey(sourceKey);
+        if (sortedSources.length) {
+          const [sourceKey, sourceValue] = sortedSources[0];
+          setSelectedCode((sourceValue as any)?.content);
+          setSelectedLanguage('sol');
+          setSelectedKey(sourceKey);
 
-        window.history.pushState(
-          null,
-          '',
-          `/packages/${name}/${variant.tag.name}/${variant.name}/code/${
-            selectedPackage.name
-          }?source=${encodeURIComponent(sourceKey)}`
-        );
+          window.history.pushState(
+            null,
+            '',
+            `/packages/${name}/${variant.tag.name}/${variant.name}/code/${
+              selectedPackage.name
+            }?source=${encodeURIComponent(sourceKey)}`
+          );
+        } else {
+          window.history.pushState(
+            null,
+            '',
+            `/packages/${name}/${variant.tag.name}/${variant.name}/code/${selectedPackage.name}`
+          );
+        }
       }
     }
   }, [


### PR DESCRIPTION
* still something weird on http://0.0.0.0:3000/packages/reya-ranks/latest/1729-router
* http://0.0.0.0:3000/packages/reya-rusd/latest/1729-router/code/reya-rusd should show "no code available" instead of empty monaco component
* http://0.0.0.0:3000/packages/reya-omnibus/latest/1729-main/code/wbtc?source=..%2Fnode_modules%2F%40voltz-protocol%2Futil-contracts%2Fsrc%2Ferrors%2FAccessError.sol clicking to a cloned package with no code should show "no code available" instead of empty monaco component
