### PR TITLE
fix(publish): over publish logs

### DIFF
--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -17,7 +17,8 @@ export { prepareMulticall } from './multicall';
 };
 
 export { CannonRegistry, OnChainRegistry, InMemoryRegistry, FallbackRegistry } from './registry';
-export { publishPackage, PackageReference, preparePublishPackage, PackagePublishCall } from './package';
+export { publishPackage, PackageReference, preparePublishPackage } from './package';
+export type { PackagePublishCall } from './package';
 export { CANNON_CHAIN_ID, getCannonRepoRegistryUrl, BUILD_VERSION } from './constants';
 export { isIpfsGateway } from './ipfs';
 export * from './access-recorder';

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -17,9 +17,9 @@ export { prepareMulticall } from './multicall';
 };
 
 export { CannonRegistry, OnChainRegistry, InMemoryRegistry, FallbackRegistry } from './registry';
-export { publishPackage, PackageReference, getProvisionedPackages } from './package';
 export { CANNON_CHAIN_ID, getCannonRepoRegistryUrl, BUILD_VERSION } from './constants';
 export { isIpfsGateway } from './ipfs';
+export * from './package';
 export * from './access-recorder';
 export * from './definition';
 export * from './helpers';

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -17,9 +17,9 @@ export { prepareMulticall } from './multicall';
 };
 
 export { CannonRegistry, OnChainRegistry, InMemoryRegistry, FallbackRegistry } from './registry';
+export { publishPackage, PackageReference, preparePublishPackage, PackagePublishCall } from './package';
 export { CANNON_CHAIN_ID, getCannonRepoRegistryUrl, BUILD_VERSION } from './constants';
 export { isIpfsGateway } from './ipfs';
-export * from './package';
 export * from './access-recorder';
 export * from './definition';
 export * from './helpers';

--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -172,7 +172,7 @@ export async function preparePublishPackage({
   chainId,
   fromStorage,
   toStorage,
-  includeProvisioned,
+  includeProvisioned = true,
 }: CopyPackageOpts) {
   debug(`copy package ${packageRef} (${fromStorage.registry.getLabel()} -> ${toStorage.registry.getLabel()})`);
 

--- a/packages/cli/src/commands/publish.test.ts
+++ b/packages/cli/src/commands/publish.test.ts
@@ -1,16 +1,16 @@
 import {
   CannonStorage,
   DeploymentInfo,
+  InMemoryRegistry,
   IPFSLoader,
   OnChainRegistry,
-  InMemoryRegistry,
-  publishPackage,
+  preparePublishPackage,
 } from '@usecannon/builder';
-import * as viem from 'viem';
 import fs from 'fs-extra';
 import _ from 'lodash';
 import path from 'path';
 import { dirSync } from 'tmp-promise';
+import * as viem from 'viem';
 import { publish } from '../commands/publish';
 import { LocalLoader } from '../loader';
 import { resolveCliSettings } from '../settings';
@@ -180,7 +180,7 @@ describe('publish command', () => {
       jest.spyOn(fs, 'readdir').mockResolvedValue(_deployDataLocalFileNames);
 
       const builder = await import('@usecannon/builder');
-      jest.spyOn(builder, 'publishPackage').mockImplementation(async () => {
+      jest.spyOn(builder, 'preparePublishPackage').mockImplementation(async () => {
         return [];
       });
     });
@@ -197,9 +197,9 @@ describe('publish command', () => {
         includeProvisioned: true,
       });
 
-      expect(publishPackage as jest.Mock).toHaveBeenCalledTimes(1);
-      expect((publishPackage as jest.Mock).mock.calls[0][0].packageRef).toEqual(fullPackageRef);
-      expect((publishPackage as jest.Mock).mock.calls[0][0].chainId).toEqual(chainId);
+      expect(preparePublishPackage as jest.Mock).toHaveBeenCalledTimes(1);
+      expect((preparePublishPackage as jest.Mock).mock.calls[0][0].packageRef).toEqual(fullPackageRef);
+      expect((preparePublishPackage as jest.Mock).mock.calls[0][0].chainId).toEqual(chainId);
     });
 
     // Not sure if it's the expected behavior to match multiple deploy files on preset is empty
@@ -216,9 +216,9 @@ describe('publish command', () => {
         skipConfirm: true,
       });
 
-      expect(publishPackage as jest.Mock).toHaveBeenCalledTimes(1);
-      expect((publishPackage as jest.Mock).mock.calls[0][0].packageRef).toEqual(fullPackageRef);
-      expect((publishPackage as jest.Mock).mock.calls[0][0].chainId).toEqual(chainId);
+      expect(preparePublishPackage as jest.Mock).toHaveBeenCalledTimes(1);
+      expect((preparePublishPackage as jest.Mock).mock.calls[0][0].packageRef).toEqual(fullPackageRef);
+      expect((preparePublishPackage as jest.Mock).mock.calls[0][0].chainId).toEqual(chainId);
     });
 
     // Not sure if it's the expected behavior to match multiple deploy files on chainId is zero
@@ -235,9 +235,9 @@ describe('publish command', () => {
         skipConfirm: true,
       });
 
-      expect(publishPackage as jest.Mock).toHaveBeenCalledTimes(1);
-      expect((publishPackage as jest.Mock).mock.calls[0][0].packageRef).toEqual(fullPackageRef);
-      expect((publishPackage as jest.Mock).mock.calls[0][0].chainId).toEqual(chainId);
+      expect(preparePublishPackage as jest.Mock).toHaveBeenCalledTimes(1);
+      expect((preparePublishPackage as jest.Mock).mock.calls[0][0].packageRef).toEqual(fullPackageRef);
+      expect((preparePublishPackage as jest.Mock).mock.calls[0][0].chainId).toEqual(chainId);
     });
   });
 });

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,15 +1,15 @@
 import {
-  CannonStorage,
-  getProvisionedPackages,
-  IPFSLoader,
   CannonRegistry,
+  CannonStorage,
+  IPFSLoader,
   OnChainRegistry,
+  PackagePublishCall,
   PackageReference,
-  publishPackage,
+  preparePublishPackage,
 } from '@usecannon/builder';
-import * as viem from 'viem';
-import { blueBright, bold, gray, italic, yellow } from 'chalk';
+import { blueBright, bold, gray, yellow } from 'chalk';
 import prompts from 'prompts';
+import * as viem from 'viem';
 import { getMainLoader } from '../loader';
 import { LocalRegistry } from '../registry';
 import { CliSettings } from '../settings';
@@ -30,11 +30,6 @@ interface DeployList {
   name: string;
   versions: string[];
   preset: string;
-  chainId: number;
-}
-
-interface SubPackage {
-  packagesNames: string[];
   chainId: number;
 }
 
@@ -150,66 +145,37 @@ export async function publish({
     return result;
   }, []);
 
-  let subPackages: SubPackage[] = [];
+  const publishCalls: PackagePublishCall[] = [];
+
+  for (const pkg of parentPackages) {
+    const publishTags: string[] = pkg.versions.concat(tags);
+
+    const calls = await preparePublishPackage({
+      packageRef: PackageReference.from(pkg.name, pkg.versions[0], pkg.preset).fullPackageRef,
+      chainId: deploys[0].chainId,
+      fromStorage,
+      toStorage,
+      tags: publishTags!,
+      includeProvisioned,
+    });
+
+    publishCalls.push(...calls);
+  }
+
   if (!skipConfirm) {
-    if (includeProvisioned) {
-      for (const pkg of parentPackages) {
-        for (const version of pkg.versions) {
-          const provisionedPackages = await getProvisionedPackages(
-            `${pkg.name}:${version}@${pkg.preset}`,
-            pkg.chainId,
-            tags,
-            fromStorage
-          );
-          subPackages.push(...provisionedPackages);
-        }
+    for (const publishCall of publishCalls) {
+      const packageName = new PackageReference(publishCall.packagesNames[0]).name;
+      console.log(blueBright(`\nThis will publish ${bold(packageName)} to the registry:`));
+      for (const fullPackageRef of publishCall.packagesNames) {
+        const { version, preset } = new PackageReference(fullPackageRef);
+        console.log(` - ${version} (preset: ${preset})`);
       }
-
-      // filter out duplicates names
-      subPackages = subPackages.map((pkg) => ({
-        ...pkg,
-        packagesNames: Array.from(new Set(pkg.packagesNames)),
-      }));
-
-      if (subPackages.length == 0) {
-        console.log(yellow('\nNo cloned packages found, publishing parent packages only...'));
-      }
-
-      parentPackages.forEach((deploy) => {
-        console.log(blueBright(`\nThis will publish ${bold(deploy.name)} to the registry:`));
-        deploy.versions.concat(tags).map((version) => {
-          console.log(` - ${version} (preset: ${deploy.preset})`);
-        });
-      });
-      console.log('\n');
-
-      subPackages.forEach((pkg: SubPackage) => {
-        const [packageName] = pkg.packagesNames;
-        console.log(
-          blueBright(
-            `This will publish ${bold(new PackageReference(packageName).name)} ${bold(
-              italic('(Cloned Package)')
-            )} to the registry:`
-          )
-        );
-        pkg.packagesNames.forEach((pkgName) => {
-          const { version, preset } = new PackageReference(pkgName);
-          console.log(` - ${version} (preset: ${preset})`);
-        });
-        console.log('\n');
-      });
-    } else {
-      parentPackages.forEach((deploy) => {
-        console.log(blueBright(`This will publish ${bold(deploy.name)}@${deploy.preset} to the registry:`));
-        deploy.versions.concat(tags).forEach((version) => {
-          console.log(` - ${version}`);
-        });
-      });
-      console.log('\n');
     }
 
+    console.log('\n');
+
     if (onChainRegistry instanceof OnChainRegistry) {
-      const totalFees = await onChainRegistry.calculatePublishingFee(parentPackages.length + subPackages.length);
+      const totalFees = await onChainRegistry.calculatePublishingFee(publishCalls.length);
 
       console.log(`Total publishing fees: ${viem.formatEther(totalFees)} ETH`);
       console.log();
@@ -232,51 +198,10 @@ export async function publish({
   console.log(gray('This may take a few minutes.'));
   console.log();
 
-  const registrationReceipts = [];
-
-  for (const pkg of parentPackages) {
-    const publishTags: string[] = pkg.versions.concat(tags);
-
-    const newReceipts = await publishPackage({
-      packageRef: PackageReference.from(pkg.name, pkg.versions[0], pkg.preset).fullPackageRef,
-      chainId: deploys[0].chainId,
-      fromStorage,
-      toStorage,
-      tags: publishTags!,
-      includeProvisioned,
-    });
-
-    registrationReceipts.push(...newReceipts);
-  }
+  const registrationReceipts = await toStorage.registry.publishMany(publishCalls);
 
   if (!quiet) {
-    console.log(bold(blueBright('Packages published:')));
-    if (includeProvisioned) {
-      parentPackages.forEach((deploy) => {
-        deploy.versions.concat(tags).forEach((ver) => {
-          const { fullPackageRef } = PackageReference.from(deploy.name, ver, deploy.preset);
-          console.log(`- ${fullPackageRef}`);
-        });
-      });
-      subPackages!.forEach((pkg) => {
-        pkg.packagesNames.forEach((pkgName) => {
-          const { fullPackageRef } = new PackageReference(pkgName);
-          console.log(`- ${fullPackageRef}`);
-        });
-      });
-    } else {
-      parentPackages.forEach((deploy) => {
-        deploy.versions.concat(tags).forEach((ver) => {
-          const { fullPackageRef } = PackageReference.from(deploy.name, ver, deploy.preset);
-          console.log(`  - ${fullPackageRef}`);
-        });
-      });
-    }
-
-    const txs = registrationReceipts.filter((tx) => !!tx);
-    if (txs.length) {
-      console.log(blueBright('Transactions:'));
-      for (const tx of txs) console.log(`  - ${tx}`);
-    }
+    console.log(blueBright('Transactions:'));
+    for (const tx of registrationReceipts) console.log(`  - ${tx}`);
   }
 }


### PR DESCRIPTION
This PR refactors the logic for calculating the publish packages, and now, when calling it from the CLI will first calculate everything that's going to do, show the confirmation, and then execute it.

Before, it was calculating the publishes 2 times, in different ways.