### PR TITLE
feat(cli): add e2e tests for publishers command

### DIFF
--- a/packages/cli/src/commands/publishers.ts
+++ b/packages/cli/src/commands/publishers.ts
@@ -18,6 +18,11 @@ interface Params {
   packageRef: string;
 }
 
+enum Network {
+  OP = 'OP',
+  MAINNET = 'ETH',
+}
+
 export async function publishers({ cliSettings, options, packageRef }: Params) {
   // throw an error if the user has not provided any addresses
   if (!options.add && !options.remove) {
@@ -86,17 +91,17 @@ export async function publishers({ cliSettings, options, packageRef }: Params) {
         name: 'value',
         message: 'Where do you want to add or remove publishers?',
         choices: [
-          { title: 'Optimism', value: 'OP' },
-          { title: 'Ethereum Mainnet', value: 'ETH' },
+          { title: 'Optimism', value: Network.OP },
+          { title: 'Ethereum Mainnet', value: Network.MAINNET },
         ],
         initial: 0,
       })
     ).value;
   } else {
-    selectedNetwork = options.optimism ? 'OP' : 'ETH';
+    selectedNetwork = options.optimism ? Network.OP : Network.MAINNET;
   }
 
-  const isMainnet = selectedNetwork === 'ETH';
+  const isMainnet = selectedNetwork === Network.MAINNET;
   const [optimismRegistryConfig, mainnetRegistryConfig] = cliSettings.registries;
   const [optimismRegistryProvider, mainnetRegistryProvider] = await resolveRegistryProviders(cliSettings);
 
@@ -216,7 +221,7 @@ export async function publishers({ cliSettings, options, packageRef }: Params) {
         waitForEvent({
           eventName: 'PackagePublishersChanged',
           abi: mainnetRegistry.contract.abi,
-          providerUrl: optimismRegistryConfig.providerUrl![0],
+          providerUrl: mainnetRegistryConfig.providerUrl![0],
           expectedArgs: {
             name: packageNameHex,
             publisher: mainnetPublishers,
@@ -233,7 +238,7 @@ export async function publishers({ cliSettings, options, packageRef }: Params) {
         }),
       ]);
 
-      console.log(green('Success!'));
+      console.log(green('Success - The publishers list has been updated!'));
       console.log('');
     })(),
   ]);

--- a/packages/cli/src/commandsConfig.ts
+++ b/packages/cli/src/commandsConfig.ts
@@ -618,11 +618,11 @@ const commandsConfig = {
         description: 'Private key of the package owner',
       },
       {
-        flags: '--optimism <key>',
+        flags: '--optimism',
         description: 'Change publishers on the Optimism network',
       },
       {
-        flags: '--mainnet <key>',
+        flags: '--mainnet',
         description: 'Change publishers on the Mainnet network',
       },
       {

--- a/packages/cli/src/commandsConfig.ts
+++ b/packages/cli/src/commandsConfig.ts
@@ -618,6 +618,18 @@ const commandsConfig = {
         description: 'Private key of the package owner',
       },
       {
+        flags: '--optimism <key>',
+        description: 'Change publishers on the Optimism network',
+      },
+      {
+        flags: '--mainnet <key>',
+        description: 'Change publishers on the Mainnet network',
+      },
+      {
+        flags: '--skip-confirm',
+        description: 'Skip confirmation to change the publishers',
+      },
+      {
         flags: '--gas-limit <gasLimit>',
         description: 'The maximum units of gas spent for the registration transaction',
       },

--- a/packages/cli/test/e2e/e2e-tests.bats
+++ b/packages/cli/test/e2e/e2e-tests.bats
@@ -200,6 +200,42 @@ teardown() {
   assert_success
 }
 
+@test "Publishers - Add a publisher on Optimism network" {
+  set_custom_config
+  start_optimism_emitter
+  run publishers.sh 1
+  echo $output
+  assert_output --partial 'Success - The publishers list has been updated!'
+  assert_success
+}
+
+@test "Publishers - Remove a publisher on Optimism network" {
+  set_custom_config
+  start_optimism_emitter
+  run publishers.sh 2
+  echo $output
+  assert_output --partial 'Success - The publishers list has been updated!'
+  assert_success
+}
+
+@test "Publishers - Add a publisher on Mainnet network" {
+  set_custom_config
+  start_optimism_emitter
+  run publishers.sh 3
+  echo $output
+  assert_output --partial 'Success - The publishers list has been updated!'
+  assert_success
+}
+
+@test "Publishers - Remove a publisher on Mainnet network" {
+  set_custom_config
+  start_optimism_emitter
+  run publishers.sh 4
+  echo $output
+  assert_output --partial 'Success - The publishers list has been updated!'
+  assert_success
+}
+
 @test "Publish - Publishing greeter package" {
   set_custom_config
   run publish.sh

--- a/packages/cli/test/e2e/scripts/non-interactive/publishers.sh
+++ b/packages/cli/test/e2e/scripts/non-interactive/publishers.sh
@@ -1,0 +1,14 @@
+case $1 in
+  1)
+    CANNON_E2E=true $CANNON publishers package-one --add 0x000000000000000000000000000000000000dEaD --optimism --private-key ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --skip-confirm
+    ;;
+  2)
+    CANNON_E2E=true $CANNON publishers package-one --remove 0x000000000000000000000000000000000000dEaD --optimism --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --skip-confirm
+    ;;
+  3)
+    CANNON_E2E=true $CANNON publishers package-one --add 0x000000000000000000000000000000000000dEaD --mainnet --private-key ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --skip-confirm
+    ;;
+  4)
+    CANNON_E2E=true $CANNON publishers package-one --remove 0x000000000000000000000000000000000000dEaD --mainnet --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --skip-confirm
+    ;;
+esac


### PR DESCRIPTION
This PR wants to add e2e tests for the publishers command:
 - Add a publisher on OP network
 - Remove a publisher on OP network
 - Add a publisher on Mainnet network
 - Remove a publisher on Mainnet network