### PR TITLE
fix(cli): change registry rpc

### DIFF
--- a/packages/builder/src/constants.ts
+++ b/packages/builder/src/constants.ts
@@ -13,13 +13,13 @@ export const DEFAULT_REGISTRY_CONFIG = [
   {
     name: 'OP Mainnet',
     chainId: 10,
-    providerUrl: ['frame', 'direct', 'https://optimism-rpc.publicnode.com'],
+    providerUrl: ['frame', 'direct', 'https://optimism.llamarpc.com'],
     address: DEFAULT_REGISTRY_ADDRESS,
   },
   {
     name: 'Ethereum Mainnet',
     chainId: 1,
-    providerUrl: ['frame', 'direct', 'https://ethereum-rpc.publicnode.com'],
+    providerUrl: ['frame', 'direct', 'https://eth.llamarpc.com'],
     address: DEFAULT_REGISTRY_ADDRESS,
   },
 ];


### PR DESCRIPTION
Public nodes are experiencing some instability; therefore, the `register` and `publishers` commands are throwing the following error

```
Error: Failed to register package: Error watching for PackageOwnerChanged event: InvalidInputRpcError: Missing or invalid parameters.
Double check you have provided the correct parameters.

URL: https://optimism-rpc.publicnode.com
Request body: {"method":"eth_getFilterChanges","params":["0x519ec925f26881d57ef91843c7df2b22"]}

Details: filter not found
Version: 2.19.4
    at register (/Users/saeta/Projects/cannon/packages/cli/dist/src/commands/register.js:195:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Command.<anonymous> (/Users/saeta/Projects/cannon/packages/cli/dist/src/index.js:439:5)
    at async Command.parseAsync (/Users/saeta/Projects/cannon/node_modules/commander/lib/command.js:935:5)
```