### PR TITLE
fix(website): CAN-431 Navigating among contracts in interact losses method references.

### DIFF
--- a/packages/website/src/features/Packages/Abi.tsx
+++ b/packages/website/src/features/Packages/Abi.tsx
@@ -259,8 +259,11 @@ export const Abi: FC<{
             borderColor="gray.700"
             gap={4}
           >
-            {allContractMethods?.map((f, index) => (
-              <Element name={getSelectorSlug(f)} key={index}>
+            {allContractMethods?.map((f) => (
+              <Element
+                name={getSelectorSlug(f)}
+                key={`${address}-${getSelectorSlug(f)}`}
+              >
                 <Function
                   selected={selectedSelector == getSelectorSlug(f)}
                   f={f}

--- a/packages/website/src/pages/packages/[name]/[tag]/[variant]/interact/_layout.tsx
+++ b/packages/website/src/pages/packages/[name]/[tag]/[variant]/interact/_layout.tsx
@@ -1,18 +1,8 @@
 'use client';
 
 import { ReactNode } from 'react';
-import { useRouter } from 'next/router';
 import InteractTab from '@/features/Packages/Tabs/InteractTab';
 
 export default function InteractLayout({ children }: { children: ReactNode }) {
-  const params = useRouter().query;
-  return (
-    <InteractTab
-      name={decodeURIComponent(params.name as string)}
-      tag={decodeURIComponent(params.tag as string)}
-      variant={decodeURIComponent(params.variant as string)}
-    >
-      {children}
-    </InteractTab>
-  );
+  return <InteractTab>{children}</InteractTab>;
 }


### PR DESCRIPTION
This PR fixes two bugs:

1. When moving among contracts listed in the header in the interact section, methods lose reference and fail when trying to call them with a message similar to this one: "Args parameters don't match". It was fixed by setting a unique key on the map that renders the box with the functionality to interact with the method. Before, it was using the `map.index` as the key, now the key is created using the contract address and the method selector. 

2. I've also fixed the issue where the contract selected loses the "selected border" when moving between methods. 