### PR TITLE
fix(website): use package ref instead of ipfs hash

### DIFF
--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -193,13 +193,18 @@ function QueueFromGitOps() {
       : '',
     chainId
   );
-  const preset = cannonDefInfo.def && cannonDefInfo.def.getPreset(ctx);
-  const cannonPkgVersionInfo = useCannonPackage(
+
+  const fullPackageRef =
     (cannonDefInfo.def &&
       `${cannonDefInfo.def.getName(ctx)}:${cannonDefInfo.def.getVersion(ctx)}${
-        preset ? '@' + preset : ''
+        cannonDefInfo.def.getPreset(ctx)
+          ? '@' + cannonDefInfo.def.getPreset(ctx)
+          : ''
       }`) ??
-      '',
+    '';
+
+  const cannonPkgVersionInfo = useCannonPackage(
+    fullPackageRef,
     currentSafe?.chainId
   );
 
@@ -703,6 +708,7 @@ function QueueFromGitOps() {
                 Transactions
               </Heading>
               <TransactionDisplay
+                packageRef={fullPackageRef}
                 safe={currentSafe as any}
                 safeTxn={stager.safeTxn}
               />

--- a/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
+++ b/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
@@ -173,7 +173,7 @@ function TransactionDetailsPage({
 
   // then reverse check the package referenced by the
   const { pkgUrl: existingRegistryUrl } = useCannonPackage(
-    `${cannonPackage.resolvedName}:${cannonPackage.resolvedVersion}@${cannonPackage.resolvedPreset}`,
+    cannonPackage.fullPackageRef!,
     parsedChainId
   );
 
@@ -409,6 +409,7 @@ function TransactionDetailsPage({
               gap={6}
             >
               <TransactionDisplay
+                packageRef={cannonPackage.fullPackageRef!}
                 safe={safe}
                 safeTxn={safeTxn as any}
                 queuedWithGitOps={queuedWithGitOps}

--- a/packages/website/src/features/Deploy/TransactionDisplay.tsx
+++ b/packages/website/src/features/Deploy/TransactionDisplay.tsx
@@ -39,6 +39,7 @@ const parseDiffFileNames = (diffString: string): string[] => {
 };
 
 export function TransactionDisplay(props: {
+  packageRef: string;
   safeTxn: SafeTransaction;
   safe: SafeDefinition;
   queuedWithGitOps?: boolean;
@@ -48,11 +49,7 @@ export function TransactionDisplay(props: {
 }) {
   const hintData = parseHintedMulticall(props.safeTxn?.data);
 
-  const cannonInfo = useCannonPackageContracts(
-    hintData?.cannonPackage && hintData.isSinglePackage
-      ? '@' + hintData.cannonPackage.replace('://', ':')
-      : ''
-  );
+  const cannonInfo = useCannonPackageContracts(props.packageRef);
 
   // git stuff
   const denom = hintData?.gitRepoUrl?.lastIndexOf(':');


### PR DESCRIPTION
This PR fixes an issue on the deploy page where an error is thrown:

```
Error: Invalid package reference "@ipfs:QmcYmR6na4ifqdT832trDfa9oYnsS3GS8ky1r8zCxumM5P". Should be of the format <package-name>:<version> or <package-name>:<version>@<preset>
    at PackageReference.parse (webpack-internal:///../builder/dist/src/package.js:40:19)
    at new PackageReference (webpack-internal:///../builder/dist/src/package.js:81:41)
    at FallbackRegistry.getUrl (webpack-internal:///../builder/dist/src/registry.js:134:36)
    at queryFn (webpack-internal:///./src/hooks/cannon.ts:278:40)
    at Object.fetchFn [as fn] (webpack-internal:///../../node_modules/@tanstack/query-core/build/modern/query.js:189:14)
    at run (webpack-internal:///../../node_modules/@tanstack/query-core/build/modern/retryer.js:93:49)
    at eval (webpack-internal:///../../node_modules/@tanstack/query-core/build/modern/retryer.js:117:11)
```