### PR TITLE
fix(inspect): debug info

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix:sol": "prettier --write '{packages,examples}/*/{contracts,src}/**/*.sol'",
     "lint:fix": "pnpm run '/^lint:fix:(js|sol)/'",
     "build": "pnpm -r --filter @usecannon/builder --filter @usecannon/cli --filter hardhat-cannon --filter @usecannon/api run build",
+    "watch": "pnpm -r --parallel --filter @usecannon/builder --filter @usecannon/cli run watch",
     "version-alpha": "lerna version prerelease --no-private",
     "version-patch": "lerna version patch --no-private",
     "version-minor": "lerna version minor --no-private",

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -1,15 +1,23 @@
+import {
+  ChainArtifacts,
+  ChainDefinition,
+  ContractData,
+  DeploymentState,
+  fetchIPFSAvailability,
+  PackageReference,
+} from '@usecannon/builder';
+import { bold, cyan, green, yellow } from 'chalk';
+import Debug from 'debug';
+import fs from 'fs-extra';
 import _ from 'lodash';
 import path from 'path';
-import fs from 'fs-extra';
-import { bold, cyan, green, yellow } from 'chalk';
-import { PackageReference } from '@usecannon/builder';
-import { fetchIPFSAvailability } from '@usecannon/builder';
-import { ContractData, ChainArtifacts, ChainDefinition, DeploymentState } from '@usecannon/builder';
+import { getContractsAndDetails, getSourceFromRegistry } from '../helpers';
 import { getMainLoader } from '../loader';
 import { createDefaultReadRegistry } from '../registry';
 import { CliSettings } from '../settings';
 import { log, warn } from '../util/console';
-import { getContractsAndDetails, getSourceFromRegistry } from '../helpers';
+
+const debug = Debug('cannon:cli:inspect');
 
 export async function inspect(
   packageRef: string,
@@ -51,6 +59,15 @@ export async function inspect(
       Specify the --chain-id parameter to retrieve the addresses/ABIs for other deployments."
       )
     );
+  }
+
+  // Mute all build outputs when printing the result to json, this is so it
+  // doesn't break the result.
+  if (json) {
+    // eslint-disable-next-line no-console
+    console.log = debug;
+    // eslint-disable-next-line no-console
+    console.debug = debug;
   }
 
   const deployData = await loader[deployUrl.split(':')[0] as 'ipfs'].read(deployUrl);


### PR DESCRIPTION
closes https://linear.app/usecannon/issue/CAN-457/cannon-inspect-has-an-extraneous-log

This PR makes sure that the build is not generating any extraneous logs when running `cannon inspect --json`, as the only expected output should be the JSON result.

Nevertheless, debug logs can still be used with:
```
DEBUG=cannon:cli:inspect dcannon inspect ...
```