### PR TITLE
fix(website): do not set nonce if no override

### DIFF
--- a/packages/website/src/features/Deploy/NoncePicker.tsx
+++ b/packages/website/src/features/Deploy/NoncePicker.tsx
@@ -24,12 +24,8 @@ export default function NoncePicker({ safe, handleChange }: Params) {
   const safeTxs = useSafeTransactions(safe);
 
   useEffect(() => {
-    if (isOverridingNonce) {
-      handleChange(currentNonce);
-    } else {
-      handleChange(null);
-    }
-  }, [currentNonce, isOverridingNonce]);
+    handleChange(currentNonce);
+  }, [currentNonce]);
 
   useEffect(() => {
     setCurrentNonce(safeTxs.nextNonce);
@@ -37,8 +33,7 @@ export default function NoncePicker({ safe, handleChange }: Params) {
 
   useEffect(() => {
     if (!safeTxs.nextNonce) return setCurrentNonce(null);
-    const nonce = isOverridingNonce ? safeTxs.nextNonce - 1 : safeTxs.nextNonce;
-    setCurrentNonce(nonce);
+    setCurrentNonce(isOverridingNonce ? safeTxs.nextNonce - 1 : null);
   }, [isOverridingNonce, safeTxs.nextNonce]);
 
   return (
@@ -53,11 +48,11 @@ export default function NoncePicker({ safe, handleChange }: Params) {
         </Checkbox>
         {isOverridingNonce && (
           <NumberInput
-            min={Number(safeTxs.nonce)}
-            value={currentNonce || 0}
+            min={Number(safeTxs.nonce) || 1}
+            value={currentNonce || 1}
             onChange={(n) => {
               const newVal = Number.parseInt(n);
-              if (!Number.isSafeInteger(newVal)) return;
+              if (!Number.isSafeInteger(newVal) || newVal < 1) return;
               setCurrentNonce(newVal);
             }}
           >

--- a/packages/website/src/features/Deploy/NoncePicker.tsx
+++ b/packages/website/src/features/Deploy/NoncePicker.tsx
@@ -28,10 +28,6 @@ export default function NoncePicker({ safe, handleChange }: Params) {
   }, [currentNonce]);
 
   useEffect(() => {
-    setCurrentNonce(safeTxs.nextNonce);
-  }, [safeTxs.nextNonce]);
-
-  useEffect(() => {
     if (!safeTxs.nextNonce) return setCurrentNonce(null);
     setCurrentNonce(isOverridingNonce ? safeTxs.nextNonce - 1 : null);
   }, [isOverridingNonce, safeTxs.nextNonce]);

--- a/packages/website/src/features/Deploy/NoncePicker.tsx
+++ b/packages/website/src/features/Deploy/NoncePicker.tsx
@@ -48,11 +48,11 @@ export default function NoncePicker({ safe, handleChange }: Params) {
         </Checkbox>
         {isOverridingNonce && (
           <NumberInput
-            min={Number(safeTxs.nonce) || 1}
-            value={currentNonce || 1}
+            min={Number(safeTxs.nonce) || 0}
+            value={currentNonce || 0}
             onChange={(n) => {
               const newVal = Number.parseInt(n);
-              if (!Number.isSafeInteger(newVal) || newVal < 1) return;
+              if (!Number.isSafeInteger(newVal) || newVal < 0) return;
               setCurrentNonce(newVal);
             }}
           >

--- a/packages/website/src/features/Deploy/NoncePicker.tsx
+++ b/packages/website/src/features/Deploy/NoncePicker.tsx
@@ -9,6 +9,7 @@ import {
   NumberInput,
   NumberInputField,
   NumberInputStepper,
+  Tooltip,
 } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 
@@ -23,6 +24,8 @@ export default function NoncePicker({ safe, handleChange }: Params) {
 
   const safeTxs = useSafeTransactions(safe);
 
+  console.log('safeTxs', safeTxs);
+
   useEffect(() => {
     handleChange(currentNonce);
   }, [currentNonce]);
@@ -35,13 +38,24 @@ export default function NoncePicker({ safe, handleChange }: Params) {
   return (
     <FormControl mb={4}>
       <HStack>
-        <Checkbox
-          disabled={!safeTxs.isSuccess}
-          isChecked={isOverridingNonce}
-          onChange={(e) => setNonceOverride(e.target.checked)}
+        <Tooltip
+          label={
+            safeTxs.staged.length === 0
+              ? 'To override nonce, you must have at least one transaction staged'
+              : ''
+          }
+          placement="top"
+          aria-label="Override Previously Staged Transaction"
+          shouldWrapChildren
         >
-          Override Previously Staged Transaction{' '}
-        </Checkbox>
+          <Checkbox
+            disabled={!safeTxs.isSuccess || safeTxs.staged.length === 0}
+            isChecked={isOverridingNonce}
+            onChange={(e) => setNonceOverride(e.target.checked)}
+          >
+            Override Previously Staged Transaction{' '}
+          </Checkbox>
+        </Tooltip>
         {isOverridingNonce && (
           <NumberInput
             min={Number(safeTxs.nonce) || 0}

--- a/packages/website/src/features/Deploy/NoncePicker.tsx
+++ b/packages/website/src/features/Deploy/NoncePicker.tsx
@@ -1,16 +1,6 @@
 import { SafeDefinition } from '@/helpers/store';
 import { useSafeTransactions } from '@/hooks/backend';
-import {
-  Checkbox,
-  FormControl,
-  HStack,
-  NumberDecrementStepper,
-  NumberIncrementStepper,
-  NumberInput,
-  NumberInputField,
-  NumberInputStepper,
-  Tooltip,
-} from '@chakra-ui/react';
+import { Checkbox, FormControl, Flex, Select, Tooltip } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 
 interface Params {
@@ -24,8 +14,6 @@ export default function NoncePicker({ safe, handleChange }: Params) {
 
   const safeTxs = useSafeTransactions(safe);
 
-  console.log('safeTxs', safeTxs);
-
   useEffect(() => {
     handleChange(currentNonce);
   }, [currentNonce]);
@@ -37,11 +25,17 @@ export default function NoncePicker({ safe, handleChange }: Params) {
 
   return (
     <FormControl mb={4}>
-      <HStack>
+      <Flex
+        justify="space-between"
+        align="center"
+        direction="row"
+        wrap="wrap"
+        gap={4}
+      >
         <Tooltip
           label={
             safeTxs.staged.length === 0
-              ? 'To override nonce, you must have at least one transaction staged'
+              ? 'You must have at least one transaction staged to override'
               : ''
           }
           placement="top"
@@ -57,23 +51,27 @@ export default function NoncePicker({ safe, handleChange }: Params) {
           </Checkbox>
         </Tooltip>
         {isOverridingNonce && (
-          <NumberInput
-            min={Number(safeTxs.nonce) || 0}
-            value={currentNonce || 0}
-            onChange={(n) => {
-              const newVal = Number.parseInt(n);
-              if (!Number.isSafeInteger(newVal) || newVal < 0) return;
-              setCurrentNonce(newVal);
-            }}
-          >
-            <NumberInputField />
-            <NumberInputStepper>
-              <NumberIncrementStepper />
-              <NumberDecrementStepper />
-            </NumberInputStepper>
-          </NumberInput>
+          <Flex direction="row" align="center" justify="space-between" grow={1}>
+            <Select
+              value={currentNonce ?? undefined}
+              onChange={(e) => {
+                const newVal = Number(e.target.value);
+                if (!Number.isSafeInteger(newVal) || newVal < 0) {
+                  setCurrentNonce(null);
+                } else {
+                  setCurrentNonce(newVal);
+                }
+              }}
+            >
+              {safeTxs.staged.map(({ txn }) => (
+                <option key={txn._nonce} value={txn._nonce}>
+                  {txn._nonce}
+                </option>
+              ))}
+            </Select>
+          </Flex>
         )}
-      </HStack>
+      </Flex>
     </FormControl>
   );
 }

--- a/packages/website/src/features/Deploy/NoncePicker.tsx
+++ b/packages/website/src/features/Deploy/NoncePicker.tsx
@@ -24,8 +24,12 @@ export default function NoncePicker({ safe, handleChange }: Params) {
   const safeTxs = useSafeTransactions(safe);
 
   useEffect(() => {
-    handleChange(currentNonce);
-  }, [currentNonce]);
+    if (isOverridingNonce) {
+      handleChange(currentNonce);
+    } else {
+      handleChange(null);
+    }
+  }, [currentNonce, isOverridingNonce]);
 
   useEffect(() => {
     setCurrentNonce(safeTxs.nextNonce);


### PR DESCRIPTION
## Disabled "override nonce" checkbox if there are no staged transactions

https://github.com/usecannon/cannon/assets/3952453/bcf4f686-30cb-4e76-bf10-65867e970e2c

## Just render available staged txns nonces when overriding a nonce

https://github.com/usecannon/cannon/assets/3952453/0656ffbd-bdea-43dd-8bc2-07dfa33bcdf8

## Other adjustments

This PR in order to fix the following error, the error is caused due to a `useEffect` that's setting the pickedNonce even if no override option is set to true

https://github.com/usecannon/cannon/assets/3952453/4f759ed5-74a6-414c-9f56-a2122226ceec

With the fix:

https://github.com/usecannon/cannon/assets/3952453/a0629b5f-f792-41ba-9d3b-8907c49e33ee



