### PR TITLE
fix(website): Correctly matching function inputs in ABI when signing a transaction

### DIFF
--- a/packages/website/src/features/Deploy/DisplayedTransaction.tsx
+++ b/packages/website/src/features/Deploy/DisplayedTransaction.tsx
@@ -10,25 +10,36 @@ import {
   Spinner,
   Text,
 } from '@chakra-ui/react';
-import { useMemo } from 'react';
+import { FC, ReactNode } from 'react';
 import { a11yDark, CopyBlock } from 'react-code-blocks';
 import {
-  Address,
   bytesToString,
   decodeFunctionData,
   Hex,
   hexToBytes,
   TransactionRequestBase,
   trim,
-  formatEther,
+  DecodeFunctionDataReturnType,
 } from 'viem';
-import { chainsById } from '@/helpers/chains';
+import { chainsById, getExplorerUrl } from '@/helpers/chains';
 import { Alert } from '@/components/Alert';
-import { useCannonPackageContracts } from '@/hooks/cannon';
+import {
+  ContractInfo,
+  useCannonPackageContracts,
+  UseCannonPackageContractsReturnType,
+} from '@/hooks/cannon';
+import { formatToken } from '@/helpers/formatters';
 
+const TxWrapper: FC<{ children: ReactNode }> = ({ children }) => (
+  <Box p={6} border="1px solid" borderColor="gray.600" bgColor="black">
+    {children}
+  </Box>
+);
+// TODO: refactor caching mechanism
+// A possible solution is to use useQuery from tanstack/react-query
 const useCannonPreloadedContracts = (
   url: string,
-  cannonInfo?: any,
+  cannonInfo?: UseCannonPackageContractsReturnType,
   isPreloaded?: boolean
 ) => {
   const useCannonContracts =
@@ -40,10 +51,10 @@ export function DisplayedTransaction(props: {
   txn?: Omit<TransactionRequestBase, 'from'>;
   chainId: number;
   pkgUrl: string;
-  cannonInfo?: any;
+  cannonInfo?: UseCannonPackageContractsReturnType;
   isPreloaded?: boolean;
 }) {
-  const chain = useMemo(() => chainsById[props.chainId], [props.chainId]);
+  const chain = chainsById[props.chainId];
 
   const cannonInfo = useCannonPreloadedContracts(
     props.pkgUrl ? '@' + props.pkgUrl.replace('://', ':') : '',
@@ -53,84 +64,87 @@ export function DisplayedTransaction(props: {
 
   if (cannonInfo.isFetching) {
     return (
-      <Box p={6} border="1px solid" borderColor="gray.600" bgColor="black">
+      <TxWrapper>
         <Flex alignItems="center" justifyContent="center" height="100%">
           <Spinner />
         </Flex>
-      </Box>
+      </TxWrapper>
     );
   }
 
   if (cannonInfo.isError) {
     return (
-      <Box p={6} border="1px solid" borderColor="gray.600" bgColor="black">
+      <TxWrapper>
         <Alert status="error">
           <AlertDescription fontSize="sm" lineHeight="0">
             Unable to fetch cannon package contracts.
           </AlertDescription>
         </Alert>
-      </Box>
+      </TxWrapper>
     );
   }
 
-  const contracts = cannonInfo.contracts as {
-    [key: string]: { address: Address; abi: any[] };
-  };
+  const contracts: ContractInfo | null = cannonInfo.contracts;
+
+  // Get the contract names that match the transaction's `to` address
   const parsedContractNames =
     props.txn && contracts
       ? Object.entries(contracts)
-          .filter((c) => c[1].address === props.txn?.to)
-          .map((v) => v[0])
-      : '';
+          .filter(([, { address }]) => address === props.txn?.to)
+          .map(([contractName]) => contractName)
+      : [];
 
-  let parsedContract = props.txn ? props.txn.to : '';
-  let parsedFunction = null;
+  let contractName = props.txn?.to ?? '';
+  let decodedFunctionData: DecodeFunctionDataReturnType | null = null;
   if (contracts) {
     for (const n of parsedContractNames) {
       try {
-        parsedFunction = decodeFunctionData({
+        decodedFunctionData = decodeFunctionData({
           abi: contracts[n].abi,
-          data: props.txn?.data as any,
+          data: props.txn?.data || '0x',
         });
-        parsedContract = n;
+        contractName = n;
         break;
       } catch {
         // ignore
       }
     }
   }
-  const execFunc = props.txn
-    ? parsedFunction
-      ? parsedFunction.functionName.split('(')[0]
-      : props.txn.data?.slice(0, 10)
-    : '';
 
-  const execContractInfo =
-    contracts && parsedContract ? contracts[parsedContract] : null;
-  const execFuncFragment =
-    contracts && execContractInfo && execFunc
-      ? execContractInfo.abi.find((f) => f.name === execFunc)
-      : null;
+  const functionName = decodedFunctionData?.functionName.split('(')[0];
+  const functionHash = props.txn?.data?.slice(0, 10);
+  const rawFunctionArgs = props.txn?.data?.slice(10);
+  const functionArgs = decodedFunctionData?.args?.map((v) => v) || [
+    rawFunctionArgs,
+  ];
+  const functionFragmentsFromAbi = contracts?.[contractName].abi.filter(
+    (f) => 'name' in f && f.name === functionName
+  );
+  const functionFragmentFromAbi = functionFragmentsFromAbi?.find(
+    (f) =>
+      f &&
+      decodedFunctionData &&
+      'inputs' in f &&
+      f.inputs?.length === decodedFunctionData.args?.length
+  );
+  const functionParameters =
+    (functionFragmentFromAbi &&
+      'inputs' in functionFragmentFromAbi &&
+      functionFragmentFromAbi.inputs) ||
+    [];
 
-  const execFuncArgs = props.txn
-    ? parsedFunction?.args?.map((v) => v) || [props.txn.data?.slice(10)]
-    : [];
-
-  const etherscanUrl =
-    chain.blockExplorers?.default?.url ?? 'https://etherscan.io';
   const address = (
-    <Link isExternal href={etherscanUrl + '/address/' + props.txn?.to}>
+    <Link isExternal href={getExplorerUrl(chain.id, props.txn?.to || '')}>
       {props.txn?.to}
     </Link>
   );
-  const selector = props.txn?.data?.slice(0, 10);
-  const value = `${formatEther(props.txn?.value || BigInt(0))} ${
-    chain?.nativeCurrency?.symbol
-  }`;
+  const value = formatToken(props.txn?.value || BigInt(0), {
+    symbol: chain?.nativeCurrency?.symbol,
+  });
 
   if (!contracts && !cannonInfo.isFetching) {
     return (
-      <Box p={6} border="1px solid" borderColor="gray.600" bgColor="black">
+      <TxWrapper>
         <Box mb={5}>
           <Alert status="warning">
             <AlertDescription fontSize="sm" lineHeight="0">
@@ -145,7 +159,7 @@ export function DisplayedTransaction(props: {
               Target: {address}
             </Text>
             <Text as="span" mr={3}>
-              Selector: {selector}
+              Selector: {functionHash}
             </Text>
             <Text as="span">Value: {value}</Text>
           </Text>
@@ -161,55 +175,50 @@ export function DisplayedTransaction(props: {
           theme={a11yDark}
           customStyle={{ fontSize: '14px' }}
         />
-      </Box>
+      </TxWrapper>
     );
   }
 
   return (
     <Box p={6} border="1px solid" borderColor="gray.600" bgColor="black">
       <Box maxW="100%" overflowX="auto">
-        <Box
-          whiteSpace="nowrap"
-          mb={execFuncFragment?.inputs?.length > 0 ? 4 : 0}
-        >
+        <Box whiteSpace="nowrap" mb={functionParameters.length > 0 ? 4 : 0}>
           <Heading size="sm" fontFamily="mono" fontWeight="semibold" mb={1}>
-            {`${parsedContract}.${execFunc}`}
+            {`${contractName}.${functionName || functionHash}`}
           </Heading>
           <Text fontSize="xs" color="gray.300">
             <Text as="span" mr={3}>
               Target: {address}
             </Text>
             <Text as="span" mr={3}>
-              Selector: {selector}
+              Selector: {functionHash}
             </Text>
             <Text as="span">Value: {value}</Text>
           </Text>
         </Box>
         <Flex flexDirection={['column', 'column', 'row']} gap={8} height="100%">
           <Box flex="1" w={['100%', '100%', '50%']}>
-            {(execFuncFragment?.inputs || []).map((_arg: any, i: number) => [
-              <Box key={JSON.stringify(execFuncFragment.inputs[i])}>
+            {functionParameters.map((_arg, i) => [
+              <Box key={JSON.stringify(functionParameters[i])}>
                 <FormControl mb="4">
                   <FormLabel fontSize="sm" mb={1}>
-                    {execFuncFragment.inputs[i].name && (
-                      <Text display="inline">
-                        {execFuncFragment.inputs[i].name}
-                      </Text>
+                    {functionParameters[i].name && (
+                      <Text display="inline">{functionParameters[i].name}</Text>
                     )}
-                    {execFuncFragment.inputs[i].type && (
+                    {functionParameters[i].type && (
                       <Text
                         fontSize="xs"
                         color="whiteAlpha.700"
                         display="inline"
                       >
                         {' '}
-                        {execFuncFragment.inputs[i].type}
+                        {functionParameters[i].type}
                       </Text>
                     )}
                   </FormLabel>
                   {_renderInput(
-                    execFuncFragment.inputs[i].type,
-                    execFuncArgs[i]
+                    functionParameters[i].type,
+                    functionArgs[i] as string
                   )}
                 </FormControl>
               </Box>,

--- a/packages/website/src/helpers/chains.ts
+++ b/packages/website/src/helpers/chains.ts
@@ -1,5 +1,6 @@
 import { merge } from 'lodash';
 import * as chains from 'viem/chains';
+import * as viem from 'viem';
 
 // For enrichment if necessary
 //import { set } from 'lodash';
@@ -77,7 +78,7 @@ export const getExplorerUrl = (chainId: number, hash: string) => {
 
   const url = explorer?.url || 'https://etherscan.io';
 
-  const type = hash.length > 42 ? 'tx' : 'address';
+  const type = viem.isAddress(hash) ? 'address' : 'tx';
   return `${url}/${type}/${hash}`;
 };
 

--- a/packages/website/src/helpers/chains.ts
+++ b/packages/website/src/helpers/chains.ts
@@ -70,6 +70,17 @@ const chainsById = Object.values(enrichedChainData).reduce((acc, chain) => {
   return acc;
 });
 
+export const getExplorerUrl = (chainId: number, hash: string) => {
+  const chain = chainsById[chainId];
+  const explorer = chain.blockExplorers?.default;
+  if (!chain || !explorer) return '';
+
+  const url = explorer?.url || 'https://etherscan.io';
+
+  const type = hash.length > 42 ? 'tx' : 'address';
+  return `${url}/${type}/${hash}`;
+};
+
 export { chainsById };
 
 export * from 'viem/chains';

--- a/packages/website/src/helpers/formatters/index.ts
+++ b/packages/website/src/helpers/formatters/index.ts
@@ -1,0 +1,5 @@
+import { formatUnits } from 'viem';
+
+export const formatToken = (amount: bigint, options?: { decimals?: number; symbol?: string }) => {
+  return `${formatUnits(amount, options?.decimals || 18)} ${options?.symbol}`.trim();
+};

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -28,7 +28,7 @@ import { useEffect, useState } from 'react';
 import { Abi, Address, createPublicClient, createWalletClient, custom, Hex, isAddressEqual, PublicClient } from 'viem';
 import { useChainId } from 'wagmi';
 
-// Needed to preapre mock run step with registerAction
+// Needed to prepare mock run step with registerAction
 import '@/lib/builder';
 
 export type BuildState =
@@ -403,7 +403,7 @@ export function useCannonPackage(packageRef: string, chainId?: number) {
   };
 }
 
-type ContractInfo = {
+export type ContractInfo = {
   [x: string]: { address: Address; abi: Abi };
 };
 
@@ -464,3 +464,4 @@ export function useCannonPackageContracts(packageRef: string, chainId?: number) 
 
   return { contracts, ...pkg };
 }
+export type UseCannonPackageContractsReturnType = ReturnType<typeof useCannonPackageContracts>;

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import { DefaultSeo } from 'next-seo';
 import '@/styles/globals.css';
 import defaultSEO from '@/constants/defaultSeo';
 import E2EWalletConnector from '../../cypress/utils/E2EWalletConnector';
+import { CannonRegistryProvider } from '@/providers/CannonRegistryProvider';
 
 const miriam = Miriam_Libre({
   subsets: ['latin'],
@@ -71,7 +72,11 @@ export default function RootLayout({
           position="relative"
         >
           <Header />
-          <Flex flex="1">{getLayout(<Component {...pageProps} />)}</Flex>
+          <Flex flex="1">
+            <CannonRegistryProvider>
+              {getLayout(<Component {...pageProps} />)}
+            </CannonRegistryProvider>
+          </Flex>
           <Footer />
           {/*<Console />*/}
           <E2EWalletConnector />

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -12,7 +12,6 @@ import { DefaultSeo } from 'next-seo';
 import '@/styles/globals.css';
 import defaultSEO from '@/constants/defaultSeo';
 import E2EWalletConnector from '../../cypress/utils/E2EWalletConnector';
-import { CannonRegistryProvider } from '@/providers/CannonRegistryProvider';
 
 const miriam = Miriam_Libre({
   subsets: ['latin'],
@@ -72,11 +71,7 @@ export default function RootLayout({
           position="relative"
         >
           <Header />
-          <Flex flex="1">
-            <CannonRegistryProvider>
-              {getLayout(<Component {...pageProps} />)}
-            </CannonRegistryProvider>
-          </Flex>
+          <Flex flex="1">{getLayout(<Component {...pageProps} />)}</Flex>
           <Footer />
           {/*<Console />*/}
           <E2EWalletConnector />


### PR DESCRIPTION
This fix addresses the issue in [#411](https://linear.app/usecannon/issue/CAN-411/website-displays-wrong-function-when-same-name-on-sign-transaction), where the code was incorrectly retrieving the first matching function inputs from the ABI. Now, it selects the function inputs by matching the function name and the exact count of arguments specified in the decodedFunctionData.

- All the `any`s have been removed from `DisplayedTransaction.tsx`.
- I've refactored the code a bit, especially renaming some variables to make it more understandable. 

Closes https://linear.app/usecannon/issue/CAN-411/website-displays-wrong-function-when-same-name-on-sign-transaction
