### PR TITLE
fix(cli): fixing publish incorrect cloned package output

### DIFF
--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -150,7 +150,7 @@ function _deployImports(deployInfo: DeploymentInfo) {
 }
 
 export async function getProvisionedPackages(packageRef: string, chainId: number, tags: string[], storage: CannonStorage) {
-  const { name, version, preset, fullPackageRef } = new PackageReference(packageRef);
+  const { preset, fullPackageRef } = new PackageReference(packageRef);
 
   const uri = await storage.registry.getUrl(fullPackageRef, chainId);
 

--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -150,7 +150,7 @@ function _deployImports(deployInfo: DeploymentInfo) {
 }
 
 export async function getProvisionedPackages(packageRef: string, chainId: number, tags: string[], storage: CannonStorage) {
-  const { preset, fullPackageRef } = new PackageReference(packageRef);
+  const { name, version, preset, fullPackageRef } = new PackageReference(packageRef);
 
   const uri = await storage.registry.getUrl(fullPackageRef, chainId);
 

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -44,7 +44,7 @@ export async function publish({
   chainId,
   presetArg,
   quiet = false,
-  includeProvisioned = false,
+  includeProvisioned = true,
   skipConfirm = false,
 }: Params) {
   const { fullPackageRef } = new PackageReference(packageRef);
@@ -169,22 +169,26 @@ export async function publish({
           !curr.packagesNames.some((r) => {
             const { name } = new PackageReference(r);
             parentPackages.some((p) => name === p.name);
-          })
+          }) && !curr.packagesNames.includes(fullPackageRef)
         ) {
           acc.push(curr);
         }
         return acc;
       }, []);
 
+      if (subPackages.length == 0) {
+        console.log(yellow(`\nNo cloned/provisioned packages found, publishing parent packages only...`));
+      }
+
       parentPackages.forEach((deploy) => {
-        console.log(blueBright(`This will publish ${bold(deploy.name)} to the registry:`));
+        console.log(blueBright(`\nThis will publish ${bold(deploy.name)} to the registry:`));
         deploy.versions.concat(tags).map((version) => {
           console.log(` - ${version} (preset: ${deploy.preset})`);
         });
       });
       console.log('\n');
 
-      subPackages!.forEach((pkg: SubPackage, index) => {
+      subPackages.forEach((pkg: SubPackage, index) => {
         console.log(
           blueBright(
             `This will publish ${bold(new PackageReference(pkg.packagesNames[index]).name)} ${bold(
@@ -196,8 +200,8 @@ export async function publish({
           const { version, preset } = new PackageReference(pkgName);
           console.log(` - ${version} (preset: ${preset})`);
         });
+        console.log('\n')
       });
-      console.log('\n');
     } else {
       parentPackages.forEach((deploy) => {
         console.log(blueBright(`This will publish ${bold(deploy.name)}@${deploy.preset} to the registry:`));

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -44,7 +44,7 @@ export async function publish({
   chainId,
   presetArg,
   quiet = false,
-  includeProvisioned = true,
+  includeProvisioned = false,
   skipConfirm = false,
 }: Params) {
   const { fullPackageRef } = new PackageReference(packageRef);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -169,7 +169,8 @@ export async function publish({
           !curr.packagesNames.some((r) => {
             const { name } = new PackageReference(r);
             parentPackages.some((p) => name === p.name);
-          }) && !curr.packagesNames.includes(fullPackageRef)
+          }) &&
+          !curr.packagesNames.includes(fullPackageRef)
         ) {
           acc.push(curr);
         }
@@ -177,7 +178,7 @@ export async function publish({
       }, []);
 
       if (subPackages.length == 0) {
-        console.log(yellow(`\nNo cloned/provisioned packages found, publishing parent packages only...`));
+        console.log(yellow('\nNo cloned/provisioned packages found, publishing parent packages only...'));
       }
 
       parentPackages.forEach((deploy) => {
@@ -200,7 +201,7 @@ export async function publish({
           const { version, preset } = new PackageReference(pkgName);
           console.log(` - ${version} (preset: ${preset})`);
         });
-        console.log('\n')
+        console.log('\n');
       });
     } else {
       parentPackages.forEach((deploy) => {


### PR DESCRIPTION
This PR fixes an incorrect output on the publish command where it wouldnt correctly filter out the parent package from the provisioned packages list.

Before:
![image](https://github.com/usecannon/cannon/assets/30664234/b5f2fa40-ad4c-4f52-bbe8-39b152efd199)

After:
![image](https://github.com/usecannon/cannon/assets/30664234/4d04e7b7-67b2-40f7-badc-fae74d792e87)
