### PR TITLE
fix(builder): ability to handle nested helper context

### DIFF
--- a/packages/builder/src/access-recorder.ts
+++ b/packages/builder/src/access-recorder.ts
@@ -70,6 +70,15 @@ export function computeTemplateAccesses(str?: string, possibleNames: string[] = 
     if (typeof (CannonHelperContext as any)[n] === 'function') {
       // the types have been a massive unsolvableseeming pain here
       recorders[n] = _.noop as unknown as AccessRecorder;
+    } else if (typeof (CannonHelperContext as any)[n] === 'object') {
+      for (const o in (CannonHelperContext as any)[n]) {
+        (recorders[n] as any) = {};
+        if (typeof (CannonHelperContext as any)[n][o] === 'function') {
+          (recorders[n] as any)[o] = _.noop as unknown as AccessRecorder;
+        } else {
+          recorders[n] = (CannonHelperContext as any)[n] as unknown as AccessRecorder;
+        }
+      }
     } else {
       recorders[n] = (CannonHelperContext as any)[n] as unknown as AccessRecorder;
     }


### PR DESCRIPTION
access recorder can incorrectly handle some CannonHelperContext helpers if they are nested in an object

to fix this, update the function to properly handle nested objects.

tested on actual issue occuring on synthetix v3 repository