### PR TITLE
fix(website): function array outputs render

### DIFF
--- a/packages/website/src/features/Packages/DeploymentExplorer.tsx
+++ b/packages/website/src/features/Packages/DeploymentExplorer.tsx
@@ -159,6 +159,8 @@ export const DeploymentExplorer: FC<{
     URL.revokeObjectURL(url);
   };
 
+  const pkgDef = deploymentData?.data?.def;
+
   return pkg?.deployUrl ? (
     <Box>
       {deploymentData.isLoading ? (
@@ -205,8 +207,8 @@ export const DeploymentExplorer: FC<{
                 </Box>
                 <CommandPreview
                   command={`cannon ${pkg.name}${
-                    pkg?.tag !== 'latest' ? `:${pkg.tag}` : ''
-                  }${pkg.preset !== 'main' ? `@${pkg.preset}` : ''}`}
+                    pkg?.tag !== 'latest' ? `:${pkgDef.version}` : ''
+                  }${pkg.preset !== 'main' ? `@${pkgDef.preset}` : ''}`}
                 />
               </Box>
             </Container>

--- a/packages/website/src/features/Packages/FunctionOutput.tsx
+++ b/packages/website/src/features/Packages/FunctionOutput.tsx
@@ -36,7 +36,11 @@ export const FunctionOutput: FC<{
     </Box>
   );
 
-  const renderOutput = (item: AbiParameter, value: { [key: string]: any }) => {
+  const renderOutput = (
+    item: AbiParameter,
+    value: { [key: string]: any },
+    index?: number
+  ) => {
     if (item.type === 'tuple' && hasComponents(item) && value) {
       return (
         <Box pl="4">
@@ -82,11 +86,19 @@ export const FunctionOutput: FC<{
           </Text>
         );
       } else if (isArray(value)) {
-        return value.map((val, idx) => (
-          <Text fontSize="xs" display="block" key={idx}>
-            {String(val)}
-          </Text>
-        ));
+        if (index !== undefined) {
+          return (
+            <Text fontSize="xs" display="block">
+              {String(value[index])}
+            </Text>
+          );
+        } else {
+          return value.map((val, idx) => (
+            <Text fontSize="xs" display="block" key={idx}>
+              {index !== undefined ? String(val[index]) : String(val)}
+            </Text>
+          ));
+        }
       } else {
         return (
           <Flex
@@ -141,7 +153,7 @@ export const FunctionOutput: FC<{
         output.map((item, index) => (
           <Box overflowX={'scroll'} p={2} key={index}>
             <ItemLabel name={item.name || ''} type={item.internalType || ''} />
-            {renderOutput(item, result)}
+            {renderOutput(item, result, index)}
           </Box>
         ))
       ) : (

--- a/packages/website/src/features/Packages/FunctionOutput.tsx
+++ b/packages/website/src/features/Packages/FunctionOutput.tsx
@@ -95,7 +95,7 @@ export const FunctionOutput: FC<{
         } else {
           return value.map((val, idx) => (
             <Text fontSize="xs" display="block" key={idx}>
-              {index !== undefined ? String(val[index]) : String(val)}
+              {String(val)}
             </Text>
           ));
         }


### PR DESCRIPTION
Previously, function call outputs were duplicated, rendering the same values in each output field.

<img width="979" alt="image" src="https://github.com/usecannon/cannon/assets/3952453/c937c338-6f82-4f8c-b407-fff3bacfaccd">

- With the fix, the function call outputs are now being rendered as expected.

https://github.com/usecannon/cannon/assets/3952453/7d749a2e-45ac-46ad-8658-9bac96208231

- Functions which return tuples, or arrays of tuples (such as https://usecannon.com/packages/synthetix/latest/10-main/interact/synthetix/CoreProxy/0xffffffaEff0B96Ea8e4f94b2253f31abdD875847#selector-0x75bf2444 ) working as expected

https://github.com/usecannon/cannon/assets/3952453/ac48cc4a-4aea-42a1-b1c3-d450582b7321


