### PR TITLE
fix(website): Add error message for insufficient funds on deployer

### DIFF
--- a/packages/website/src/features/Deploy/PublishUtility.tsx
+++ b/packages/website/src/features/Deploy/PublishUtility.tsx
@@ -200,7 +200,6 @@ export default function PublishUtility(props: {
           isClosable: true,
         });
       }
-
     },
   });
 

--- a/packages/website/src/features/Deploy/PublishUtility.tsx
+++ b/packages/website/src/features/Deploy/PublishUtility.tsx
@@ -156,12 +156,21 @@ export default function PublishUtility(props: {
     onError(err) {
       // eslint-disable-next-line no-console
       console.error(err);
-      toast({
-        title: 'Error Publishing Package',
-        status: 'error',
-        duration: 30000,
-        isClosable: true,
-      });
+      if (err.message.includes('exceeds the balance of the account')) {
+        toast({
+          title: 'Error Publishing Package: Insufficient Funds',
+          status: 'error',
+          duration: 10000,
+          isClosable: true,
+        });
+      } else {
+        toast({
+          title: 'Error Publishing Package',
+          status: 'error',
+          duration: 10000,
+          isClosable: true,
+        });
+      }
     },
   });
 
@@ -175,12 +184,23 @@ export default function PublishUtility(props: {
     onError(err) {
       // eslint-disable-next-line no-console
       console.error(err);
-      toast({
-        title: 'Error Publishing Package',
-        status: 'error',
-        duration: 10000,
-        isClosable: true,
-      });
+
+      if (err.message.includes('exceeds the balance of the account')) {
+        toast({
+          title: 'Error Publishing Package: Insufficient Funds',
+          status: 'error',
+          duration: 10000,
+          isClosable: true,
+        });
+      } else {
+        toast({
+          title: 'Error Publishing Package',
+          status: 'error',
+          duration: 10000,
+          isClosable: true,
+        });
+      }
+
     },
   });
 

--- a/packages/website/src/hooks/backend.ts
+++ b/packages/website/src/hooks/backend.ts
@@ -259,7 +259,7 @@ export function useTxnStager(
   } else if (existingSigsCount < requiredSigs && (signConditionFailed || existingSigsCount + 1 < requiredSigs)) {
     execConditionFailed = `insufficient signers to execute (required: ${requiredSigs})`;
   } else if (stageTxnMutate.isError) {
-    execConditionFailed = `Simluation error: ${stageTxnMutate.failureReason}`;
+    execConditionFailed = `Simulation error: ${stageTxnMutate.failureReason}`;
   }
 
   return {


### PR DESCRIPTION
Before: 
![image](https://github.com/user-attachments/assets/0c6d78b7-e4b3-4051-81a5-ad55248c42f4)

Now:
![image](https://github.com/user-attachments/assets/debcb6e4-f1fb-4213-836e-00f427cf303b)


fixes https://linear.app/usecannon/issue/CAN-308/more-clear-error-on-insufficient-funds-when-publishing

