### PR TITLE
fix(alter): update contract address on subpackages

### DIFF
--- a/packages/cli/src/commands/alter.ts
+++ b/packages/cli/src/commands/alter.ts
@@ -227,19 +227,29 @@ export async function alter(
       }
 
       break;
-    case 'set-contract-address':
-      // find the steps that deploy contract
-      for (const actionStep in deployInfo.state) {
-        if (
-          deployInfo.state[actionStep].artifacts.contracts &&
-          deployInfo.state[actionStep].artifacts.contracts![targets[0]]
-        ) {
-          deployInfo.state[actionStep].artifacts.contracts![targets[0]].address = targets[1] as viem.Address;
-          deployInfo.state[actionStep].artifacts.contracts![targets[0]].deployTxnHash = '';
-        }
+    case 'set-contract-address': {
+      const [targetContractName, targetAddress] = targets;
+
+      if (!viem.isAddress(targetAddress)) {
+        throw new Error(`Invalid address given: "${targetAddress}"`);
       }
 
+      // find the step that deploy contract
+      const [targetStep] = Object.values(deployInfo.state).filter(
+        (step) => !!step.artifacts?.contracts?.[targetContractName]
+      );
+
+      if (!targetStep) {
+        throw new Error(`Could not find contract by step name "${targetContractName}"`);
+      }
+
+      debug(`setting "${targetContractName}" address to "${targetAddress}"`);
+
+      targetStep.artifacts!.contracts![targetContractName].address = targetAddress;
+      targetStep.artifacts!.contracts![targetContractName].deployTxnHash = '';
+
       break;
+    }
     case 'mark-complete':
       // some steps may require access to misc artifacts
       await runtime.restoreMisc(deployInfo.miscUrl);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -27,8 +27,8 @@ import commandsConfig from './commandsConfig';
 import {
   checkCannonVersion,
   checkForgeAstSupport,
-  getPackageReference,
   ensureChainIdConsistency,
+  getPackageReference,
   setupAnvil,
 } from './helpers';
 import { getMainLoader } from './loader';
@@ -39,15 +39,15 @@ import { resolveCliSettings } from './settings';
 import { PackageSpecification } from './types';
 import { pickAnvilOptions } from './util/anvil';
 import { doBuild } from './util/build';
-import { log, error, warn } from './util/console';
+import { error, log, warn } from './util/console';
 import { getContractsRecursive } from './util/contracts-recursive';
 import { parsePackageArguments, parsePackagesArguments } from './util/params';
 import {
   getChainIdFromProviderUrl,
   isURL,
   ProviderAction,
-  resolveProviderAndSigners,
   resolveProvider,
+  resolveProviderAndSigners,
 } from './util/provider';
 import { isPackageRegistered } from './util/register';
 import { writeModuleDeployments } from './util/write-deployments';


### PR DESCRIPTION
Closes https://linear.app/usecannon/issue/CAN-440/cannon-alter-packagename-set-contract-address-chain-id-xx-subpkg

This PR was used to debug the `set-contract-address` cannon command when editing subpackages.

1. ~~It adds the `--no-publish` flag to be able to test out new ipfs builds without having to publish to the registry~~
2. Rewrites the `set-contract-address` to make it more readable and make sure that only finds 1 step by the given name
3. Adds params validations in case of missing commands and some extra `debug` statements.