### PR TITLE
fix(website): publish utility was not loading package correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10211,7 +10211,6 @@
     },
     "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
       "version": "1.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/packages/builder/src/constants.ts
+++ b/packages/builder/src/constants.ts
@@ -1,5 +1,4 @@
 import Debug from 'debug';
-
 import { Address } from 'viem';
 
 const debug = Debug('cannon:builder:constants');

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -3,7 +3,7 @@
   "version": "2.15.5",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3001",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint --fix",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -3,7 +3,7 @@
   "version": "2.15.5",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "build": "next build",
     "start": "next start",
     "lint": "next lint --fix",

--- a/packages/website/src/features/Deploy/DisplayedTransaction.tsx
+++ b/packages/website/src/features/Deploy/DisplayedTransaction.tsx
@@ -57,7 +57,7 @@ export function DisplayedTransaction(props: {
   const chain = chainsById[props.chainId];
 
   const cannonInfo = useCannonPreloadedContracts(
-    props.pkgUrl ? '@' + props.pkgUrl.replace('://', ':') : '',
+    props.pkgUrl,
     props.cannonInfo,
     props.isPreloaded
   );

--- a/packages/website/src/features/Deploy/DisplayedTransaction.tsx
+++ b/packages/website/src/features/Deploy/DisplayedTransaction.tsx
@@ -1,3 +1,11 @@
+import { Alert } from '@/components/Alert';
+import { chainsById, getExplorerUrl } from '@/helpers/chains';
+import { formatToken } from '@/helpers/formatters';
+import {
+  ContractInfo,
+  useCannonPackageContracts,
+  UseCannonPackageContractsReturnType,
+} from '@/hooks/cannon';
 import {
   AlertDescription,
   Box,
@@ -15,20 +23,12 @@ import { a11yDark, CopyBlock } from 'react-code-blocks';
 import {
   bytesToString,
   decodeFunctionData,
+  DecodeFunctionDataReturnType,
   Hex,
   hexToBytes,
   TransactionRequestBase,
   trim,
-  DecodeFunctionDataReturnType,
 } from 'viem';
-import { chainsById, getExplorerUrl } from '@/helpers/chains';
-import { Alert } from '@/components/Alert';
-import {
-  ContractInfo,
-  useCannonPackageContracts,
-  UseCannonPackageContractsReturnType,
-} from '@/hooks/cannon';
-import { formatToken } from '@/helpers/formatters';
 
 const TxWrapper: FC<{ children: ReactNode }> = ({ children }) => (
   <Box p={6} border="1px solid" borderColor="gray.600" bgColor="black">

--- a/packages/website/src/features/Deploy/PublishUtility.tsx
+++ b/packages/website/src/features/Deploy/PublishUtility.tsx
@@ -53,7 +53,7 @@ export default function PublishUtility(props: {
     resolvedVersion,
     resolvedPreset,
     ipfsQuery: ipfsPkgQuery,
-  } = useCannonPackage(props.deployUrl.replace('ipfs://', '@ipfs:'));
+  } = useCannonPackage(props.deployUrl);
 
   // then reverse check the package referenced by the
   const {

--- a/packages/website/src/features/Deploy/PublishUtility.tsx
+++ b/packages/website/src/features/Deploy/PublishUtility.tsx
@@ -53,7 +53,7 @@ export default function PublishUtility(props: {
     resolvedVersion,
     resolvedPreset,
     ipfsQuery: ipfsPkgQuery,
-  } = useCannonPackage('@' + props.deployUrl.replace('://', ':'));
+  } = useCannonPackage(props.deployUrl.replace('ipfs://', '@ipfs:'));
 
   // then reverse check the package referenced by the
   const {
@@ -72,7 +72,7 @@ export default function PublishUtility(props: {
     resolvedVersion ? ':' + resolvedVersion : ''
   }${resolvedPreset ? '@' + resolvedPreset : ''}`;
 
-  const publishers = useCannonPackagePublishers(resolvedName!);
+  const publishers = useCannonPackagePublishers(resolvedName);
 
   const canPublish = publishers.some(
     ({ publisher }) =>

--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -708,7 +708,6 @@ function QueueFromGitOps() {
                 Transactions
               </Heading>
               <TransactionDisplay
-                packageRef={fullPackageRef}
                 safe={currentSafe as any}
                 safeTxn={stager.safeTxn}
               />

--- a/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
+++ b/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
@@ -409,7 +409,6 @@ function TransactionDetailsPage({
               gap={6}
             >
               <TransactionDisplay
-                packageRef={cannonPackage.fullPackageRef!}
                 safe={safe}
                 safeTxn={safeTxn as any}
                 queuedWithGitOps={queuedWithGitOps}

--- a/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
+++ b/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
@@ -165,11 +165,7 @@ function TransactionDetailsPage({
     void switchChain();
   }, [account.isConnected, currentSafe?.chainId]);
 
-  const cannonPackage = useCannonPackage(
-    hintData?.cannonPackage
-      ? `ipfs://${_.last(hintData?.cannonPackage.split('/'))}`
-      : ''
-  );
+  const cannonPackage = useCannonPackage(hintData?.cannonPackage);
 
   // then reverse check the package referenced by the
   const { pkgUrl: existingRegistryUrl } = useCannonPackage(

--- a/packages/website/src/features/Deploy/TransactionDisplay.tsx
+++ b/packages/website/src/features/Deploy/TransactionDisplay.tsx
@@ -39,7 +39,6 @@ const parseDiffFileNames = (diffString: string): string[] => {
 };
 
 export function TransactionDisplay(props: {
-  packageRef: string;
   safeTxn: SafeTransaction;
   safe: SafeDefinition;
   queuedWithGitOps?: boolean;
@@ -49,7 +48,7 @@ export function TransactionDisplay(props: {
 }) {
   const hintData = parseHintedMulticall(props.safeTxn?.data);
 
-  const cannonInfo = useCannonPackageContracts(props.packageRef);
+  const cannonInfo = useCannonPackageContracts(hintData?.cannonPackage);
 
   // git stuff
   const denom = hintData?.gitRepoUrl?.lastIndexOf(':');
@@ -293,7 +292,7 @@ export function TransactionDisplay(props: {
 
       <Box maxW="100%" overflowX="scroll">
         {hintData.txns.map((txn, i) => {
-          const pkgUrl = hintData.cannonPackage.split(',')[i];
+          const pkgUrl = hintData.cannonPackage;
           return (
             <Box key={`tx-${i}`} mb={8}>
               <DisplayedTransaction

--- a/packages/website/src/features/Deploy/TransactionDisplay.tsx
+++ b/packages/website/src/features/Deploy/TransactionDisplay.tsx
@@ -292,7 +292,8 @@ export function TransactionDisplay(props: {
 
       <Box maxW="100%" overflowX="scroll">
         {hintData.txns.map((txn, i) => {
-          const pkgUrl = hintData.cannonPackage;
+          const pkgUrl = hintData.cannonPackage.split(',')[i];
+
           return (
             <Box key={`tx-${i}`} mb={8}>
               <DisplayedTransaction

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -388,21 +388,22 @@ export function useCannonPackage(packageRef?: string, chainId?: number) {
     enabled: !!pkgUrl,
   });
 
-  const fullPackageRef = ipfsQuery.data?.fullPackageRef;
-
   const registryQueryMeta = useQuery({
-    queryKey: ['cannon', 'registry-meta', fullPackageRef, packageChainId],
+    queryKey: ['cannon', 'registry-meta', packageRef, packageChainId],
     queryFn: async () => {
-      if (typeof fullPackageRef !== 'string' || fullPackageRef.length < 3) {
+      if (typeof packageRef !== 'string' || packageRef.length < 3) {
         return null;
       }
 
-      const metaUrl = await registry.getMetaUrl(fullPackageRef, packageChainId);
+      if (packageRef.startsWith('ipfs://')) return { url: packageRef };
+      if (packageRef.startsWith('@ipfs:')) return { url: packageRef.replace('@ipfs:', 'ipfs://') };
+
+      const metaUrl = await registry.getMetaUrl(pkgUrl!, packageChainId);
 
       if (metaUrl) {
         return { metaUrl };
       } else {
-        throw new Error(`package not found: ${fullPackageRef} (${packageChainId})`);
+        throw new Error(`package not found: ${pkgUrl} (${packageChainId})`);
       }
     },
     refetchOnWindowFocus: false,
@@ -421,7 +422,7 @@ export function useCannonPackage(packageRef?: string, chainId?: number) {
     resolvedName: ipfsQuery.data?.resolvedName,
     resolvedVersion: ipfsQuery.data?.resolvedVersion,
     resolvedPreset: ipfsQuery.data?.resolvedPreset,
-    fullPackageRef,
+    fullPackageRef: ipfsQuery.data?.fullPackageRef,
   };
 }
 

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -322,7 +322,7 @@ export function useCannonWriteDeployToIpfs(
   };
 }
 
-export function useCannonPackage(packageRef: string, chainId?: number) {
+export function useCannonPackage(packageRef?: string, chainId?: number) {
   const connectedChainId = useChainId();
   const registry = useCannonRegistry();
   const settings = useStore((s) => s.settings);
@@ -444,7 +444,7 @@ function getContractsRecursive(outputs: ChainArtifacts, prefix?: string): Contra
   return contracts;
 }
 
-export function useCannonPackageContracts(packageRef: string, chainId?: number) {
+export function useCannonPackageContracts(packageRef?: string, chainId?: number) {
   const pkg = useCannonPackage(packageRef, chainId);
   const [contracts, setContracts] = useState<ContractInfo | null>(null);
   const settings = useStore((s) => s.settings);

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -388,22 +388,21 @@ export function useCannonPackage(packageRef?: string, chainId?: number) {
     enabled: !!pkgUrl,
   });
 
+  const fullPackageRef = ipfsQuery.data?.fullPackageRef;
+
   const registryQueryMeta = useQuery({
-    queryKey: ['cannon', 'registry-meta', packageRef, packageChainId],
+    queryKey: ['cannon', 'registry-meta', fullPackageRef, packageChainId],
     queryFn: async () => {
-      if (typeof packageRef !== 'string' || packageRef.length < 3) {
+      if (typeof fullPackageRef !== 'string' || fullPackageRef.length < 3) {
         return null;
       }
 
-      if (packageRef.startsWith('ipfs://')) return { url: packageRef };
-      if (packageRef.startsWith('@ipfs:')) return { url: packageRef.replace('@ipfs:', 'ipfs://') };
-
-      const metaUrl = await registry.getMetaUrl(pkgUrl!, packageChainId);
+      const metaUrl = await registry.getMetaUrl(fullPackageRef, packageChainId);
 
       if (metaUrl) {
         return { metaUrl };
       } else {
-        throw new Error(`package not found: ${pkgUrl} (${packageChainId})`);
+        return null;
       }
     },
     refetchOnWindowFocus: false,
@@ -422,7 +421,7 @@ export function useCannonPackage(packageRef?: string, chainId?: number) {
     resolvedName: ipfsQuery.data?.resolvedName,
     resolvedVersion: ipfsQuery.data?.resolvedVersion,
     resolvedPreset: ipfsQuery.data?.resolvedPreset,
-    fullPackageRef: ipfsQuery.data?.fullPackageRef,
+    fullPackageRef,
   };
 }
 

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -331,23 +331,26 @@ export function useCannonPackage(packageRef: string, chainId?: number) {
   const packageChainId = chainId ?? connectedChainId;
 
   const registryQuery = useQuery({
-    queryKey: ['cannon', 'registry', packageRef, packageChainId],
+    queryKey: ['cannon', 'registry-url', packageRef, packageChainId],
     queryFn: async () => {
-      if (!packageRef || packageRef.length < 3) {
+      if (typeof packageRef !== 'string' || packageRef.length < 3) {
         return null;
       }
 
+      if (packageRef.startsWith('ipfs://')) return { url: packageRef };
+      if (packageRef.startsWith('@ipfs:')) return { url: packageRef.replace('@ipfs:', 'ipfs://') };
+
       const url = await registry.getUrl(packageRef, packageChainId);
-      const metaUrl = await registry.getMetaUrl(packageRef, packageChainId);
 
       if (url) {
-        return { url, metaUrl };
+        return { url };
       } else {
         throw new Error(`package not found: ${packageRef} (${packageChainId})`);
       }
     },
     refetchOnWindowFocus: false,
   });
+
   const pkgUrl = registryQuery.data?.url;
 
   const ipfsQuery = useQuery({
@@ -385,20 +388,40 @@ export function useCannonPackage(packageRef: string, chainId?: number) {
     enabled: !!pkgUrl,
   });
 
+  const fullPackageRef = ipfsQuery.data?.fullPackageRef;
+
+  const registryQueryMeta = useQuery({
+    queryKey: ['cannon', 'registry-meta', fullPackageRef, packageChainId],
+    queryFn: async () => {
+      if (typeof fullPackageRef !== 'string' || fullPackageRef.length < 3) {
+        return null;
+      }
+
+      const metaUrl = await registry.getMetaUrl(fullPackageRef, packageChainId);
+
+      if (metaUrl) {
+        return { metaUrl };
+      } else {
+        throw new Error(`package not found: ${fullPackageRef} (${packageChainId})`);
+      }
+    },
+    refetchOnWindowFocus: false,
+  });
+
   return {
-    isLoading: registryQuery.isLoading || ipfsQuery.isLoading,
-    isFetching: registryQuery.isFetching || ipfsQuery.isFetching,
-    isError: registryQuery.isError || ipfsQuery.isError,
-    error: registryQuery.error || registryQuery.error,
+    isLoading: registryQuery.isLoading || ipfsQuery.isLoading || registryQueryMeta.isLoading,
+    isFetching: registryQuery.isFetching || ipfsQuery.isFetching || registryQueryMeta.isFetching,
+    isError: registryQuery.isError || ipfsQuery.isError || registryQueryMeta.isError,
+    error: registryQuery.error || registryQuery.error || registryQueryMeta.error,
     registryQuery,
     ipfsQuery,
     pkgUrl,
-    metaUrl: registryQuery.data?.metaUrl,
+    metaUrl: registryQueryMeta.data?.metaUrl,
     pkg: ipfsQuery.data?.deployInfo,
     resolvedName: ipfsQuery.data?.resolvedName,
     resolvedVersion: ipfsQuery.data?.resolvedVersion,
     resolvedPreset: ipfsQuery.data?.resolvedPreset,
-    fullPackageRef: ipfsQuery.data?.fullPackageRef,
+    fullPackageRef,
   };
 }
 

--- a/packages/website/src/hooks/registry.ts
+++ b/packages/website/src/hooks/registry.ts
@@ -9,22 +9,21 @@ type Publishers = {
   chainId: number;
 };
 
-export function useCannonPackagePublishers(packageName: string) {
+export function useCannonPackagePublishers(packageName?: string) {
   const [publishers, setPublishers] = useState<Publishers[]>([]);
 
   useEffect(() => {
-    const registryChainIds = DEFAULT_REGISTRY_CONFIG.map((registry) => registry.chainId);
+    if (!packageName) return setPublishers([]);
 
-    const onChainRegistries = registryChainIds.map(
-      (chainId: number) =>
-        new OnChainRegistry({
-          address: DEFAULT_REGISTRY_ADDRESS,
-          provider: viem.createPublicClient({
-            chain: findChain(chainId) as viem.Chain,
-            transport: viem.http(),
-          }) as any, // TODO: fix type
-        })
-    );
+    const onChainRegistries = DEFAULT_REGISTRY_CONFIG.map((config) => {
+      return new OnChainRegistry({
+        address: DEFAULT_REGISTRY_ADDRESS,
+        provider: viem.createPublicClient({
+          chain: findChain(config.chainId),
+          transport: viem.http(),
+        }) as any, // TODO: fix type
+      });
+    });
 
     const fetchPublishers = async () => {
       const [optimismRegistry, mainnetRegistry] = onChainRegistries;


### PR DESCRIPTION
This PR fixes a bug where the `PublishUtility` was trying to fetch the package ipfs url by ipfs url instead of package name. With this fix it just returns the given ipfs url and correctly resolves the `fullPackageRef` when necessary.