### PR TITLE
fix: variant splitting

### DIFF
--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -91,6 +91,16 @@ export class PackageReference {
     return new PackageReference(`${name}:${version}@${preset}`);
   }
 
+  /**
+   * Parse variant string into chainId and preset
+   * @param variant string
+   * @returns chainId and preset
+   */
+  static parseVariant(variant: string): [number, string] {
+    const [chainId, preset] = variant.split(/-(.*)/s);
+    return [Number(chainId), preset];
+  }
+
   constructor(ref: string) {
     const parsed = PackageReference.parse(ref);
     const { name, version = PackageReference.DEFAULT_TAG, preset = PackageReference.DEFAULT_PRESET } = parsed;

--- a/packages/builder/src/util.ts
+++ b/packages/builder/src/util.ts
@@ -173,13 +173,3 @@ export function encodeDeployData(...args: Parameters<typeof viem.encodeDeployDat
   const data = viem.encodeDeployData(...args);
   return data.startsWith('0x') ? data : (`0x${data}` as viem.Hex);
 }
-
-/**
- * Parse variant string into chainId and preset
- * @param variant string
- * @returns chainId and preset
- */
-export function parseVariant(variant: string): [number, string] {
-  const [chainId, preset] = variant.split(/-(.*)/s);
-  return [Number(chainId), preset];
-}

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -9,7 +9,6 @@ import * as viem from 'viem';
 import { CliSettings } from './settings';
 import { isConnectedToInternet } from './util/is-connected-to-internet';
 import { resolveRegistryProviders } from './util/provider';
-import { parseVariant } from '@usecannon/builder';
 
 const debug = Debug('cannon:cli:registry');
 
@@ -103,7 +102,7 @@ export class LocalRegistry extends CannonRegistry {
           debug(`checking ${packageRef}, ${chainId} for a match with ${t}`);
 
           const [tagName, tagVersion, tagVariant] = t.replace('.txt', '').split('_');
-          const [tagChainId, tagPreset] = parseVariant(tagVariant);
+          const [tagChainId, tagPreset] = PackageReference.parseVariant(tagVariant);
 
           if (chainId && tagChainId !== chainId) return false;
 
@@ -125,7 +124,7 @@ export class LocalRegistry extends CannonRegistry {
       })
       .map((t) => {
         const [name, version, tagVariant] = t.replace('.txt', '').split('_');
-        const [chainId, preset] = parseVariant(tagVariant);
+        const [chainId, preset] = PackageReference.parseVariant(tagVariant);
         return { name: `${name}:${version}@${preset}`, chainId };
       });
   }

--- a/packages/indexer/src/registry.ts
+++ b/packages/indexer/src/registry.ts
@@ -9,7 +9,6 @@ import {
   OnChainRegistry,
   PackageReference,
   StepState,
-  parseVariant,
 } from '@usecannon/builder';
 import { createClient, RedisClientType, SchemaFieldTypes } from 'redis';
 /* eslint no-console: "off" */
@@ -454,7 +453,7 @@ export async function scanChain(mainnetClient: viem.PublicClient, optimismClient
       for (const event of _.sortBy(usableEvents, 'timestamp') as any[]) {
         try {
           const variant = viem.hexToString(event.args.variant || '0x', { size: 32 });
-          const [chainId, preset] = parseVariant(variant);
+          const [chainId, preset] = PackageReference.parseVariant(variant);
 
           const packageRef = `${viem.hexToString(event.args.name, { size: 32 })}:${viem.hexToString(event.args.tag || '0x', {
             size: 32,

--- a/packages/website/src/app/packages/[name]/[tag]/[variant]/page.tsx
+++ b/packages/website/src/app/packages/[name]/[tag]/[variant]/page.tsx
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic';
 import chains from '@/helpers/chains';
 import { find } from 'lodash';
 import { ChainData } from '@/features/Search/PackageCard/Chain';
-import { parseVariant } from '@usecannon/builder/src';
+import { PackageReference } from '@usecannon/builder/src';
 
 const NoSSR = dynamic(
   async () => {
@@ -19,7 +19,7 @@ export async function generateMetadata({
 }: {
   params: { name: string; tag: string; variant: string };
 }) {
-  const [chainId, preset] = parseVariant(params.variant);
+  const [chainId, preset] = PackageReference.parseVariant(params.variant);
   const chain: { name: string; id: number } =
     Number(chainId) == 13370
       ? { id: 13370, name: 'Cannon' }

--- a/packages/website/src/features/Packages/CodePage.tsx
+++ b/packages/website/src/features/Packages/CodePage.tsx
@@ -8,7 +8,7 @@ import { Address } from 'viem';
 import { useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { getPackage } from '@/helpers/api';
-import { parseVariant } from '@usecannon/builder/src';
+import { PackageReference } from '@usecannon/builder/src';
 
 export const CodePage: FC<{
   name: string;
@@ -17,7 +17,7 @@ export const CodePage: FC<{
   moduleName?: string;
   contractAddress?: Address;
 }> = ({ name, tag, variant, moduleName }) => {
-  const [chainId, preset] = parseVariant(variant);
+  const [chainId, preset] = PackageReference.parseVariant(variant);
 
   const packagesQuery = useQuery({
     queryKey: ['package', [`${name}:${tag}@${preset}/${chainId}`]],

--- a/packages/website/src/features/Packages/Interact.tsx
+++ b/packages/website/src/features/Packages/Interact.tsx
@@ -16,7 +16,7 @@ import {
 import {
   ChainArtifacts,
   ContractData,
-  parseVariant,
+  PackageReference,
 } from '@usecannon/builder/src';
 import { FC, useContext, useEffect, useState } from 'react';
 import { Address } from 'viem';
@@ -35,7 +35,7 @@ export const Interact: FC<{
 }> = ({ name, tag, variant, moduleName, contractName, contractAddress }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
-  const [chainId, preset] = parseVariant(variant);
+  const [chainId, preset] = PackageReference.parseVariant(variant);
 
   const packagesQuery = useQuery({
     queryKey: ['package', [`${name}:${tag}@${preset}/${chainId}`]],

--- a/packages/website/src/features/Packages/Tabs/CannonfileTab.tsx
+++ b/packages/website/src/features/Packages/Tabs/CannonfileTab.tsx
@@ -6,14 +6,14 @@ import { CannonfileExplorer } from '@/features/Packages/CannonfileExplorer';
 import { CustomSpinner } from '@/components/CustomSpinner';
 import { useQuery } from '@tanstack/react-query';
 import { getPackage } from '@/helpers/api';
-import { parseVariant } from '@usecannon/builder/src';
+import { PackageReference } from '@usecannon/builder/src';
 
 export const CannonfileTab: FC<{
   name: string;
   tag: string;
   variant: string;
 }> = ({ name, tag, variant }) => {
-  const [chainId, preset] = parseVariant(variant);
+  const [chainId, preset] = PackageReference.parseVariant(variant);
 
   const packagesQuery = useQuery({
     queryKey: ['package', [`${name}:${tag}@${preset}/${chainId}`]],

--- a/packages/website/src/features/Packages/Tabs/InteractTab.tsx
+++ b/packages/website/src/features/Packages/Tabs/InteractTab.tsx
@@ -21,7 +21,7 @@ import { getOutput } from '@/lib/builder';
 import { usePathname, useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { getPackage } from '@/helpers/api';
-import { parseVariant } from '@usecannon/builder/src';
+import { PackageReference } from '@usecannon/builder/src';
 
 type Option = {
   moduleName: string;
@@ -37,7 +37,7 @@ export const InteractTab: FC<{
   variant: string;
   children?: ReactNode;
 }> = ({ name, tag, variant, children }) => {
-  const [chainId, preset] = parseVariant(variant);
+  const [chainId, preset] = PackageReference.parseVariant(variant);
 
   const packagesQuery = useQuery({
     queryKey: ['package', [`${name}:${tag}@${preset}/${chainId}`]],


### PR DESCRIPTION
This PR addresses an issue where we're parsing the variant incorrectly, and presets with more than one dash (`-`) were truncated.