### PR TITLE
fix(website): simulation of deploy contract

### DIFF
--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -63,9 +63,6 @@ import NoncePicker from './NoncePicker';
 import { TransactionDisplay } from './TransactionDisplay';
 import 'react-diff-view/style/index.css';
 
-// Needed to preapre mock run step with registerAction
-import '@/lib/builder';
-
 export default function QueueFromGitOpsPage() {
   return <QueueFromGitOps />;
 }

--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -363,7 +363,10 @@ function QueueFromGitOps() {
 
   const isPartialDataRequired =
     buildInfo.buildSkippedSteps.filter(
-      (s) => s.name.includes('contract') || s.name.includes('router')
+      (s) =>
+        s.name.startsWith('contract') ||
+        s.name.startsWith('deploy') ||
+        s.name.startsWith('router')
     ).length > 0;
 
   const loadingDataForDeploy =

--- a/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
+++ b/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
@@ -68,9 +68,6 @@ interface Props {
   sigHash: string;
 }
 
-// Needed to preapre mock run step with registerAction
-import '@/lib/builder';
-
 function TransactionDetailsPage({
   safeAddress,
   chainId,

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -151,6 +151,8 @@ export function useCannonBuild(safe: SafeDefinition | null, def?: ChainDefinitio
     currentRuntime.on(
       Events.PostStepExecute,
       (stepType: string, stepLabel: string, stepConfig: any, stepCtx: ChainBuilderContext, stepOutput: ChainArtifacts) => {
+        const stepName = `${stepType}.${stepLabel}`;
+
         addLog(
           `cannon.ts: on Events.PostStepExecute operation ${stepType}.${stepLabel} output: ${JSON.stringify(stepOutput)}`
         );
@@ -163,6 +165,10 @@ export function useCannonBuild(safe: SafeDefinition | null, def?: ChainDefinitio
         }
 
         setBuildStatus(`Building ${stepType}.${stepLabel}...`);
+
+        if (stepType === 'contract' || stepType === 'deploy') {
+          skippedSteps.push({ name: stepName, err: new Error('Cannot deploy contract on a Safe transaction') });
+        }
       }
     );
 

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -166,7 +166,8 @@ export function useCannonBuild(safe: SafeDefinition | null, def?: ChainDefinitio
 
         setBuildStatus(`Building ${stepType}.${stepLabel}...`);
 
-        if (stepType === 'contract' || stepType === 'deploy') {
+        // a step that deploys a contract is a step that has no txns deployed but contract(s) deployed
+        if (_.keys(stepOutput.txns).length === 0 && _.keys(stepOutput.contracts).length > 0) {
           skippedSteps.push({ name: stepName, err: new Error('Cannot deploy contract on a Safe transaction') });
         }
       }

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -28,6 +28,9 @@ import { useEffect, useState } from 'react';
 import { Abi, Address, createPublicClient, createWalletClient, custom, Hex, isAddressEqual, PublicClient } from 'viem';
 import { useChainId } from 'wagmi';
 
+// Needed to preapre mock run step with registerAction
+import '@/lib/builder';
+
 export type BuildState =
   | {
       status: 'idle' | 'loading' | 'error';


### PR DESCRIPTION
Closes https://linear.app/usecannon/issue/CAN-409/throw-an-error-when-trying-to-deploy-a-contract-using-the-web-deployer

This PR now shows an error when trying to stage a Safe transaction with a contract deployment:
<img width="749" alt="Screenshot 2024-07-19 at 01 59 59" src="https://github.com/user-attachments/assets/1c28e745-ab9a-40c5-a417-438d1aaebcd2">