### PR TITLE
fix(builder): deps are modified by definition.ts

### DIFF
--- a/packages/builder/src/definition.test.ts
+++ b/packages/builder/src/definition.test.ts
@@ -51,6 +51,26 @@ describe('ChainDefinition', () => {
     });
   });
 
+  describe.only('computeDependencies()', () => {
+    it('does not modify the underlying `raw` data structure', () => {
+      const rawDef: RawChainDefinition = {
+        name: 'test',
+        version: '1.0.0',
+        var: {
+          a: { b: '<%= settings.c %>' },
+          d: { c: '1234' },
+        },
+        deploy: {
+          woot: { artifact: 'wohoo', args: ['<%= settings.b %>'], depends: [] },
+        },
+      };
+
+      const def = new ChainDefinition(_.cloneDeep(rawDef));
+
+      expect((def as any).raw).toEqual(rawDef);
+    });
+  });
+
   describe('checkCycles()', () => {
     it('works when there are 0 nodes', async () => {
       const def = makeFakeChainDefinition({});

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -312,7 +312,7 @@ export class ChainDefinition {
         `);
     }
 
-    const deps = (_.get(this.raw, node)!.depends || []) as string[];
+    const deps = _.clone(_.get(this.raw, node)!.depends || []) as string[];
 
     const n = node.split('.')[0];
 


### PR DESCRIPTION
causes a number of bugs:
* tons of duplicate dependencies on upload (should save a good bit of space!)
* publish urls changing
* publish urls mismatching
* additional packages being published when they shouldn't because their publish urls posthumously change