### PR TITLE
fix(website): nonce selector

### DIFF
--- a/packages/website/src/features/Deploy/QueueDrawer.tsx
+++ b/packages/website/src/features/Deploy/QueueDrawer.tsx
@@ -1,20 +1,29 @@
 'use client';
 
-import React, { Suspense, useState } from 'react';
 import { links } from '@/constants/links';
+import WithSafe from '@/features/Deploy/WithSafe';
 import { makeMultisend } from '@/helpers/multisend';
 import { useQueueTxsStore, useStore } from '@/helpers/store';
 import { useTxnStager } from '@/hooks/backend';
 import { useCannonPackageContracts } from '@/hooks/cannon';
 import { useSimulatedTxns } from '@/hooks/fork';
 import { SafeTransaction } from '@/types/SafeTransaction';
+import { AddIcon, InfoOutlineIcon } from '@chakra-ui/icons';
 import {
-  IconButton,
   Box,
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
   FormControl,
   FormHelperText,
   FormLabel,
   HStack,
+  Icon,
+  IconButton,
   Input,
   InputGroup,
   InputRightElement,
@@ -22,17 +31,10 @@ import {
   Text,
   Tooltip,
   useToast,
-  Drawer,
-  DrawerOverlay,
-  DrawerContent,
-  DrawerCloseButton,
-  DrawerHeader,
-  DrawerBody,
-  Button,
-  Icon,
 } from '@chakra-ui/react';
-import { AddIcon, InfoOutlineIcon } from '@chakra-ui/icons';
+import { useConnectModal } from '@rainbow-me/rainbowkit';
 import { useRouter } from 'next/navigation';
+import React, { Suspense, useState } from 'react';
 import {
   AbiFunction,
   encodeAbiParameters,
@@ -41,14 +43,11 @@ import {
   TransactionRequestBase,
   zeroAddress,
 } from 'viem';
-import { useWriteContract } from 'wagmi';
+import { useAccount, useWriteContract } from 'wagmi';
 import NoncePicker from './NoncePicker';
 import { QueueTransaction } from './QueueTransaction';
-import 'react-diff-view/style/index.css';
 import { SafeAddressInput } from './SafeAddressInput';
-import WithSafe from '@/features/Deploy/WithSafe';
-import { useAccount } from 'wagmi';
-import { useConnectModal } from '@rainbow-me/rainbowkit';
+import 'react-diff-view/style/index.css';
 
 export const QueuedTxns = ({
   onDrawerClose,
@@ -360,6 +359,7 @@ export const QueuedTxns = ({
 
         {queuedIdentifiableTxns.length > 0 && (
           <Box>
+            <NoncePicker safe={currentSafe} handleChange={setPickedNonce} />
             <>
               {!account.isConnected ? (
                 <Button
@@ -372,10 +372,6 @@ export const QueuedTxns = ({
                 </Button>
               ) : (
                 <>
-                  <NoncePicker
-                    safe={currentSafe as any}
-                    onPickedNonce={setPickedNonce}
-                  />
                   <HStack gap="6">
                     {disableExecute ? (
                       <Tooltip label={stager.signConditionFailed}>

--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -53,11 +53,10 @@ import {
   zeroAddress,
 } from 'viem';
 import { useWriteContract } from 'wagmi';
+import pkg from '../../../package.json';
 import NoncePicker from './NoncePicker';
 import { TransactionDisplay } from './TransactionDisplay';
 import 'react-diff-view/style/index.css';
-
-import pkg from '../../../package.json';
 
 export default function QueueFromGitOpsPage() {
   return <QueueFromGitOps />;
@@ -582,10 +581,7 @@ function QueueFromGitOps() {
           )}
           {uploadToPublishIpfs.deployedIpfsHash && multicallTxn.data && (
             <Box>
-              <NoncePicker
-                safe={currentSafe as any}
-                onPickedNonce={setPickedNonce}
-              />
+              <NoncePicker safe={currentSafe} handleChange={setPickedNonce} />
               <HStack gap="6">
                 {stager.execConditionFailed ? (
                   <Tooltip label={stager.signConditionFailed}>

--- a/packages/website/src/features/Deploy/QueueTransaction.tsx
+++ b/packages/website/src/features/Deploy/QueueTransaction.tsx
@@ -1,19 +1,20 @@
 import { useStore } from '@/helpers/store';
+import { useCannonPackageContracts } from '@/hooks/cannon';
 import { useSimulatedTxns } from '@/hooks/fork';
+import { CloseIcon } from '@chakra-ui/icons';
 import {
   Alert,
   AlertDescription,
   AlertIcon,
   AlertTitle,
   Box,
-  IconButton,
   Flex,
   FormControl,
   FormLabel,
+  IconButton,
   Text,
   Tooltip,
 } from '@chakra-ui/react';
-import { CloseIcon } from '@chakra-ui/icons';
 import { AbiFunction } from 'abitype/src/abi';
 import {
   chakraComponents,
@@ -28,13 +29,12 @@ import {
   Address,
   decodeErrorResult,
   encodeFunctionData,
-  toFunctionSelector,
   Hex,
+  toFunctionSelector,
   TransactionRequestBase,
 } from 'viem';
 import { FunctionInput } from '../Packages/FunctionInput';
 import 'react-diff-view/style/index.css';
-import { useCannonPackageContracts } from '@/hooks/cannon';
 
 type OptionData = {
   value: any;
@@ -86,7 +86,7 @@ function decodeError(err: Hex, abi: Abi) {
       data: err,
     });
 
-    return `${parsedError.errorName}(${parsedError.args?.join(', ')})`;
+    return `${parsedError.errorName}(${parsedError.args?.join(', ') || ''})`;
   } catch (err) {
     // ignore
   }

--- a/packages/website/src/features/Deploy/SignTransactionsPage.tsx
+++ b/packages/website/src/features/Deploy/SignTransactionsPage.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useStore } from '@/helpers/store';
+import { useSafeTransactions } from '@/hooks/backend';
+import { useExecutedTransactions } from '@/hooks/safe';
 import {
   Box,
   Checkbox,
@@ -10,9 +12,7 @@ import {
   Link,
   Text,
 } from '@chakra-ui/react';
-import { useSafeTransactions } from '@/hooks/backend';
-import { useExecutedTransactions } from '@/hooks/safe';
-import { useStore } from '@/helpers/store';
+import { useState } from 'react';
 import { Transaction } from './Transaction';
 
 export default function SignTransactionsPage() {


### PR DESCRIPTION
A bug appeared where it was automatically setting the tx nonce to the current one, instead of the next one. This was fixed doing a refactor at [`src/hooks/backend.ts`](https://github.com/usecannon/cannon/blob/6ddf99ae185c2cb3a98d32f8918e195b0c458df3/packages/website/src/hooks/backend.ts#L19-L77) to make it calculate the nonce after the data was fetch.

This is how it is looking right now, by default sets the nonce as `lastNonce + 1`, and if you check the nonce override, will set the selector with `lastNonce`:
<img width="775" alt="Screenshot 2024-05-14 at 16 54 38" src="https://github.com/usecannon/cannon/assets/558901/649f5bce-bd43-4894-ab5e-3400b7b28b2c">
<img width="765" alt="Screenshot 2024-05-14 at 16 54 43" src="https://github.com/usecannon/cannon/assets/558901/b7db95f1-c53f-43cb-9cd2-f44de83b825d">


### Extra
Also, a minor bug was fixed when rendering errors with `undefined` arguments:
Before:
<img width="712" alt="Screenshot 2024-05-14 at 14 37 27" src="https://github.com/usecannon/cannon/assets/558901/2e9dd16b-c10a-41cb-9ad3-8f2021a6b32b">
After:
<img width="727" alt="Screenshot 2024-05-14 at 14 37 38" src="https://github.com/usecannon/cannon/assets/558901/9c3149b3-4183-4e1b-9633-009a9782cf12">

