### PR TITLE
fix(builder): Force use of array on invoke target

### DIFF
--- a/examples/sample-foundry-project/cannonfile.toml
+++ b/examples/sample-foundry-project/cannonfile.toml
@@ -18,3 +18,19 @@ artifact = "Greeter"
 args = ["<%= settings.msg %>"]
 libraries.Library = "<%= contracts.library.address %>"
 salt = "<%= settings.salt %>"
+
+[deploy.ClonedGreeter]
+artifact = "ClonedGreeter"
+args = ["<%= settings.msg %>"]
+libraries.Library = "<%= contracts.library.address %>"
+salt = "<%= settings.salt %>"
+
+[router.test]
+contracts = [
+  "library",
+  "greeter",
+]
+
+[invoke.initializeMarket]
+target=["test"]
+func = "greet"


### PR DESCRIPTION
Turns out the error only happened because we allowed targets to be defined as strings as well which was causing the `getInputs` function to incorrectly return values, causing the computation of dependencies to fail.