### PR TITLE
fix(api): redis reconnection strategy

### DIFF
--- a/packages/api/src/errors.ts
+++ b/packages/api/src/errors.ts
@@ -9,6 +9,13 @@ export class ServerError extends Error {
   }
 }
 
+export class ServiceUnavailableError extends ServerError {
+  constructor(message = 'Server Unavailable', status = 503) {
+    super(message);
+    this.status = status;
+  }
+}
+
 export class BadRequestError extends ServerError {
   constructor(message = 'Bad Request', status = 400) {
     super(message);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -28,6 +28,7 @@ app.use(
     limit: 100,
     standardHeaders: 'draft-7',
     legacyHeaders: false,
+    validate: { trustProxy: !config.TRUST_PROXY },
   })
 );
 
@@ -40,5 +41,5 @@ app.use(apiErrorHandler);
 
 app.listen(config.PORT, () => {
   // eslint-disable-next-line no-console
-  console.log(`\n · status: running · version: ${packageJson.version} · port ${config.PORT} ·\n`);
+  console.log(`\n · status: running · version: ${packageJson.version} · port ${config.PORT} ·`);
 });


### PR DESCRIPTION
With the default redis reconnection strategy, the server would just wait until it can connect to redis with an exponential retry timeout, this lead to the server to just be waiting an "infinite" amount of time.

With this fix, now:
1. Redis retries reconnecting always every 5 secs (doesn't make sense to wait 150 secs on third retry)
2. After 5 retries, the server will halt with an error (this will restart the server and notify us by email, thanks to DO)
3. Now, the client instantly gets a `503` when redis is not available, so it can be correctly handled by the client, instead of having to wait something like 90 secs timeout.