### PR TITLE
fix(website): CAN-374 stage TX with value

### DIFF
--- a/packages/website/src/helpers/multisend.ts
+++ b/packages/website/src/helpers/multisend.ts
@@ -9,9 +9,7 @@ export function makeMultisend(txns: Partial<TransactionRequestBase>[]): {
   value: string;
   data: Hex;
 } {
-  const totalValue = txns.reduce((val, txn) => {
-    return val + (txn.value || BigInt(0));
-  }, BigInt(0));
+  const totalValue = txns.reduce((val, txn) => val + (txn.value || BigInt(0)), BigInt(0));
 
   return {
     operation: '1', // multicall is a DELEGATECALL

--- a/packages/website/src/hooks/backend.ts
+++ b/packages/website/src/hooks/backend.ts
@@ -222,7 +222,7 @@ export function useTxnStager(
     functionName: 'execTransaction',
     args: [
       safeTxn.to,
-      Number(safeTxn.value).toString() || '0',
+      BigInt(safeTxn.value.toString() || '0'),
       safeTxn.data,
       safeTxn.operation,
       safeTxn.safeTxGas,


### PR DESCRIPTION
Closes [CAN-374.](https://linear.app/usecannon/issue/CAN-374/address-assorted-web-app-concerns)

Fixes an issue on interact section. When a tx was staged with a value like 2222^18 it was failing becuase the value (most of the times passed as string) was converted to Number instead of a BigInt.