### PR TITLE
fix(cli): output url store data

### DIFF
--- a/packages/builder/src/loader.ts
+++ b/packages/builder/src/loader.ts
@@ -35,7 +35,8 @@ export class IPFSLoader implements CannonLoader {
   }
 
   getLabel() {
-    return `ipfs ${this.ipfsUrl}`;
+    debug(`IPFSLoader.getLabel() ${this.ipfsUrl}`);
+    return this.ipfsUrl;
   }
 
   async put(misc: any): Promise<string> {

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -75,7 +75,8 @@ export class CliLoader implements CannonLoader {
   }
 
   getLabel() {
-    return `cli ${this.ipfs ? this.ipfs.getLabel() + ' + ' + this.repo.getLabel() : this.repo.getLabel()}`;
+    debug(`cli ${this.ipfs ? this.ipfs.getLabel() + ' + ' + this.repo.getLabel() : this.repo.getLabel()}`);
+    return this.ipfs ? this.ipfs.getLabel() : this.repo.getLabel();
   }
 
   getCacheFilePath(url: string) {


### PR DESCRIPTION
This PR fixes the following output: 

<img width="932" alt="Screenshot 2024-05-31 at 2 09 26 AM" src="https://github.com/usecannon/cannon/assets/15804684/3587562b-c0eb-40f5-a97f-2ad284d6742f">
