### PR TITLE
fix(website): add packageName when enqueuing transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40247,6 +40247,111 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.1.tgz",
+      "integrity": "sha512-kGjnjcIJehEcd3rT/3NAATJQndAEELk0J9GmGMXHSC75TMnvpOhONcjNHbjtcWE5HUQnIHy5JVkatrnYm1QhVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.1.tgz",
+      "integrity": "sha512-dAdWndgdQi7BK2WSXrx4lae7mYcOYjbHJUhvOUnJjMNYrmYhxbbvJ2xElZpxNxdfA6zkqagIB9He2tQk+l16ew==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.1.tgz",
+      "integrity": "sha512-2ZctfnyFOGvTkoD6L+DtQtO3BfFz4CapoHnyLTXkOxbZkVRgg3TQBUjTD/xKrO1QWeydeo8AWfZRg8539qNKrg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.1.tgz",
+      "integrity": "sha512-jazZXctiaanemy4r+TPIpFP36t1mMwWCKMsmrTRVChRqE6putyAxZA4PDujx0SnfvZHosjdkx9xIq9BzBB5tWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.1.tgz",
+      "integrity": "sha512-YGHklaJ/Cj/F0Xd8jxgj2p8po4JTCi6H7Z3Yics3xJhm9CPIqtl8erlpK1CLv+HInDqEWfXilqatF8YsLxxA2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.1.tgz",
+      "integrity": "sha512-o+ISKOlvU/L43ZhtAAfCjwIfcwuZstiHVXq/BDsZwGqQE0h/81td95MPHliWCnFoikzWcYqh+hz54ZB2FIT8RA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.1.tgz",
+      "integrity": "sha512-GmRoTiLcvCLifujlisknv4zu9/C4i9r0ktsA8E51EMqJL4bD4CpO7lDYr7SrUxCR0tS4RVcrqKmCak24T0ohaw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/packages/website/src/features/Deploy/QueueDrawer.tsx
+++ b/packages/website/src/features/Deploy/QueueDrawer.tsx
@@ -222,7 +222,6 @@ export const QueuedTxns = ({
         {queuedIdentifiableTxns.length > 0
           ? queuedIdentifiableTxns.map((queuedIdentifiableTxn, i) => (
               <Box
-                overflow="hidden"
                 key={i}
                 mb={8}
                 p={0}

--- a/packages/website/src/features/Deploy/QueueDrawer.tsx
+++ b/packages/website/src/features/Deploy/QueueDrawer.tsx
@@ -222,9 +222,10 @@ export const QueuedTxns = ({
         {queuedIdentifiableTxns.length > 0
           ? queuedIdentifiableTxns.map((queuedIdentifiableTxn, i) => (
               <Box
+                overflow="hidden"
                 key={i}
                 mb={8}
-                p={6}
+                p={0}
                 bg="gray.800"
                 display="block"
                 borderWidth="1px"

--- a/packages/website/src/features/Deploy/QueueTransaction.tsx
+++ b/packages/website/src/features/Deploy/QueueTransaction.tsx
@@ -1,7 +1,7 @@
 import { useStore } from '@/helpers/store';
-import { useCannonPackageContracts } from '@/hooks/cannon';
+import { useCannonPackage, useCannonPackageContracts } from '@/hooks/cannon';
 import { useSimulatedTxns } from '@/hooks/fork';
-import { CloseIcon } from '@chakra-ui/icons';
+import { DeleteIcon } from '@chakra-ui/icons';
 import {
   Alert,
   AlertDescription,
@@ -10,14 +10,14 @@ import {
   Box,
   Flex,
   FormControl,
+  FormHelperText,
   FormLabel,
   IconButton,
-  Text,
-  Tooltip,
+  Input,
   InputGroup,
   InputRightAddon,
-  Input,
-  FormHelperText,
+  Text,
+  Tooltip,
 } from '@chakra-ui/react';
 import { AbiFunction } from 'abitype/src/abi';
 import {
@@ -33,11 +33,11 @@ import {
   Address,
   decodeErrorResult,
   encodeFunctionData,
+  formatEther,
   Hex,
+  parseEther,
   toFunctionSelector,
   TransactionRequestBase,
-  parseEther,
-  formatEther,
 } from 'viem';
 import { FunctionInput } from '../Packages/FunctionInput';
 import 'react-diff-view/style/index.css';
@@ -133,6 +133,7 @@ export function QueueTransaction({
   const [value, setValue] = useState<string | undefined>(
     tx?.value ? formatEther(BigInt(tx?.value)).toString() : undefined
   );
+  const pkg = useCannonPackage(target, chainId);
   const { contracts } = useCannonPackageContracts(target, chainId);
 
   const [selectedContractName, setSelectedContractName] = useState<
@@ -224,12 +225,43 @@ export function QueueTransaction({
 
   return (
     <Flex direction="column">
+      <Flex
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="space-between"
+        backgroundColor="gray.700"
+        p={3}
+        pl={6}
+        pr={6}
+      >
+        <Text fontWeight={600} fontSize="sm" color="gray.300">
+          {pkg.fullPackageRef}
+        </Text>
+        {isDeletable && (
+          <Tooltip label="Remove transaction">
+            <IconButton
+              variant="outline"
+              border="none"
+              _hover={{ bg: 'gray.700' }}
+              size="xs"
+              colorScheme="red"
+              color="gray.300"
+              onClick={onDelete}
+              aria-label="Remove transaction"
+              icon={<DeleteIcon />}
+            />
+          </Tooltip>
+        )}
+      </Flex>
       <Flex alignItems="center">
         <Flex
           flexDirection="column"
           flex="1"
           w={['100%', '100%', '50%']}
           gap="10px"
+          p={6}
+          pt={4}
+          pb={4}
         >
           <FormControl mb={2}>
             <FormLabel>Contract</FormLabel>
@@ -415,24 +447,6 @@ export function QueueTransaction({
                 </Box>
               </Alert>
             )}
-          {isDeletable && (
-            <Tooltip label="Remove transaction">
-              <IconButton
-                position="absolute"
-                top={3}
-                right={3}
-                variant="outline"
-                border="none"
-                _hover={{ bg: 'gray.700' }}
-                size="xs"
-                colorScheme="red"
-                color="red.400"
-                onClick={onDelete}
-                aria-label="Remove transaction"
-                icon={<CloseIcon />}
-              />
-            </Tooltip>
-          )}
         </Flex>
       </Flex>
     </Flex>

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -1,18 +1,12 @@
-import _ from 'lodash';
-import { useChainId } from 'wagmi';
-import { useEffect, useState } from 'react';
-import { BaseTransaction } from '@safe-global/safe-apps-sdk';
-import { useMutation, UseMutationOptions, useQuery } from '@tanstack/react-query';
-import { Abi, Address, createPublicClient, createWalletClient, custom, isAddressEqual, PublicClient } from 'viem';
-
-import { useGitRepo } from '@/hooks/git';
+import { inMemoryLoader, loadCannonfile, StepExecutionError } from '@/helpers/cannon';
 import { IPFSBrowserLoader } from '@/helpers/ipfs';
-import { useLogs } from '@/providers/logsProvider';
-import { useCannonRegistry } from '@/hooks/registry';
 import { createFork, findChain } from '@/helpers/rpc';
 import { SafeDefinition, useStore } from '@/helpers/store';
-import { inMemoryLoader, loadCannonfile, StepExecutionError } from '@/helpers/cannon';
-
+import { useGitRepo } from '@/hooks/git';
+import { useCannonRegistry } from '@/hooks/registry';
+import { useLogs } from '@/providers/logsProvider';
+import { BaseTransaction } from '@safe-global/safe-apps-sdk';
+import { useMutation, UseMutationOptions, useQuery } from '@tanstack/react-query';
 import {
   build as cannonBuild,
   CannonStorage,
@@ -26,8 +20,13 @@ import {
   Events,
   getOutputs,
   InMemoryRegistry,
+  PackageReference,
   publishPackage,
 } from '@usecannon/builder';
+import _ from 'lodash';
+import { useEffect, useState } from 'react';
+import { Abi, Address, createPublicClient, createWalletClient, custom, isAddressEqual, PublicClient } from 'viem';
+import { useChainId } from 'wagmi';
 
 export type BuildState =
   | {
@@ -353,10 +352,11 @@ export function useCannonPackage(packageRef: string, chainId?: number) {
         const resolvedName = def.getName(ctx);
         const resolvedVersion = def.getVersion(ctx);
         const resolvedPreset = def.getPreset(ctx);
+        const { fullPackageRef } = PackageReference.from(resolvedName, resolvedVersion, resolvedPreset);
 
         if (deployInfo) {
           addLog(`Loaded ${resolvedName}:${resolvedVersion}@${resolvedPreset} from IPFS`);
-          return { deployInfo, ctx, resolvedName, resolvedVersion, resolvedPreset };
+          return { deployInfo, ctx, resolvedName, resolvedVersion, resolvedPreset, fullPackageRef };
         } else {
           throw new Error('failed to download package data');
         }
@@ -380,6 +380,7 @@ export function useCannonPackage(packageRef: string, chainId?: number) {
     resolvedName: ipfsQuery.data?.resolvedName,
     resolvedVersion: ipfsQuery.data?.resolvedVersion,
     resolvedPreset: ipfsQuery.data?.resolvedPreset,
+    fullPackageRef: ipfsQuery.data?.fullPackageRef,
   };
 }
 


### PR DESCRIPTION
This PR proposed a new title for each enqueued TX, to show the package name.

This is specially useful when coming back from a previously saved state, if I don't remember from which package was created the TX, now it can be checked. 

(also updates the X icon for a 🗑️ )

Before:
<img width="759" alt="Screenshot 2024-05-16 at 20 36 06" src="https://github.com/usecannon/cannon/assets/558901/6325d29c-433b-4003-bb93-0fb573c90f72">

After:
<img width="758" alt="Screenshot 2024-05-16 at 20 36 21" src="https://github.com/usecannon/cannon/assets/558901/9a87ed66-7f66-4daf-8f95-1cb0e43ba15a">
