### PR TITLE
fix(builder): Error passthrough on rpc errors

### DIFF
--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -138,7 +138,7 @@ export class FallbackRegistry extends EventEmitter implements CannonRegistry {
       debug('trying registry', registry.getLabel());
       try {
         const result = await registry.getUrl(packageRef, chainId);
-        
+
         if (result) {
           debug('fallback registry: loaded from registry', registry.getLabel());
           await this.emit('getPackageUrl', { fullPackageRef, chainId, result, registry, fallbackRegistry: this });
@@ -152,7 +152,7 @@ export class FallbackRegistry extends EventEmitter implements CannonRegistry {
               `you can verify this if you have access to the node logs. \n\n ${err} \n ${err.error}`
           );
         }
-        
+
         throw new Error(err);
       }
     }
@@ -179,7 +179,7 @@ export class FallbackRegistry extends EventEmitter implements CannonRegistry {
               `you can verify this if you have access to the node logs. \n\n ${err} \n ${err.error}`
           );
         }
-        
+
         throw new Error(err);
       }
     }

--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -138,7 +138,7 @@ export class FallbackRegistry extends EventEmitter implements CannonRegistry {
       debug('trying registry', registry.getLabel());
       try {
         const result = await registry.getUrl(packageRef, chainId);
-
+        
         if (result) {
           debug('fallback registry: loaded from registry', registry.getLabel());
           await this.emit('getPackageUrl', { fullPackageRef, chainId, result, registry, fallbackRegistry: this });
@@ -152,6 +152,8 @@ export class FallbackRegistry extends EventEmitter implements CannonRegistry {
               `you can verify this if you have access to the node logs. \n\n ${err} \n ${err.error}`
           );
         }
+        
+        throw new Error(err);
       }
     }
 
@@ -177,6 +179,8 @@ export class FallbackRegistry extends EventEmitter implements CannonRegistry {
               `you can verify this if you have access to the node logs. \n\n ${err} \n ${err.error}`
           );
         }
+        
+        throw new Error(err);
       }
     }
 


### PR DESCRIPTION
Any errors that happen while trying to communicate with the RPC during read operations on optimism were being skipped, which is why the fallback registry would try mainnet even though it may result in fetching the wrong package info.

Adding a throw statement resulted in the RPC error being thrown when a read operation fails due to an RPC issue. 

fixes https://linear.app/usecannon/issue/CAN-470/differentiate-errors-better-on-the-fallback-registry


Examples:

Package only on Ethereum mainnet throws rpc error if there is one:
https://www.loom.com/share/bfea17e267f4436395dcdac94e2afd9d

Package only on Ethereum mainnet throws rpc error if there is one:
https://www.loom.com/share/393264be32cd44bcbb499e800521d0aa

Package on both networks does not fall back to eth mainnet if theres an rpc error: 
https://www.loom.com/share/e064960836264851aa8ffe63f1ab3dd2

Ive confirmed that all the packages are resolved correctly and the fallback behaviour now works ONLY if the package is not found (aka returns empty string)
