### PR TITLE
fix: a number of issues with cannon settings handling

### DIFF
--- a/packages/builder/src/constants.ts
+++ b/packages/builder/src/constants.ts
@@ -8,17 +8,19 @@ export const BUILD_VERSION = 7;
 
 // Production settings (OP Mainnet & ETH Mainnet)
 export const DEFAULT_REGISTRY_ADDRESS: Address = '0x8E5C7EFC9636A6A0408A46BB7F617094B81e5dba';
+
+// the below RPC configuration is our public infura, but it only allows for requests against the cannon registry contract
 export const DEFAULT_REGISTRY_CONFIG = [
   {
     name: 'OP Mainnet',
     chainId: 10,
-    rpcUrl: ['frame', 'direct', 'https://optimism.llamarpc.com'],
+    rpcUrl: ['frame', 'direct', 'https://optimism-mainnet.infura.io/v3/831b4daacdb44a28ba250505347cbeb4'],
     address: DEFAULT_REGISTRY_ADDRESS,
   },
   {
     name: 'Ethereum Mainnet',
     chainId: 1,
-    rpcUrl: ['frame', 'direct', 'https://eth.llamarpc.com'],
+    rpcUrl: ['frame', 'direct', 'https://mainnet.infura.io/v3/831b4daacdb44a28ba250505347cbeb4'],
     address: DEFAULT_REGISTRY_ADDRESS,
   },
 ];

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -14,15 +14,15 @@ export async function setup() {
   // Setup Anvil
   await setupAnvil();
 
-  const settings = resolveCliSettings();
-  const cliSettingsStore = untildify(path.join(settings.cannonDirectory, CLI_SETTINGS_STORE));
-
   // Exit if settings is already configured
-  if (settings.cannonSettings) {
+  if (process.env.CANNON_SETTINGS) {
     log('Your Cannon settings are being explicitly defined as follows:');
-    log(JSON.stringify(settings.cannonSettings));
+    log(JSON.stringify(process.env.CANNON_SETTINGS));
     return;
   }
+
+  const settings = resolveCliSettings();
+  const cliSettingsStore = untildify(path.join(settings.cannonDirectory, CLI_SETTINGS_STORE));
   log('Cannon’s settings are optional. They can be defined in a JSON file and overridden with environment variables.\n');
   log(`This will update your settings stored in ${cliSettingsStore}`);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -398,8 +398,10 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
     options.chainId = chainIdPrompt.value;
   }
 
-  const isDefaultSettings = _.isEqual(cliSettings.registries, DEFAULT_REGISTRY_CONFIG);
-  if (!isDefaultSettings) throw new Error('Only default registries are supported for now');
+  const isDefaultRegistryChains =
+    cliSettings.registries[0].chainId === DEFAULT_REGISTRY_CONFIG[0].chainId &&
+    cliSettings.registries[1].chainId === DEFAULT_REGISTRY_CONFIG[1].chainId;
+  if (!isDefaultRegistryChains) throw new Error('Only default registries are supported for now');
 
   // mock provider urls when the execution comes from e2e tests
   if (cliSettings.isE2E) {

--- a/packages/cli/src/settings.test.ts
+++ b/packages/cli/src/settings.test.ts
@@ -1,0 +1,158 @@
+import { CliSettings, resolveCliSettingsNoCache as resolveCliSettings } from './settings';
+
+describe('settings.ts', () => {
+  describe('resolveCliSettings()', () => {
+    beforeEach(() => {
+      //jest.resetModules();
+      process.env = {};
+    });
+
+    it('should use default values when no overrides or environment variables are provided', () => {
+      const settings = resolveCliSettings();
+      expect(settings.cannonDirectory).toContain('.local/share/cannon');
+      expect(settings.rpcUrl).toBe('frame,direct');
+      expect(settings.ipfsTimeout).toBe(300000);
+      expect(settings.ipfsRetries).toBe(3);
+      expect(settings.registryPriority).toBe('onchain');
+      expect(settings.quiet).toBe(false);
+      expect(settings.trace).toBe(false);
+    });
+
+    it('should use environment variables when provided', () => {
+      process.env.CANNON_DIRECTORY = '/custom/path';
+      process.env.CANNON_RPC_URL = 'https://custom.rpc.url';
+      process.env.CANNON_IPFS_TIMEOUT = '60000';
+      process.env.CANNON_REGISTRY_PRIORITY = 'local';
+      process.env.CANNON_QUIET = 'true';
+
+      const settings = resolveCliSettings();
+      expect(settings.cannonDirectory).toBe('/custom/path');
+      expect(settings.rpcUrl).toBe('https://custom.rpc.url');
+      expect(settings.ipfsTimeout).toBe(60000);
+      expect(settings.registryPriority).toBe('local');
+      expect(settings.quiet).toBe(true);
+    });
+
+    it('should use overrides when provided', () => {
+      const overrides = {
+        rpcUrl: 'https://override.rpc.url',
+        ipfsRetries: 5,
+        registryPriority: 'offline' as const,
+        trace: true,
+      };
+
+      const settings = resolveCliSettings(overrides);
+      expect(settings.rpcUrl).toBe('https://override.rpc.url');
+      expect(settings.ipfsRetries).toBe(5);
+      expect(settings.registryPriority).toBe('offline');
+      expect(settings.trace).toBe(true);
+    });
+
+    it('should handle custom registry settings', () => {
+      process.env.CANNON_REGISTRY_ADDRESS = '0x1234567890123456789012345678901234567890';
+      process.env.CANNON_REGISTRY_RPC_URL = 'https://custom.registry.rpc';
+      process.env.CANNON_REGISTRY_CHAIN_ID = '1337';
+
+      const settings = resolveCliSettings();
+      expect(settings.registries).toEqual([
+        {
+          name: 'Custom Network',
+          rpcUrl: ['https://custom.registry.rpc'],
+          chainId: 1337,
+          address: '0x1234567890123456789012345678901234567890',
+        },
+      ]);
+    });
+
+    it('should handle deprecated providerUrl override', () => {
+      const overrides = {
+        providerUrl: 'https://deprecated.provider.url',
+      };
+
+      const settings = resolveCliSettings(overrides);
+      expect(settings.rpcUrl).toBe('https://deprecated.provider.url');
+    });
+
+    it('should normalize private key', () => {
+      process.env.CANNON_PRIVATE_KEY = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+
+      const settings = resolveCliSettings();
+      expect(settings.privateKey).toBe('0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef');
+
+      process.env.CANNON_PRIVATE_KEY = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+
+      const settings2 = resolveCliSettings();
+      expect(settings2.privateKey).toBe('0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef');
+    });
+
+    it('should use CANNON_SETTINGS when provided', () => {
+      const customSettings: CliSettings = {
+        cannonDirectory: '/custom/cannon/directory',
+        rpcUrl: 'https://custom.rpc.url',
+        privateKey: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        ipfsTimeout: 60000,
+        ipfsRetries: 10,
+        ipfsUrl: 'https://custom.ipfs.url',
+        writeIpfsUrl: 'https://custom.write.ipfs.url',
+        publishIpfsUrl: 'https://custom.publish.ipfs.url',
+        registries: [
+          {
+            name: 'Custom Registry',
+            chainId: 1337,
+            rpcUrl: ['https://custom.registry.rpc'],
+            address: '0x1234567890123456789012345678901234567890'
+          }
+        ],
+        registryPriority: 'local' as const,
+        etherscanApiUrl: 'https://custom.etherscan.api',
+        etherscanApiKey: 'customEtherscanApiKeyxxxxxxxxxxxxx',
+        quiet: true,
+        trace: false,
+        isE2E: false
+      };
+      process.env.CANNON_SETTINGS = JSON.stringify(customSettings);
+
+      const settings = resolveCliSettings();
+      expect(settings).toEqual(expect.objectContaining(customSettings));
+
+      delete process.env.CANNON_SETTINGS;
+    });
+
+    it('should prioritize environment variables over CANNON_SETTINGS', () => {
+      const customSettings: Partial<CliSettings> = {
+        rpcUrl: 'https://custom.rpc.url',
+        ipfsRetries: 10
+      };
+      process.env.CANNON_SETTINGS = JSON.stringify(customSettings);
+      process.env.CANNON_RPC_URL = 'https://env.rpc.url';
+      process.env.CANNON_IPFS_RETRIES = '5';
+
+      const settings = resolveCliSettings();
+      expect(settings.rpcUrl).toBe('https://env.rpc.url');
+      expect(settings.ipfsRetries).toBe(5);
+
+      delete process.env.CANNON_SETTINGS;
+      delete process.env.CANNON_RPC_URL;
+      delete process.env.CANNON_IPFS_RETRIES;
+    });
+
+    it('should allow overrides to take precedence over CANNON_SETTINGS', () => {
+      const customSettings: Partial<CliSettings> = {
+        rpcUrl: 'https://custom.rpc.url',
+        ipfsRetries: 10
+      };
+      process.env.CANNON_SETTINGS = JSON.stringify(customSettings);
+
+      const overrides = {
+        rpcUrl: 'https://override.rpc.url',
+        ipfsRetries: 15
+      };
+
+      const settings = resolveCliSettings(overrides);
+      expect(settings.rpcUrl).toBe('https://override.rpc.url');
+      expect(settings.ipfsRetries).toBe(15);
+
+      delete process.env.CANNON_SETTINGS;
+    });
+  });
+});

--- a/packages/cli/src/settings.test.ts
+++ b/packages/cli/src/settings.test.ts
@@ -100,15 +100,15 @@ describe('settings.ts', () => {
             name: 'Custom Registry',
             chainId: 1337,
             rpcUrl: ['https://custom.registry.rpc'],
-            address: '0x1234567890123456789012345678901234567890'
-          }
+            address: '0x1234567890123456789012345678901234567890',
+          },
         ],
         registryPriority: 'local' as const,
         etherscanApiUrl: 'https://custom.etherscan.api',
         etherscanApiKey: 'customEtherscanApiKeyxxxxxxxxxxxxx',
         quiet: true,
         trace: false,
-        isE2E: false
+        isE2E: false,
       };
       process.env.CANNON_SETTINGS = JSON.stringify(customSettings);
 
@@ -121,7 +121,7 @@ describe('settings.ts', () => {
     it('should prioritize environment variables over CANNON_SETTINGS', () => {
       const customSettings: Partial<CliSettings> = {
         rpcUrl: 'https://custom.rpc.url',
-        ipfsRetries: 10
+        ipfsRetries: 10,
       };
       process.env.CANNON_SETTINGS = JSON.stringify(customSettings);
       process.env.CANNON_RPC_URL = 'https://env.rpc.url';
@@ -139,13 +139,13 @@ describe('settings.ts', () => {
     it('should allow overrides to take precedence over CANNON_SETTINGS', () => {
       const customSettings: Partial<CliSettings> = {
         rpcUrl: 'https://custom.rpc.url',
-        ipfsRetries: 10
+        ipfsRetries: 10,
       };
       process.env.CANNON_SETTINGS = JSON.stringify(customSettings);
 
       const overrides = {
         rpcUrl: 'https://override.rpc.url',
-        ipfsRetries: 15
+        ipfsRetries: 15,
       };
 
       const settings = resolveCliSettings(overrides);

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -207,8 +207,6 @@ function _resolveCliSettings(overrides: Partial<CliSettings> = {}): CliSettings 
     fileSettings = fs.existsSync(cliSettingsStore) ? fs.readJsonSync(cliSettingsStore) : {};
   }
 
-  console.log('my process env', process.env.CANNON_DIRECTORY);
-
   const {
     CANNON_DIRECTORY,
     CANNON_PROVIDER_URL,


### PR DESCRIPTION
* fix settings to be able to load registry settings from file successfully
* add tests to verify that file settings, env settings, and their interplay work as expected
* updates the builder constants to use our own infura service (the infura is gated to only accept requests relating to our registry contracts and no others)