### PR TITLE
fix(builder): use `evm_setAccountCode` when loading precompiles

### DIFF
--- a/packages/builder/src/helpers.ts
+++ b/packages/builder/src/helpers.ts
@@ -65,7 +65,16 @@ export async function getCannonContract(args: {
 export async function loadPrecompiles(provider: viem.TestClient) {
   const precompiles = await import('./precompiles');
 
-  for (const precompileCall of precompiles.default) {
-    await provider.setCode(precompileCall);
+  for (const precompileCall of precompiles.default)
+    if (provider.mode === 'ganache') {
+      await provider.request({
+        // @ts-ignore: evm_setAccountCode is not currently implemented in Viem.
+        method: 'evm_setAccountCode',
+        params: [precompileCall.address, precompileCall.bytecode]
+      });
+    } else {
+      await provider.setCode(precompileCall);
+    }
+
   }
 }

--- a/packages/builder/src/helpers.ts
+++ b/packages/builder/src/helpers.ts
@@ -70,11 +70,9 @@ export async function loadPrecompiles(provider: viem.TestClient) {
       await provider.request({
         // @ts-ignore: evm_setAccountCode is not currently implemented in Viem.
         method: 'evm_setAccountCode',
-        params: [precompileCall.address, precompileCall.bytecode]
+        params: [precompileCall.address, precompileCall.bytecode],
       });
     } else {
       await provider.setCode(precompileCall);
     }
-
-  }
 }


### PR DESCRIPTION
Viem currently does not have implemented the `evm_setAccountCode` method. I have added this code as a workaround to make it work on the website where we're using Ganache.