### PR TITLE
fix(website): Fix unknown chain bug in package page

### DIFF
--- a/packages/website/src/helpers/chains.ts
+++ b/packages/website/src/helpers/chains.ts
@@ -72,7 +72,19 @@ const chainsById = Object.values(enrichedChainData).reduce((acc, chain) => {
   return acc;
 });
 
-export const getChainById = (chainId: number) => find(chains, (chain: ChainData) => chain.id === Number(chainId));
+export const getChainById = (chainId: number) => {
+  const chain = find(chains, (chain: ChainData) => chain.id === Number(chainId));
+
+  if (!chain) {
+    return {
+      id: chainId,
+      name: "Unknown Chain",
+      color: 'gray.600'
+    }
+  }
+
+  return chain;
+};
 
 export const getExplorerUrl = (chainId: number, hash: string) => {
   const chain = chainsById[chainId];

--- a/packages/website/src/helpers/chains.ts
+++ b/packages/website/src/helpers/chains.ts
@@ -78,9 +78,9 @@ export const getChainById = (chainId: number) => {
   if (!chain) {
     return {
       id: chainId,
-      name: "Unknown Chain",
-      color: 'gray.600'
-    }
+      name: 'Unknown Chain',
+      color: 'gray.600',
+    };
   }
 
   return chain;

--- a/packages/website/src/helpers/chains.ts
+++ b/packages/website/src/helpers/chains.ts
@@ -80,7 +80,7 @@ export const getChainById = (chainId: number) => {
       id: chainId,
       name: 'Unknown Chain',
       color: 'gray.600',
-    };
+    } as ChainData;
   }
 
   return chain;

--- a/packages/website/src/pages/packages/[name]/[tag]/[variant]/cannonfile/index.tsx
+++ b/packages/website/src/pages/packages/[name]/[tag]/[variant]/cannonfile/index.tsx
@@ -5,9 +5,7 @@ import { ReactElement } from 'react';
 import { NextSeo } from 'next-seo';
 import defaultSEO from '@/constants/defaultSeo';
 import { PackageReference } from '@usecannon/builder';
-import { ChainData } from '@/features/Search/PackageCard/Chain';
-import chains from '@/helpers/chains';
-import { find } from 'lodash';
+import { getChainById } from '@/helpers/chains';
 
 function generateMetadata({
   params,
@@ -15,13 +13,8 @@ function generateMetadata({
   params: { name: string; tag: string; variant: string };
 }) {
   const [chainId, preset] = PackageReference.parseVariant(params.variant);
-  const chain: { name: string; id: number } =
-    Number(chainId) == 13370
-      ? { id: 13370, name: 'Cannon' }
-      : (find(chains, (chain: ChainData) => chain.id === Number(chainId)) as {
-          name: string;
-          id: number;
-        });
+  const chain = getChainById(chainId);
+
 
   const title = `${params.name} on ${chain.name} | Cannon`;
 

--- a/packages/website/src/pages/packages/[name]/[tag]/[variant]/cannonfile/index.tsx
+++ b/packages/website/src/pages/packages/[name]/[tag]/[variant]/cannonfile/index.tsx
@@ -15,7 +15,6 @@ function generateMetadata({
   const [chainId, preset] = PackageReference.parseVariant(params.variant);
   const chain = getChainById(chainId);
 
-
   const title = `${params.name} on ${chain.name} | Cannon`;
 
   const description = `Cannon file for package ${params.name}${

--- a/packages/website/src/pages/packages/[name]/[tag]/[variant]/code/index.tsx
+++ b/packages/website/src/pages/packages/[name]/[tag]/[variant]/code/index.tsx
@@ -6,9 +6,7 @@ import NestedLayout from './_layout';
 import { NextSeo } from 'next-seo';
 import defaultSEO from '@/constants/defaultSeo';
 import { PackageReference } from '@usecannon/builder';
-import { ChainData } from '@/features/Search/PackageCard/Chain';
-import chains from '@/helpers/chains';
-import { find } from 'lodash';
+import { getChainById } from '@/helpers/chains';
 
 function generateMetadata({
   params,
@@ -16,13 +14,8 @@ function generateMetadata({
   params: { name: string; tag: string; variant: string };
 }) {
   const [chainId, preset] = PackageReference.parseVariant(params.variant);
-  const chain: { name: string; id: number } =
-    Number(chainId) == 13370
-      ? { id: 13370, name: 'Cannon' }
-      : (find(chains, (chain: ChainData) => chain.id === Number(chainId)) as {
-          name: string;
-          id: number;
-        });
+  const chain = getChainById(chainId);
+
 
   const title = `${params.name} on ${chain.name} | Cannon`;
 

--- a/packages/website/src/pages/packages/[name]/[tag]/[variant]/code/index.tsx
+++ b/packages/website/src/pages/packages/[name]/[tag]/[variant]/code/index.tsx
@@ -16,7 +16,6 @@ function generateMetadata({
   const [chainId, preset] = PackageReference.parseVariant(params.variant);
   const chain = getChainById(chainId);
 
-
   const title = `${params.name} on ${chain.name} | Cannon`;
 
   const description = `Explore the Cannon package code for ${params.name}${

--- a/packages/website/src/pages/packages/[name]/[tag]/[variant]/index.tsx
+++ b/packages/website/src/pages/packages/[name]/[tag]/[variant]/index.tsx
@@ -2,9 +2,7 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { NextSeo } from 'next-seo';
 import defaultSEO from '@/constants/defaultSeo';
-import chains from '@/helpers/chains';
-import { find } from 'lodash';
-import { ChainData } from '@/features/Search/PackageCard/Chain';
+import { getChainById } from '@/helpers/chains';
 import { PackageReference } from '@usecannon/builder';
 
 import TagVariantLayout from './_layout';
@@ -25,21 +23,12 @@ function generateMetadata({
   params: { name: string; tag: string; variant: string };
 }) {
   const [chainId, preset] = PackageReference.parseVariant(params.variant);
-  const chain: { name: string; id: number } =
-    Number(chainId) == 13370
-      ? { id: 13370, name: 'Cannon' }
-      : (find(chains, (chain: ChainData) => chain.id === Number(chainId)) as {
-          name: string;
-          id: number;
-        });
+  const chain = getChainById(chainId);
 
-  const title = `${params.name} on ${chain ? chain.name : 'chain'} | Cannon`;
+  const title = `${params.name} on ${chain.name} | Cannon`;
 
-  const description = `Explore the Cannon package for ${params.name}${
-    params.tag !== 'latest' ? `:${params.tag}` : ''
-  }${preset !== 'main' ? `@${preset}` : ''} on ${
-    chain ? chain.name : 'chain'
-  } (ID: ${chainId})`;
+  const description = `Explore the Cannon package for ${params.name}${params.tag !== 'latest' ? `:${params.tag}` : ''
+    }${preset !== 'main' ? `@${preset}` : ''} on ${chain.name} (ID: ${chainId})`;
 
   const metadata = {
     title,

--- a/packages/website/src/pages/packages/[name]/[tag]/[variant]/index.tsx
+++ b/packages/website/src/pages/packages/[name]/[tag]/[variant]/index.tsx
@@ -27,8 +27,9 @@ function generateMetadata({
 
   const title = `${params.name} on ${chain.name} | Cannon`;
 
-  const description = `Explore the Cannon package for ${params.name}${params.tag !== 'latest' ? `:${params.tag}` : ''
-    }${preset !== 'main' ? `@${preset}` : ''} on ${chain.name} (ID: ${chainId})`;
+  const description = `Explore the Cannon package for ${params.name}${
+    params.tag !== 'latest' ? `:${params.tag}` : ''
+  }${preset !== 'main' ? `@${preset}` : ''} on ${chain.name} (ID: ${chainId})`;
 
   const metadata = {
     title,

--- a/packages/website/src/pages/packages/[name]/[tag]/[variant]/interact/index.tsx
+++ b/packages/website/src/pages/packages/[name]/[tag]/[variant]/interact/index.tsx
@@ -18,13 +18,14 @@ function generateMetadata({
   preset: string;
 }) {
   const chain = getChainById(chainId);
-  if (!chain) throw new Error(`Chain with ID ${chainId} not found`);
 
-  const title = `${name} on ${chain.name} | Cannon`;
+  const title = `${name} on ${chain ? chain.name : 'Unknown Chain'} | Cannon`;
 
   const description = `Explore the Cannon package for ${name}${
     tag !== 'latest' ? `:${tag}` : ''
-  }${preset !== 'main' ? `@${preset}` : ''} on ${chain.name} (ID: ${chain.id})`;
+  }${preset !== 'main' ? `@${preset}` : ''} on ${
+    chain ? chain.name : 'Unknown Chain'
+  } (ID: ${chain ? chain.id : chainId})`;
 
   const metadata = {
     title,

--- a/packages/website/src/pages/packages/[name]/[tag]/[variant]/interact/index.tsx
+++ b/packages/website/src/pages/packages/[name]/[tag]/[variant]/interact/index.tsx
@@ -19,13 +19,10 @@ function generateMetadata({
 }) {
   const chain = getChainById(chainId);
 
-  const title = `${name} on ${chain ? chain.name : 'Unknown Chain'} | Cannon`;
+  const title = `${name} on ${chain.name}`;
 
-  const description = `Explore the Cannon package for ${name}${
-    tag !== 'latest' ? `:${tag}` : ''
-  }${preset !== 'main' ? `@${preset}` : ''} on ${
-    chain ? chain.name : 'Unknown Chain'
-  } (ID: ${chain ? chain.id : chainId})`;
+  const description = `Explore the Cannon package for ${name}${tag !== 'latest' ? `:${tag}` : ''
+    }${preset !== 'main' ? `@${preset}` : ''} on ${chain.name} (ID: ${chain.id})`;
 
   const metadata = {
     title,

--- a/packages/website/src/pages/packages/[name]/[tag]/[variant]/interact/index.tsx
+++ b/packages/website/src/pages/packages/[name]/[tag]/[variant]/interact/index.tsx
@@ -21,8 +21,9 @@ function generateMetadata({
 
   const title = `${name} on ${chain.name}`;
 
-  const description = `Explore the Cannon package for ${name}${tag !== 'latest' ? `:${tag}` : ''
-    }${preset !== 'main' ? `@${preset}` : ''} on ${chain.name} (ID: ${chain.id})`;
+  const description = `Explore the Cannon package for ${name}${
+    tag !== 'latest' ? `:${tag}` : ''
+  }${preset !== 'main' ? `@${preset}` : ''} on ${chain.name} (ID: ${chain.id})`;
 
   const metadata = {
     title,


### PR DESCRIPTION
When an unknown chain id is used in a package, we get an application error when trying to access that packages page on the web app.

Added a placeholder chain config so that when unknown chains are used, it defaults to that.