### PR TITLE
fix(api): gentler parsing of redis results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41882,6 +41882,7 @@
         "@usecannon/builder": "^2.14.2",
         "@usecannon/cli": "^2.14.2",
         "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
         "envalid": "^8.0.0",
         "express": "5.0.0-beta.3",
         "express-basic-auth": "^1.2.1",
@@ -41987,6 +41988,17 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "packages/api/node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "packages/api/node_modules/express": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,6 +17,7 @@
     "@usecannon/builder": "^2.14.2",
     "@usecannon/cli": "^2.14.2",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
     "envalid": "^8.0.0",
     "express": "5.0.0-beta.3",
     "express-basic-auth": "^1.2.1",

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -1,4 +1,5 @@
 import { cleanEnv, EnvError, makeValidator, str } from 'envalid';
+import 'dotenv/config';
 
 const int = makeValidator<number>((input: string) => {
   const coerced = Number.parseInt(input, 10);

--- a/packages/api/src/helpers.ts
+++ b/packages/api/src/helpers.ts
@@ -1,6 +1,6 @@
 import * as viem from 'viem';
 import { BadRequestError, ServerError } from './errors';
-import { RedisPackage, RedisTag } from './types';
+import { ApiDocumentType, RedisPackage, RedisTag } from './types';
 
 const packageNameRegex = /^[a-z0-9][A-Za-z0-9-]{1,29}[a-z0-9]$/;
 export function isPackageName(packageName: any) {
@@ -54,7 +54,7 @@ export function parseChainIds(chainIds: any): number[] {
 export function parseTextQuery(query: any): string {
   if (!query) return '';
 
-  if (typeof query !== 'string' || query.length > 256) {
+  if (typeof query !== 'string' || query.length > 2048) {
     throw new BadRequestError('Invalid query parameter');
   }
 
@@ -64,8 +64,22 @@ export function parseTextQuery(query: any): string {
       .toLowerCase()
       .replace(/\s+/g, '-')
       // only leave valid characters and remove starting or ending '-'s
-      .replace(/^[-]+|[^a-z0-9-]|[-]+$/g, '')
+      .replace(/^[-_]+|[^a-z0-9-_]|[-_]+$/g, '') || ''
   );
+}
+
+export function parseQueryTypes(type: any): ApiDocumentType[] {
+  if (!type) return [];
+
+  if (typeof type !== 'string' || type.length > 512) {
+    throw new BadRequestError('Invalid type parameter');
+  }
+
+  return type
+    .trim()
+    .toLowerCase()
+    .replace(/^[^a-z]+|[^a-z,]+|[^a-z]+$/g, '')
+    .split(',') as ApiDocumentType[];
 }
 
 export function parseAddresses(addresses: any) {

--- a/packages/api/src/queries/contracts.ts
+++ b/packages/api/src/queries/contracts.ts
@@ -2,13 +2,27 @@ import { PackageReference } from '@usecannon/builder';
 import { AggregateGroupByReducers, AggregateSteps } from 'redis';
 import * as viem from 'viem';
 import * as keys from '../db/keys';
+import { isChainId, isContractName } from '../helpers';
 import { useRedis } from '../redis';
 import { ApiContract } from '../types';
 
-async function _queryContracts(params: { query: string; limit?: number }) {
+type ContractQueryResult = { contractName: string; package: string; chainId: string; address: string };
+
+function _parseAggregateResult(doc: ContractQueryResult) {
+  if (!doc) return;
+  if (!isContractName(doc.contractName)) return;
+  if (!PackageReference.isValid(doc.package)) return;
+  if (!isChainId(doc.chainId)) return;
+  if (!viem.isAddress(doc.address)) return;
+  return doc;
+}
+
+async function _aggregateContracts(query: string): Promise<ContractQueryResult[]> {
   const redis = await useRedis();
 
-  const results = (await redis.ft.aggregate(keys.RKEY_ABI_SEARCHABLE, params.query, {
+  const data: ContractQueryResult[] = [];
+
+  const res = (await redis.ft.aggregate(keys.RKEY_ABI_SEARCHABLE, query, {
     LOAD: { identifier: '@package' },
     STEPS: [
       {
@@ -22,10 +36,32 @@ async function _queryContracts(params: { query: string; limit?: number }) {
     ],
   })) as {
     total: number;
-    results: { contractName: string; package: string; chainId: string; address: string }[];
+    results: ContractQueryResult[];
   };
 
-  const data: ApiContract[] = results.results.map((doc) => {
+  for (const doc of res.results) {
+    const parsed = _parseAggregateResult(doc);
+
+    if (!parsed) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        new Error(
+          `Could not parse "${doc && JSON.stringify(doc)}" on query "FT.AGGREGATE ${keys.RKEY_ABI_SEARCHABLE} ${query}"`
+        )
+      );
+      continue;
+    }
+
+    data.push(parsed);
+  }
+
+  return data;
+}
+
+async function _queryContracts(params: { query: string; limit?: number }) {
+  const results = await _aggregateContracts(params.query);
+
+  const data = results.map((doc) => {
     const ref = new PackageReference(doc.package);
     return {
       type: 'contract',

--- a/packages/api/src/queries/packages.ts
+++ b/packages/api/src/queries/packages.ts
@@ -65,7 +65,7 @@ async function _queryPackages(params: { query: string; limit?: number; includeNa
 
       if (!pkg) {
         // eslint-disable-next-line no-console
-        console.error(new Error(`Package not found for tag "${JSON.stringify(item)}"`));
+        console.warn(new Error(`Package not found for tag "${JSON.stringify(item)}"`));
         continue;
       }
 

--- a/packages/api/src/routes/search.ts
+++ b/packages/api/src/routes/search.ts
@@ -13,7 +13,7 @@ import {
 import { findContractsByAddress, searchContracts } from '../queries/contracts';
 import { findFunctionsBySelector, searchFunctions } from '../queries/functions';
 import { findPackagesByPartialRef, searchPackages } from '../queries/packages';
-import { ApiDocument, ApiDocumentType } from '../types';
+import { ApiDocument } from '../types';
 
 const search = express.Router();
 

--- a/packages/api/src/routes/search.ts
+++ b/packages/api/src/routes/search.ts
@@ -2,7 +2,14 @@ import express from 'express';
 import Fuse from 'fuse.js';
 import * as viem from 'viem';
 import { BadRequestError } from '../errors';
-import { isContractName, isFunctionSelector, isPartialPackageRef, parseChainIds } from '../helpers';
+import {
+  isContractName,
+  isFunctionSelector,
+  isPartialPackageRef,
+  parseChainIds,
+  parseQueryTypes,
+  parseTextQuery,
+} from '../helpers';
 import { findContractsByAddress, searchContracts } from '../queries/contracts';
 import { findFunctionsBySelector, searchFunctions } from '../queries/functions';
 import { findPackagesByPartialRef, searchPackages } from '../queries/packages';
@@ -35,8 +42,8 @@ search.get('/search', async (req, res) => {
     throw new BadRequestError('Invalid "query" param');
   }
 
-  const { query = '' } = req.query;
-  const types = (typeof req.query.types === 'string' ? req.query.types.split(',') : []) as ApiDocumentType[];
+  const query = parseTextQuery(req.query.query);
+  const types = parseQueryTypes(req.query.types);
 
   const response = {
     status: 200,

--- a/packages/website/.env.local.example
+++ b/packages/website/.env.local.example
@@ -1,2 +1,3 @@
 # More info https://www.rainbowkit.com/docs/installation#configure
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
+API_URL=https://api.usecannon.com

--- a/packages/website/src/helpers/api.ts
+++ b/packages/website/src/helpers/api.ts
@@ -1,9 +1,12 @@
 import axios from 'axios';
 
+const baseURL = process.env.NEXT_PUBLIC_API_URL || 'https://api.usecannon.com';
+
 export const getSearch = async ({ queryKey }: { queryKey: any[] }) => {
   const [, searchTerm] = queryKey;
   try {
-    const response = await axios.get('https://api.usecannon.com/search', {
+    const response = await axios.get('search', {
+      baseURL,
       params: {
         query: searchTerm,
       },
@@ -17,7 +20,8 @@ export const getSearch = async ({ queryKey }: { queryKey: any[] }) => {
 export const getPackages = async ({ queryKey }: { queryKey: any[] }) => {
   const [, searchTerm, selectedChains, types] = queryKey;
   try {
-    const response = await axios.get('https://api.usecannon.com/search', {
+    const response = await axios.get('search', {
+      baseURL,
       params: {
         query: searchTerm,
         chainIds: selectedChains.length > 0 ? selectedChains.join(',') : undefined,
@@ -32,7 +36,7 @@ export const getPackages = async ({ queryKey }: { queryKey: any[] }) => {
 
 export const getChains = async () => {
   try {
-    const response = await axios.get('https://api.usecannon.com/chains');
+    const response = await axios.get('chains', { baseURL });
     return response.data;
   } catch (error) {
     throw new Error('Failed to fetch chains', error as Error);
@@ -42,7 +46,7 @@ export const getChains = async () => {
 export const getPackage = async ({ queryKey }: { queryKey: any[] }) => {
   const [, name] = queryKey;
   try {
-    const response = await axios.get('https://api.usecannon.com/packages/' + name);
+    const response = await axios.get(`packages/${name}`, { baseURL });
     return response.data;
   } catch (error) {
     throw new Error('Failed to fetch package', error as Error);


### PR DESCRIPTION
This PR makes sure that the API does not return a `500` in case it cannot parse a result from the database. It just ignores the result and `console.warn` it so it could be potentially parsed in the future.

As an extra, adds the possibility to set a custom API endpoint, mostly for dev/test purposes.