### PR TITLE
fix(cli): parsing and application of `--gas-price` and related

### DIFF
--- a/packages/builder/src/runtime.test.ts
+++ b/packages/builder/src/runtime.test.ts
@@ -178,67 +178,67 @@ describe('runtime.ts', () => {
 
     describe('gas settings', () => {
       it('sets the gas price', async () => {
-        const gasPrice = '123456';
+        const gasPrice = viem.parseGwei('123456');
         const newRuntime = runtime.derive({
           gasPrice,
         });
 
-        expect(newRuntime.gasPrice).toBe(viem.parseGwei(gasPrice).toString());
+        expect(newRuntime.gasPrice).toBe(gasPrice);
         expect(newRuntime.gasFee).toBeUndefined();
         expect(newRuntime.priorityGasFee).toBeUndefined();
       });
       it('sets the gas price and derive again', async () => {
-        const gasPrice = '123456';
+        const gasPrice = viem.parseGwei('123456');
         const newRuntime = runtime.derive({
           gasPrice,
         });
 
         const newNewRuntime = newRuntime.derive({});
 
-        expect(newNewRuntime.gasPrice).toBe(viem.parseGwei(gasPrice).toString());
+        expect(newNewRuntime.gasPrice).toBe(gasPrice);
         expect(newNewRuntime.gasFee).toBeUndefined();
         expect(newNewRuntime.priorityGasFee).toBeUndefined();
       });
 
       it('sets gas fee price', async () => {
-        const gasFee = '123456';
+        const gasFee = viem.parseGwei('123456');
         const newRuntime = runtime.derive({
           gasFee,
         });
 
-        expect(newRuntime.gasFee).toBe(viem.parseGwei(gasFee).toString());
+        expect(newRuntime.gasFee).toBe(gasFee);
         expect(newRuntime.gasPrice).toBeUndefined();
         expect(newRuntime.priorityGasFee).toBeUndefined();
       });
 
       it('sets priority gas fee price', async () => {
-        const gasFee = '123456';
-        const priorityGasFee = '012345';
+        const gasFee = viem.parseGwei('123456');
+        const priorityGasFee = viem.parseGwei('012345');
         const newRuntime = runtime.derive({
           gasFee,
           priorityGasFee,
         });
 
-        expect(newRuntime.gasFee).toBe(viem.parseGwei(gasFee).toString());
-        expect(newRuntime.priorityGasFee).toBe(viem.parseGwei(priorityGasFee).toString());
+        expect(newRuntime.gasFee).toBe(gasFee);
+        expect(newRuntime.priorityGasFee).toBe(priorityGasFee);
         expect(newRuntime.gasPrice).toBeUndefined();
       });
 
       it('ignore gas price if gas fee is set', async () => {
-        const gasFee = '123456';
-        const gasPrice = '012345';
+        const gasFee = viem.parseGwei('123456');
+        const gasPrice = viem.parseGwei('012345');
         const newRuntime = runtime.derive({
           gasFee,
           gasPrice,
         });
 
-        expect(newRuntime.gasFee).toBe(viem.parseGwei(gasFee).toString());
+        expect(newRuntime.gasFee).toBe(gasFee);
         expect(newRuntime.priorityGasFee).toBeUndefined();
         expect(newRuntime.gasPrice).toBeUndefined();
       });
 
       it('throw if priority gas fee is set without gas fee', async () => {
-        const priorityGasFee = '012345';
+        const priorityGasFee = viem.parseGwei('012345');
         expect(() =>
           runtime.derive({
             priorityGasFee,

--- a/packages/builder/src/runtime.ts
+++ b/packages/builder/src/runtime.ts
@@ -101,12 +101,6 @@ export class CannonStorage extends EventEmitter {
   }
 }
 
-const parseGasValue = (value: string | undefined) => {
-  if (!value) return undefined;
-
-  return viem.parseGwei(value);
-};
-
 export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRuntimeInfo {
   provider: viem.PublicClient;
   readonly chainId: number;

--- a/packages/builder/src/runtime.ts
+++ b/packages/builder/src/runtime.ts
@@ -104,7 +104,7 @@ export class CannonStorage extends EventEmitter {
 const parseGasValue = (value: string | undefined) => {
   if (!value) return undefined;
 
-  return viem.parseGwei(value).toString();
+  return viem.parseGwei(value);
 };
 
 export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRuntimeInfo {
@@ -121,9 +121,9 @@ export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRu
   ctx: ChainBuilderContext | null;
   private publicSourceCode: boolean | undefined;
   private signals: { cancelled: boolean } = { cancelled: false };
-  private _gasPrice: string | undefined;
-  private _gasFee: string | undefined;
-  private _priorityGasFee: string | undefined;
+  private _gasPrice: bigint | undefined;
+  private _gasFee: bigint | undefined;
+  private _priorityGasFee: bigint | undefined;
 
   private cleanSnapshot: any;
 
@@ -177,14 +177,14 @@ export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRu
       }
     }
 
-    this._gasFee = parseGasValue(info.gasFee);
-    this._priorityGasFee = parseGasValue(info.priorityGasFee);
+    this._gasFee = info.gasFee;
+    this._priorityGasFee = info.priorityGasFee;
 
     if (info.gasPrice) {
       if (info.gasFee) {
         debug(yellow('WARNING: gasPrice is ignored when gasFee is set'));
       } else {
-        this._gasPrice = parseGasValue(info.gasPrice);
+        this._gasPrice = info.gasPrice;
       }
     }
   }
@@ -193,13 +193,13 @@ export class ChainBuilderRuntime extends CannonStorage implements ChainBuilderRu
     this.signals.cancelled = true;
   }
 
-  get gasPrice(): string | undefined {
+  get gasPrice(): bigint | undefined {
     return this._gasPrice;
   }
-  get gasFee(): string | undefined {
+  get gasFee(): bigint | undefined {
     return this._gasFee;
   }
-  get priorityGasFee(): string | undefined {
+  get priorityGasFee(): bigint | undefined {
     return this._priorityGasFee;
   }
 

--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -713,9 +713,9 @@ export const routerSchema = z
      */
     overrides: z
       .object({
-        gasLimit: z.string(),
-        simulate: z.boolean(),
+        gasLimit: z.string().optional(),
       })
+      .optional()
       .describe('Override transaction settings'),
     /**
      *  List of operations that this operation depends on, which Cannon will execute first. If unspecified, Cannon automatically detects dependencies.

--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -709,6 +709,15 @@ export const routerSchema = z
      */
     salt: z.string().optional().describe('Used to force new copy of a contract (not actually used)'),
     /**
+     *   Override transaction settings
+     */
+    overrides: z
+      .object({
+        gasLimit: z.string(),
+        simulate: z.boolean(),
+      })
+      .describe('Override transaction settings'),
+    /**
      *  List of operations that this operation depends on, which Cannon will execute first. If unspecified, Cannon automatically detects dependencies.
      */
     depends: z

--- a/packages/builder/src/steps/router.ts
+++ b/packages/builder/src/steps/router.ts
@@ -65,6 +65,10 @@ const routerStep = {
       config.salt = template(config.salt)(ctx);
     }
 
+    if (config?.overrides?.gasLimit) {
+      config.overrides.gasLimit = template(config.overrides.gasLimit)(ctx);
+    }
+
     return config;
   },
 
@@ -74,6 +78,10 @@ const routerStep = {
     accesses.accesses.push(
       ...config.contracts.map((c) => (c.includes('.') ? `imports.${c.split('.')[0]}` : `contracts.${c}`))
     );
+
+    if (config?.overrides) {
+      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.overrides.gasLimit, possibleFields));
+    }
 
     return accesses;
   },
@@ -157,6 +165,23 @@ const routerStep = {
       }),
       chain: undefined,
     });
+
+    if (config.overrides?.gasLimit) {
+      preparedTxn.gas = BigInt(config.overrides.gasLimit);
+    }
+
+    if (runtime.gasPrice) {
+      preparedTxn.gasPrice = runtime.gasPrice;
+    }
+
+    if (runtime.gasFee) {
+      preparedTxn.maxFeePerGas = runtime.gasFee;
+    }
+
+    if (runtime.priorityGasFee) {
+      preparedTxn.maxPriorityFeePerGas = runtime.priorityGasFee;
+    }
+
     const hash = await signer.wallet.sendTransaction(preparedTxn as any);
 
     const receipt = await runtime.provider.waitForTransactionReceipt({ hash });

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -193,11 +193,11 @@ export interface ChainBuilderRuntimeInfo {
   allowPartialDeploy: boolean;
 
   // Gas price to use for transactions
-  gasPrice?: string;
+  gasPrice?: bigint;
 
   // Base and Priority gas fee to use for transactions - EIP1559
-  gasFee?: string;
-  priorityGasFee?: string;
+  gasFee?: bigint;
+  priorityGasFee?: bigint;
 }
 
 export interface PackageState {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -52,9 +52,9 @@ interface Params {
   publicSourceCode?: boolean;
   providerUrl?: string;
   registryPriority?: 'local' | 'onchain' | 'offline';
-  gasPrice?: string;
-  gasFee?: string;
-  priorityGasFee?: string;
+  gasPrice?: bigint;
+  gasFee?: bigint;
+  priorityGasFee?: bigint;
   writeScript?: string;
   writeScriptFormat?: WriteScriptFormat;
 }

--- a/packages/cli/src/commandsConfig.ts
+++ b/packages/cli/src/commandsConfig.ts
@@ -67,10 +67,6 @@ const anvilOptions = [
     description: 'Timeout in ms for requests sent to remote JSON-RPC server in forking mode.',
   },
   {
-    flags: '--block-base-fee-per-gas [number]',
-    description: 'The base fee in a block.',
-  },
-  {
     flags: '--code-size-limit [number]',
     description: 'EIP-170: Contract code size limit in bytes. Useful to increase this because of tests.',
   },
@@ -81,10 +77,6 @@ const anvilOptions = [
   {
     flags: '--gas-limit [number]',
     description: 'The block gas limit.',
-  },
-  {
-    flags: '--gas-price [number]',
-    description: 'The gas price.',
   },
   {
     flags: '--accounts [number]',
@@ -293,15 +285,15 @@ const commandsConfig = {
       },
       {
         flags: '--gas-price <gasPrice>',
-        description: 'Specify a gas price to use for the deployment',
+        description: 'The gas price used by all transactions processed by this build. Expressed in GWEI.',
       },
       {
         flags: '--max-gas-fee <maxGasFee>',
-        description: 'Specify max fee per gas (EIP-1559) for deployment',
+        description: 'Specify max fee per gas (EIP-1559) for all transactions processed by this build. Expressed in GWEI.',
       },
       {
         flags: '--max-priority-gas-fee <maxpriorityGasFee>',
-        description: 'Specify max fee per gas (EIP-1559) for deployment',
+        description: 'Specify max fee per gas (EIP-1559) for all transactions processed by this build. Expressed in GWEI.',
       },
       {
         flags: '--skip-compile',

--- a/packages/cli/src/util/anvil.ts
+++ b/packages/cli/src/util/anvil.ts
@@ -77,10 +77,6 @@ export type AnvilOptions = {
    */
   timeout?: number | undefined;
   /**
-   * The base fee in a block.
-   */
-  blockBaseFeePerGas?: number | bigint | undefined;
-  /**
    * The chain id.
    */
   chainId?: number | undefined;
@@ -94,14 +90,6 @@ export type AnvilOptions = {
    * Disable the `call.gas_limit <= block.gas_limit` constraint.
    */
   disableBlockGasLimit?: boolean | undefined;
-  /**
-   * The block gas limit.
-   */
-  gasLimit?: number | bigint | undefined;
-  /**
-   * The gas price.
-   */
-  gasPrice?: number | bigint | undefined;
   /**
    * Number of dev accounts to generate and configure.
    *
@@ -220,12 +208,9 @@ const anvilOptionKeys = [
   'noStorageCaching',
   'retries',
   'timeout',
-  'blockBaseFeePerGas',
   'chainId',
   'codeSizeLimit',
   'disableBlockGasLimit',
-  'gasLimit',
-  'gasPrice',
   'accounts',
   'balance',
   'derivationPath',

--- a/packages/cli/src/util/build.ts
+++ b/packages/cli/src/util/build.ts
@@ -278,8 +278,12 @@ async function prepareBuildConfig(
     providerUrl: cliSettings.providerUrl,
     writeScript: opts.writeScript,
     writeScriptFormat: opts.writeScriptFormat,
-    gasPrice: opts.gasPrice,
-    gasFee: opts.maxGasFee,
-    priorityGasFee: opts.maxPriorityGasFee,
+    gasPrice: parseGwei(opts.gasPrice),
+    gasFee: parseGwei(opts.maxGasFee),
+    priorityGasFee: parseGwei(opts.maxPriorityGasFee),
   };
+}
+
+function parseGwei(v: string | undefined): bigint | undefined {
+  return v ? viem.parseGwei(v) : undefined;
 }


### PR DESCRIPTION
the arguments were not parsable or usable at all because they would be passed through multiple processes

now the command works as expected, parsing the inputted value in gwei and converting it early on to avoid ambiguity