### PR TITLE
fix(builder): extraneous publishes when they are not needed

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -136,7 +136,7 @@ ${printChainDefinitionProblems(problems)}`);
             const newStates = await def.getState(n, runtime, ctx, depsTainted);
             state[n] = {
               artifacts: newArtifacts,
-              hash: newStates ? newStates[0] : null,
+              hash: newStates && newStates.length ? newStates[0] : null,
               version: BUILD_VERSION,
             };
             tainted.add(n);
@@ -298,7 +298,7 @@ export async function buildLayer(
       const newHashes = await def.getState(action, runtime, ctx, false);
       state[action] = {
         artifacts: newArtifacts,
-        hash: newHashes ? newHashes[0] : null,
+        hash: newHashes && newHashes.length ? newHashes[0] : null,
         version: BUILD_VERSION,
         // add the chain dump later once all steps have been executed
       };

--- a/packages/builder/src/package.test.ts
+++ b/packages/builder/src/package.test.ts
@@ -80,7 +80,7 @@ describe('package.ts', () => {
       options: {},
     };
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       toRegistry = new InMemoryRegistry();
       toLoader = new IPFSLoader('world');
       toStorage = new CannonStorage(toRegistry, { https: toLoader }, 'https');

--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -5,7 +5,7 @@ import { ChainDefinition } from './definition';
 import { CannonStorage } from './runtime';
 import { BundledOutput, ChainArtifacts, DeploymentInfo, StepState } from './types';
 
-const debug = Debug('cannon:cli:publish');
+const debug = Debug('cannon:builder:package');
 
 interface PartialRefValues {
   name: string;
@@ -122,7 +122,7 @@ export async function forPackageTree<T extends { url?: string; artifacts?: Chain
     const nestedDeployInfo = await store.readBlob(importArtifact.url);
     const result = await forPackageTree(store, nestedDeployInfo, action, importArtifact, onlyResultProvisioned);
 
-    const newUrl = _.last(result)!.url;
+    const newUrl = _.last(result)?.url;
     if (newUrl && newUrl !== importArtifact.url) {
       importArtifact.url = newUrl!;
       const updatedNestedDeployInfo = await store.readBlob(newUrl);
@@ -219,11 +219,30 @@ export async function publishPackage({
       return alreadyCopiedIpfs.get(checkKey);
     }
 
+    const def = new ChainDefinition(deployInfo.def);
+
+    const preCtx = await createInitialContext(def, deployInfo.meta, deployInfo.chainId!, deployInfo.options);
+
+    const curFullPackageRef = `${def.getName(preCtx)}:${def.getVersion(preCtx)}@${
+      context && context.preset ? context.preset : presetRef
+    }`;
+
+    // if the package has already been published to the registry and it has the same ipfs hash, skip.
+    const oldUrl = await toStorage.registry.getUrl(curFullPackageRef, chainId);
+    const newUrl = await fromStorage.registry.getUrl(curFullPackageRef, chainId);
+    if (oldUrl === newUrl) {
+      debug('package already published... skip!', curFullPackageRef);
+      alreadyCopiedIpfs.set(checkKey, null);
+      return null;
+    }
+
+    debug('copy ipfs for', curFullPackageRef, oldUrl, newUrl);
+
     const newMiscUrl = await toStorage.putBlob(await fromStorage.readBlob(deployInfo!.miscUrl));
 
     // TODO: This metaUrl block is being called on each loop, but it always uses the same parameters.
     //       Should it be called outside the scoped copyIpfs() function?
-    const metaUrl = await fromStorage.registry.getMetaUrl(fullPackageRef, chainId);
+    const metaUrl = await fromStorage.registry.getMetaUrl(curFullPackageRef, chainId);
     let newMetaUrl = metaUrl;
 
     if (metaUrl) {
@@ -241,10 +260,6 @@ export async function publishPackage({
     if (!url) {
       throw new Error('uploaded url is invalid');
     }
-
-    const def = new ChainDefinition(deployInfo.def);
-
-    const preCtx = await createInitialContext(def, deployInfo.meta, deployInfo.chainId!, deployInfo.options);
 
     const returnVal = {
       packagesNames: _.uniq([def.getVersion(preCtx) || 'latest', ...(context && context.tags ? context.tags : tags)]).map(
@@ -269,7 +284,7 @@ export async function publishPackage({
   }
 
   // We call this regardless of includeProvisioned because we want to ALWAYS upload the subpackages ipfs data.
-  const calls = await forPackageTree(fromStorage, deployData, copyIpfs);
+  const calls = (await forPackageTree(fromStorage, deployData, copyIpfs)).filter((v: any) => v !== null);
 
   if (includeProvisioned) {
     debug('publishing with provisioned');

--- a/packages/cli/src/commands/publish.test.ts
+++ b/packages/cli/src/commands/publish.test.ts
@@ -1,13 +1,12 @@
 import {
-  CannonSigner,
   CannonStorage,
   DeploymentInfo,
   IPFSLoader,
   OnChainRegistry,
+  InMemoryRegistry,
   publishPackage,
 } from '@usecannon/builder';
 import * as viem from 'viem';
-import { privateKeyToAccount } from 'viem/accounts';
 import fs from 'fs-extra';
 import _ from 'lodash';
 import path from 'path';
@@ -24,9 +23,7 @@ describe('publish command', () => {
   const fullPackageRef = `package:1.2.3@${preset}`;
   const basePackageRef = 'package:1.2.3';
   const otherPreset = 'other';
-  let signer: CannonSigner;
-  let provider: viem.PublicClient;
-  let onChainRegistry: OnChainRegistry;
+  let onChainRegistry: InMemoryRegistry;
   const deployDataLocalFileName = `${basePackageRef.replace(':', '_')}_${chainId}-${preset}.txt`;
   const deployDataLocalFileNameLatest = `package_latest_${chainId}-${preset}.txt`;
   const miscData = { misc: 'info' };
@@ -71,9 +68,7 @@ describe('publish command', () => {
       })
     );
 
-    const privateKey = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
-    signer = { address: privateKeyToAccount(privateKey).address, wallet: {} as any };
-    onChainRegistry = new OnChainRegistry({ signer, provider, address: '0x' });
+    onChainRegistry = new InMemoryRegistry();
   });
 
   beforeEach(() => {
@@ -154,13 +149,8 @@ describe('publish command', () => {
       skipConfirm: true,
     });
 
-    expect(OnChainRegistry.prototype.publish as jest.Mock).toHaveBeenCalledTimes(1);
-    expect(OnChainRegistry.prototype.publish as jest.Mock).toHaveBeenCalledWith(
-      [fullPackageRef, ...tags.map((tag) => `package:${tag}@${preset}`)],
-      chainId,
-      testPkgDataNewIpfsUrl,
-      testPkgNewMetaIpfsUrl
-    );
+    expect(await onChainRegistry.getUrl(fullPackageRef, chainId)).toEqual(testPkgDataNewIpfsUrl);
+    expect(await onChainRegistry.getUrl(`package:tag0@${preset}`, chainId)).toEqual(testPkgDataNewIpfsUrl);
   });
 
   it('should publish the package to the registry with no tags', async () => {
@@ -176,10 +166,7 @@ describe('publish command', () => {
       includeProvisioned: true,
     });
 
-    expect(OnChainRegistry.prototype.publishMany as jest.Mock).toHaveBeenCalledTimes(1);
-    // the first call to publishMany first argument has a property packagesNames which is an array of strings
-    // the first element is the package name and the rest are the tags
-    expect((OnChainRegistry.prototype.publishMany as jest.Mock).mock.calls[0][0][0].packagesNames).toEqual([fullPackageRef]);
+    expect(await onChainRegistry.getUrl(fullPackageRef, chainId)).toEqual(testPkgDataNewIpfsUrl);
   });
 
   describe('scanDeploys', () => {


### PR DESCRIPTION
prevent unnecessary payment of fees, speed up ipfs uploads, and reduce ipfs waste by removing duplication