### PR TITLE
fix(website): Interact throws an error when contracts cannot be found

### DIFF
--- a/packages/website/src/features/Packages/Tabs/InteractTab.tsx
+++ b/packages/website/src/features/Packages/Tabs/InteractTab.tsx
@@ -114,8 +114,6 @@ export const InteractTab: FC<{
 
     const cannonOutputs: ChainArtifacts = getOutput(deploymentData.data);
 
-    console.log('cannonOutputs: ', cannonOutputs);
-
     if (cannonOutputs.contracts) {
       processContracts(cannonOutputs.contracts, name);
     }


### PR DESCRIPTION
Interact page is throwing an unexpected error for Infinex Core Test package: 

<img width="1512" alt="Screenshot 2024-08-21 at 11 19 08 AM" src="https://github.com/user-attachments/assets/a6b077d5-887b-4144-a889-f93f091f37b6">
