### PR TITLE
fix(website): run package command (version/preset)

### DIFF
--- a/packages/website/src/features/Packages/DeploymentExplorer.tsx
+++ b/packages/website/src/features/Packages/DeploymentExplorer.tsx
@@ -159,6 +159,8 @@ export const DeploymentExplorer: FC<{
     URL.revokeObjectURL(url);
   };
 
+  const pkgDef = deploymentData?.data?.def;
+
   return pkg?.deployUrl ? (
     <Box>
       {deploymentData.isLoading ? (
@@ -205,8 +207,8 @@ export const DeploymentExplorer: FC<{
                 </Box>
                 <CommandPreview
                   command={`cannon ${pkg.name}${
-                    pkg?.tag !== 'latest' ? `:${pkg.tag}` : ''
-                  }${pkg.preset !== 'main' ? `@${pkg.preset}` : ''}`}
+                    pkg?.tag !== 'latest' ? `:${pkgDef.version}` : ''
+                  }${pkg.preset !== 'main' ? `@${pkgDef.preset}` : ''}`}
                 />
               </Box>
             </Container>


### PR DESCRIPTION
This PR addresses an issue with the error in rendering the package version and preset in the run package command:

<img width="2042" alt="Screenshot 2024-05-12 at 6 46 45 PM" src="https://github.com/usecannon/cannon/assets/3952453/e8237090-156f-4c81-b650-f085d9c4c309">

With the implemented fix:

<img width="2048" alt="image" src="https://github.com/usecannon/cannon/assets/3952453/b79fc79d-ab16-4f9b-9f0e-8f77efbd8ef4">