### PR TITLE
fix(website): previous package input behavior

### DIFF
--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -56,14 +56,13 @@ import { useWriteContract } from 'wagmi';
 import pkg from '../../../package.json';
 import NoncePicker from './NoncePicker';
 import { TransactionDisplay } from './TransactionDisplay';
+import { PackageReference } from '@usecannon/builder/src';
+
 import 'react-diff-view/style/index.css';
 
 export default function QueueFromGitOpsPage() {
   return <QueueFromGitOps />;
 }
-// Regex to match this pattern:
-// <package-name>:<version> or <package-name>:<version>@<preset>
-const PackageRegex = /^([a-z0-9-]+):([a-z0-9-]+)(@([a-z0-9-]+))?$/;
 
 function QueueFromGitOps() {
   const router = useRouter();
@@ -181,7 +180,7 @@ function QueueFromGitOps() {
   }, [previousPackageInput, cannonDefInfo.def?.getPreset(ctx)]);
 
   const cannonPkgPreviousInfo = useCannonPackage(
-    cannonDefInfo.def && PackageRegex.test(previousPackageInput)
+    cannonDefInfo.def && PackageReference.isValid(previousPackageInput)
       ? `${previousName}:${previousVersion}${
           previousPreset ? '@' + previousPreset : ''
         }`
@@ -460,7 +459,7 @@ function QueueFromGitOps() {
             </FormHelperText>
             {cannonPkgPreviousInfo.error ||
             (previousPackageInput.length > 0 &&
-              !PackageRegex.test(previousPackageInput)) ? (
+              !PackageReference.isValid(previousPackageInput)) ? (
               <Alert mt="6" status="error" bg="red.700">
                 <AlertIcon mr={3} />
                 <strong>
@@ -468,7 +467,7 @@ function QueueFromGitOps() {
                     'Invalid package name. Should be of the format <package-name>:<version> or <package-name>:<version>@<preset>'}
                 </strong>
               </Alert>
-            ) : undefined}
+            ) : null}
           </FormControl>
           {/* TODO: insert/load override settings here */}
           <FormControl mb="6">

--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -61,6 +61,9 @@ import 'react-diff-view/style/index.css';
 export default function QueueFromGitOpsPage() {
   return <QueueFromGitOps />;
 }
+// Regex to match this pattern:
+// <package-name>:<version> or <package-name>:<version>@<preset>
+const PackageRegex = /^([a-z0-9-]+):([a-z0-9-]+)(@([a-z0-9-]+))?$/;
 
 function QueueFromGitOps() {
   const router = useRouter();
@@ -178,11 +181,11 @@ function QueueFromGitOps() {
   }, [previousPackageInput, cannonDefInfo.def?.getPreset(ctx)]);
 
   const cannonPkgPreviousInfo = useCannonPackage(
-    (cannonDefInfo.def &&
-      `${previousName}:${previousVersion}${
-        previousPreset ? '@' + previousPreset : ''
-      }`) ??
-      '',
+    cannonDefInfo.def && PackageRegex.test(previousPackageInput)
+      ? `${previousName}:${previousVersion}${
+          previousPreset ? '@' + previousPreset : ''
+        }`
+      : '',
     chainId
   );
   const preset = cannonDefInfo.def && cannonDefInfo.def.getPreset(ctx);
@@ -455,10 +458,15 @@ function QueueFromGitOps() {
                 <Code>--upgrade-from</Code>
               </Link>
             </FormHelperText>
-            {cannonPkgPreviousInfo.error ? (
+            {cannonPkgPreviousInfo.error ||
+            (previousPackageInput.length > 0 &&
+              !PackageRegex.test(previousPackageInput)) ? (
               <Alert mt="6" status="error" bg="red.700">
                 <AlertIcon mr={3} />
-                <strong>{cannonPkgPreviousInfo.error.toString()}</strong>
+                <strong>
+                  {cannonPkgPreviousInfo?.error?.toString() ||
+                    'Invalid package name. Should be of the format <package-name>:<version> or <package-name>:<version>@<preset>'}
+                </strong>
               </Alert>
             ) : undefined}
           </FormControl>


### PR DESCRIPTION
The main purpose of this PR is to:

- When previous package input is empty clear errors
- Show error when package input data does not fulfill the expected regex
- Just Fetch previous package data when regex is fulfilled
 

https://github.com/usecannon/cannon/assets/3952453/df311407-c003-4d6a-bc42-ba0fcaeff6d5


