### PR TITLE
fix(website): do not open drawer on queued txn

### DIFF
--- a/packages/website/src/features/Packages/Function.tsx
+++ b/packages/website/src/features/Packages/Function.tsx
@@ -287,12 +287,11 @@ export const Function: FC<{
     });
 
     toast({
-      title: 'Transaction queued',
+      title: `Total transactions queued: ${lastQueuedTxnsId + 1}`,
       status: 'success',
       duration: 5000,
       isClosable: true,
     });
-    onDrawerOpen?.();
   };
 
   const renderFunctionContent = () => (


### PR DESCRIPTION
This PR updates the transaction queuing behavior. Instead of opening the drawer for each queued transaction event, a toast notification will now display the total number of queued transactions.

https://github.com/usecannon/cannon/assets/3952453/c7ed409e-89d4-4236-a0ad-58563c3f6eb7

