### PR TITLE
fix(builder): package length check

### DIFF
--- a/packages/builder/src/package.test.ts
+++ b/packages/builder/src/package.test.ts
@@ -1,8 +1,8 @@
+import { CannonStorage } from './';
 import { IPFSLoader } from './loader';
-import { InMemoryRegistry } from './registry';
 import { PackageReference, publishPackage } from './package';
+import { InMemoryRegistry } from './registry';
 import { DeploymentInfo } from './types';
-import { CannonStorage } from '.';
 
 jest.mock('./loader');
 
@@ -27,7 +27,7 @@ describe('package.ts', () => {
       expect(ref).toHaveProperty('fullPackageRef', fullPackageRef);
     });
 
-    test.each([['a'], ['aa'], ['-aa'], ['some_package'], ['super-long-package-invalid-namee']])(
+    test.each([['a'], ['aa'], ['-aa'], ['some_package'], ['super-long-package-invalid-nameee']])(
       'throws an error with "%s"',
       (packageRef) => {
         expect(() => {

--- a/packages/builder/src/package.ts
+++ b/packages/builder/src/package.ts
@@ -37,7 +37,7 @@ export interface PackagePublishCall {
 export class PackageReference {
   static DEFAULT_TAG = 'latest';
   static DEFAULT_PRESET = 'main';
-  static PACKAGE_REGEX = /^(?<name>@?[a-z0-9][A-Za-z0-9-]{1,29}[a-z0-9])(?::(?<version>[^@]+))?(@(?<preset>[^\s]+))?$/;
+  static PACKAGE_REGEX = /^(?<name>@?[a-z0-9][A-Za-z0-9-]{1,30}[a-z0-9])(?::(?<version>[^@]+))?(@(?<preset>[^\s]+))?$/;
 
   /**
    * Anything before the colon or an @ (if no version is present) is the package name.

--- a/packages/registry/test/contracts/CannonRegistry.test.ts
+++ b/packages/registry/test/contracts/CannonRegistry.test.ts
@@ -1,11 +1,12 @@
 import { deepEqual, equal, ok } from 'assert/strict';
 import { BigNumber, ContractTransaction, Signer } from 'ethers';
 import { ethers } from 'hardhat';
+import { stringToHex } from 'viem';
 import { CannonRegistry as TCannonRegistry } from '../../typechain-types/contracts/CannonRegistry';
 import { MockOptimismBridge as TMockOptimismBridge } from '../../typechain-types/contracts/MockOptimismBridge';
 import assertRevert from '../helpers/assert-revert';
 
-const toBytes32 = ethers.utils.formatBytes32String;
+const toBytes32 = (str: string) => stringToHex(str, { size: 32 });
 const parseEther = ethers.utils.parseEther;
 
 describe('CannonRegistry', function () {
@@ -99,6 +100,15 @@ describe('CannonRegistry', function () {
 
       equal(await CannonRegistry.validatePackageName(toBytes32(testName.slice(0, minLength))), true);
       equal(await CannonRegistry.validatePackageName(toBytes32(testName.slice(0, minLength - 1))), false);
+    });
+
+    it('it validates package names of 32 characters directly', async function () {
+      equal(
+        await CannonRegistry.validatePackageName('0x692D646F6E742D636F6E7461696E2D612D6E756C6C2D7465726D696E61746F72'),
+        true
+      );
+
+      equal(await CannonRegistry.validatePackageName(toBytes32('i-dont-contain-a-null-terminator')), true);
     });
   });
 


### PR DESCRIPTION
This PR fixes the correct handling of null terminators for the builder. Before that we where using ethers.js it adds an extra `00` at the end when calling `ethers.utils.formatBytes32String`, which meant that we couldn't register packages with 32 length, just 31. Since we moved to viem this is fixed because the `stringToHex` helper does not add the null terminator, and in turn this PR fixes the length validation to 32.