### PR TITLE
fix(website): allow fresh safes to queue txs

### DIFF
--- a/packages/website/src/hooks/backend.ts
+++ b/packages/website/src/hooks/backend.ts
@@ -30,8 +30,11 @@ export function useSafeTransactions(safe?: SafeDefinition) {
     functionName: 'nonce',
   });
 
+  // since nonce can be 0, we need to check if the data is defined
+  const nonceQueryIsLoaded = nonceQuery.data !== undefined && !nonceQuery.isFetching && !nonceQuery.isError;
+
   const staged =
-    stagedQuery.data && nonceQuery.data
+    stagedQuery.data && nonceQueryIsLoaded
       ? _.sortBy(
           stagedQuery.data.data.filter((t: any) => t.txn._nonce >= (nonceQuery as any).data),
           'txn._nonce'
@@ -78,7 +81,8 @@ export function useTxnStager(
     gasPrice: txn.gasPrice || '0',
     gasToken: txn.gasToken || viem.zeroAddress,
     refundReceiver: querySafeAddress as any,
-    _nonce: txn._nonce || (staged.length ? _.last(staged).txn._nonce + 1 : Number(nonce || 0)),
+    // Since nonce can be 0, we need to check if the txn._nonce is defined with the nullish coalescing operator
+    _nonce: txn._nonce ?? (staged.length ? _.last(staged).txn._nonce + 1 : Number(nonce || 0)),
   };
 
   // try to match with an existing transaction


### PR DESCRIPTION
For fresh wallets (nonce equals to 0) there was no possible to queue txs

## Functionality after the fix

https://github.com/usecannon/cannon/assets/3952453/1e698026-abef-4f12-b37d-df8b6d6d943f


