### PR TITLE
Add contract address for create2 on alter import

### DIFF
--- a/packages/builder/src/steps/deploy.ts
+++ b/packages/builder/src/steps/deploy.ts
@@ -412,13 +412,15 @@ const deploySpec = {
 
     const txn = await runtime.provider.getTransactionReceipt({ hash: existingKeys[0] as viem.Hash });
 
-    if (!txn.contractAddress) {
+    if (!txn.contractAddress && !txn.logs[0].address) {
       throw new Error('imported txn does not appear to deploy a contract');
     }
 
     const block = await runtime.provider.getBlock({ blockNumber: txn?.blockNumber });
 
-    return generateOutputs(config, ctx, artifactData, txn, block, txn.contractAddress!, packageState.currentLabel);
+    const contractAddress = txn.contractAddress || txn.logs[0].address;
+
+    return generateOutputs(config, ctx, artifactData, txn, block, contractAddress, packageState.currentLabel);
   },
 };
 


### PR DESCRIPTION
Currently the txn doesnt output the contract address when importing from a create2 txn, however the logs contain the address at which the contract was deployed to. Not sure if this is the way to go, looking into a way to extract the contract address from a create2 txn using viems `getContractAddress` function.

fixes https://linear.app/usecannon/issue/CAN-439/cannon-alter-import-with-create2-contract-fails-to-import