### PR TITLE
chore(website): replace useCannonRegistry hook with CannonRegistryProvider

### DIFF
--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -3,7 +3,7 @@ import { IPFSBrowserLoader } from '@/helpers/ipfs';
 import { createFork, findChain } from '@/helpers/rpc';
 import { SafeDefinition, useStore } from '@/helpers/store';
 import { useGitRepo } from '@/hooks/git';
-import { useCannonRegistry } from '@/hooks/registry';
+import { useCannonRegistry } from '@/providers/CannonRegistryProvider';
 import { useLogs } from '@/providers/logsProvider';
 import { BaseTransaction } from '@safe-global/safe-apps-sdk';
 import { useMutation, UseMutationOptions, useQuery } from '@tanstack/react-query';

--- a/packages/website/src/hooks/registry.ts
+++ b/packages/website/src/hooks/registry.ts
@@ -1,30 +1,7 @@
-import { inMemoryRegistry } from '@/helpers/cannon';
 import { findChain } from '@/helpers/rpc';
-import { FallbackRegistry, OnChainRegistry, DEFAULT_REGISTRY_ADDRESS, DEFAULT_REGISTRY_CONFIG } from '@usecannon/builder';
-import { useEffect, useMemo, useState } from 'react';
+import { OnChainRegistry, DEFAULT_REGISTRY_ADDRESS, DEFAULT_REGISTRY_CONFIG } from '@usecannon/builder';
+import { useEffect, useState } from 'react';
 import * as viem from 'viem';
-
-export function useCannonRegistry() {
-  return useMemo(() => {
-    const registryChainIds = DEFAULT_REGISTRY_CONFIG.map((registry) => registry.chainId);
-
-    const onChainRegistries = registryChainIds.map(
-      (chainId: number) =>
-        new OnChainRegistry({
-          address: DEFAULT_REGISTRY_ADDRESS,
-          provider: viem.createPublicClient({
-            chain: findChain(chainId) as viem.Chain,
-            transport: viem.http(),
-          }),
-        })
-    );
-
-    // Create a regsitry that loads data first from Memory to be able to utilize
-    // the locally built data
-    const fallbackRegistry = new FallbackRegistry([inMemoryRegistry, ...onChainRegistries]);
-    return fallbackRegistry;
-  }, []);
-}
 
 type Publishers = {
   publisher: viem.Address;

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import { DefaultSeo } from 'next-seo';
 import '@/styles/globals.css';
 import defaultSEO from '@/constants/defaultSeo';
 import E2EWalletConnector from '../../cypress/utils/E2EWalletConnector';
+import { CannonRegistryProvider } from '@/providers/CannonRegistryProvider';
 
 const miriam = Miriam_Libre({
   subsets: ['latin'],
@@ -71,7 +72,11 @@ export default function RootLayout({
           position="relative"
         >
           <Header />
-          <Flex flex="1">{getLayout(<Component {...pageProps} />)}</Flex>
+          <Flex flex="1">
+            <CannonRegistryProvider>
+              {getLayout(<Component {...pageProps} />)}
+            </CannonRegistryProvider>
+          </Flex>
           <Footer />
           {/*<Console />*/}
           <E2EWalletConnector />

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -12,7 +12,6 @@ import { DefaultSeo } from 'next-seo';
 import '@/styles/globals.css';
 import defaultSEO from '@/constants/defaultSeo';
 import E2EWalletConnector from '../../cypress/utils/E2EWalletConnector';
-import { CannonRegistryProvider } from '@/providers/CannonRegistryProvider';
 
 const miriam = Miriam_Libre({
   subsets: ['latin'],
@@ -72,11 +71,7 @@ export default function RootLayout({
           position="relative"
         >
           <Header />
-          <Flex flex="1">
-            <CannonRegistryProvider>
-              {getLayout(<Component {...pageProps} />)}
-            </CannonRegistryProvider>
-          </Flex>
+          <Flex flex="1">{getLayout(<Component {...pageProps} />)}</Flex>
           <Footer />
           {/*<Console />*/}
           <E2EWalletConnector />

--- a/packages/website/src/pages/_providers.tsx
+++ b/packages/website/src/pages/_providers.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { CannonRegistryProvider } from '@/providers/CannonRegistryProvider';
 import LogsProvider from '@/providers/logsProvider';
 import WalletProvider from '@/providers/walletProvider';
 import { theme } from '@/theme/theme';
@@ -28,7 +29,9 @@ export default function Providers({ children }: { children: ReactNode }) {
       <ChakraProvider theme={theme} colorModeManager={csm as any}>
         <QueryClientProvider client={queryClient}>
           <LogsProvider>
-            <WalletProvider>{children}</WalletProvider>
+            <CannonRegistryProvider>
+              <WalletProvider>{children}</WalletProvider>
+            </CannonRegistryProvider>
           </LogsProvider>
         </QueryClientProvider>
       </ChakraProvider>

--- a/packages/website/src/providers/CannonRegistryProvider.tsx
+++ b/packages/website/src/providers/CannonRegistryProvider.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext } from 'react';
+import { inMemoryRegistry } from '@/helpers/cannon';
+import {
+  FallbackRegistry,
+  OnChainRegistry,
+  DEFAULT_REGISTRY_ADDRESS,
+  DEFAULT_REGISTRY_CONFIG,
+} from '@usecannon/builder';
+import { findChain } from '@/helpers/rpc';
+import { Chain, http, createPublicClient } from 'viem';
+
+type RegistryContextType = FallbackRegistry | undefined;
+
+const CannonRegistryContext = createContext<RegistryContextType>(undefined);
+
+type Props = {
+  children: React.ReactNode;
+};
+export const CannonRegistryProvider: React.FC<Props> = ({ children }) => {
+  const onChainRegistries = DEFAULT_REGISTRY_CONFIG.map(
+    (registry) => registry.chainId
+  ).map(
+    (chainId: number) =>
+      new OnChainRegistry({
+        address: DEFAULT_REGISTRY_ADDRESS,
+        provider: createPublicClient({
+          chain: findChain(chainId) as Chain,
+          transport: http(),
+        }),
+      })
+  );
+
+  const fallbackRegistry = new FallbackRegistry([
+    inMemoryRegistry,
+    ...onChainRegistries,
+  ]);
+
+  return (
+    <CannonRegistryContext.Provider value={fallbackRegistry}>
+      {children}
+    </CannonRegistryContext.Provider>
+  );
+};
+
+export const useCannonRegistry = (): FallbackRegistry => {
+  const context = useContext(CannonRegistryContext);
+  if (context === undefined) {
+    throw new Error(
+      'useCannonRegistry must be used within a CannonRegistryProvider'
+    );
+  }
+  return context;
+};


### PR DESCRIPTION
The `useCannonRegistry` hook is utilized by `useCannonBuild` and `useCannonPackage`, which are hooks used in many components. Previously, each component that consumed one of these hooks would trigger the creation of provider instances for all chains. This refactor ensures that these instances are created only once when the dApp is initialized.

Ideally, we should identify all top-level components using the hook and register the provider at the highest appropriate level. However, given the widespread use of these hooks, defining it on the `_app.ts` file seems temporarily a valid option.