### PR TITLE
fix(website): Add null check to variable on txn display

### DIFF
--- a/packages/website/src/features/Deploy/DisplayedTransaction.tsx
+++ b/packages/website/src/features/Deploy/DisplayedTransaction.tsx
@@ -100,7 +100,7 @@ export function DisplayedTransaction(props: {
     for (const n of parsedContractNames) {
       try {
         decodedFunctionData = decodeFunctionData({
-          abi: contracts[n].abi,
+          abi: contracts[n]?.abi,
           data: props.txn?.data || '0x',
         });
         contractName = n;
@@ -117,7 +117,7 @@ export function DisplayedTransaction(props: {
   const functionArgs = decodedFunctionData?.args?.map((v) => v) || [
     rawFunctionArgs,
   ];
-  const functionFragmentsFromAbi = contracts?.[contractName].abi.filter(
+  const functionFragmentsFromAbi = contracts?.[contractName]?.abi.filter(
     (f) => 'name' in f && f.name === functionName
   );
   const functionFragmentFromAbi = functionFragmentsFromAbi?.find(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e679e609-b092-4550-936a-7c77788f23c9)

The error above was ocurring because the contract name lookup on the `contracts`  array inside `DisplayedTransaction.tsx` didnt have a null check.