### PR TITLE
fix(builder): Fix output for invalid fromCall.func

### DIFF
--- a/packages/builder/src/steps/invoke.ts
+++ b/packages/builder/src/steps/invoke.ts
@@ -118,7 +118,7 @@ async function runTxn(
     if (!neededOwnerFuncAbi) {
       throw new Error(
         `contract ${contract.address} for ${packageState.currentLabel} does not contain the function "${
-          config.func
+          config.fromCall.func
         }" to determine owner. List of recognized functions is:\n${Object.keys(
           contract.abi.filter((v) => v.type === 'function').map((v) => (v as viem.AbiFunction).name)
         ).join(


### PR DESCRIPTION
When the `fromCall.func` function doesnt exist or is invalid, the error incorrectly prints out the value for the `func` defined function
![image](https://github.com/user-attachments/assets/1fe07c12-0af0-4b47-b803-d3d10a4e1501)
