### PR TITLE
fix(website): vertical overflow on subnavigation

### DIFF
--- a/packages/website/src/pages/packages/[name]/[tag]/[variant]/_layout.tsx
+++ b/packages/website/src/pages/packages/[name]/[tag]/[variant]/_layout.tsx
@@ -121,7 +121,13 @@ export default function PackageLayout({ children }: { children: ReactNode }) {
                   <VersionSelect pkg={packagesQuery.data.data} />
                 </Box>
               </Flex>
-              <Flex gap={8} align="center" maxW="100%" overflowX="auto">
+              <Flex
+                gap={8}
+                align="center"
+                maxW="100%"
+                overflowX="auto"
+                overflowY="hidden"
+              >
                 <NavLink
                   isActive={pathname == '/packages/[name]/[tag]/[variant]'}
                   href={`/packages/${packagesQuery.data.data.name}/${params.tag}/${params.variant}`}


### PR DESCRIPTION
This fixes the following scroll when connecting a mouse on a mac:
https://github.com/user-attachments/assets/e26d78d5-ecaa-4301-8283-a839ed6c54a5

