### PR TITLE
fix: Invalid import references

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -13,8 +13,8 @@ import {
   getOutputs,
   PackageReference,
   traceActions,
+  CannonSigner,
 } from '@usecannon/builder';
-import { CannonSigner } from '@usecannon/builder/src';
 import { bold, cyanBright, gray, green, magenta, red, yellow, yellowBright } from 'chalk';
 import _ from 'lodash';
 import { table } from 'table';

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -9,8 +9,8 @@ import {
   getOutputs,
   PackageReference,
   renderTrace,
+  TraceEntry
 } from '@usecannon/builder';
-import { TraceEntry } from '@usecannon/builder/src';
 import _ from 'lodash';
 import * as viem from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';

--- a/packages/cli/src/helpers.test.ts
+++ b/packages/cli/src/helpers.test.ts
@@ -1,5 +1,4 @@
 import * as viem from 'viem';
-import { InMemoryRegistry } from '@usecannon/builder/src';
 import {
   getContractsAndDetails,
   checkAndNormalizePrivateKey,
@@ -10,7 +9,7 @@ import {
   getChainName,
 } from './helpers';
 import { LocalRegistry } from './registry';
-import { ChainArtifacts, FallbackRegistry } from '@usecannon/builder';
+import { ChainArtifacts, FallbackRegistry, InMemoryRegistry } from '@usecannon/builder';
 
 describe('getChainId', getChainIdTestCases);
 describe('getChainName', getChainNameTestCases);

--- a/packages/cli/src/write-script/types.ts
+++ b/packages/cli/src/write-script/types.ts
@@ -1,9 +1,9 @@
 import type { ChainArtifacts } from '@usecannon/builder';
-import type { Config as StepDeploy } from '@usecannon/builder/src/steps/deploy';
-import type { Config as StepInvoke } from '@usecannon/builder/src/steps/invoke';
-import type { Config as StepRouter } from '@usecannon/builder/src/steps/router';
-import type { Config as StepPull } from '@usecannon/builder/src/steps/pull';
-import type { Config as StepClone } from '@usecannon/builder/src/steps/clone';
+import type { Config as StepDeploy } from '@usecannon/builder/dist/src/steps/deploy';
+import type { Config as StepInvoke } from '@usecannon/builder/dist/src/steps/invoke';
+import type { Config as StepRouter } from '@usecannon/builder/dist/src/steps/router';
+import type { Config as StepPull } from '@usecannon/builder/dist/src/steps/pull';
+import type { Config as StepClone } from '@usecannon/builder/dist/src/steps/clone';
 import * as viem from 'viem';
 
 type BaseDumpLine = {


### PR DESCRIPTION
Because code of `cli` references sources of `builder` instead of referencing compiled dist files tsc includes whole cannon source when compiling downstream projects and fails to build.


## Before
<img width="675" alt="image" src="https://github.com/user-attachments/assets/16794f79-5bd3-4fd1-a7cf-f138f5ad3b33">

## After
<img width="674" alt="image" src="https://github.com/user-attachments/assets/5d6dd1bc-3bcf-4f7a-90b2-df8934439dd9">
