### PR TITLE
fix(cli): normalize pk when prompted

### DIFF
--- a/packages/cli/src/util/provider.ts
+++ b/packages/cli/src/util/provider.ts
@@ -266,7 +266,7 @@ export async function resolveProviderAndSigners({
           });
 
           if (keyPrompt.value) {
-            const account = privateKeyToAccount(keyPrompt.value as viem.Hex);
+            const account = privateKeyToAccount(normalizePrivateKey(keyPrompt.value as viem.Hex));
 
             signers.push({
               address: account.address,


### PR DESCRIPTION
When the private key is prompted, it currently isn't being normalized. As a result, private keys without the 0x prefix are not working correctly. This issue does not affect the flag or environment variable.