### PR TITLE
fix(website): Display all contracts in a package in deployments tab

### DIFF
--- a/packages/website/src/features/Packages/DeploymentExplorer.tsx
+++ b/packages/website/src/features/Packages/DeploymentExplorer.tsx
@@ -2,12 +2,12 @@ import 'prismjs';
 import 'prismjs/components/prism-toml';
 
 import React, { FC } from 'react';
-import { Box, Collapse, Flex, Heading, Link, Text, Tooltip } from '@chakra-ui/react';
+import { Box, Flex, Heading, Link, Text, Tooltip } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import { links } from '@/constants/links';
 import { CustomSpinner } from '@/components/CustomSpinner';
 import { DeploymentInfo } from '@usecannon/builder/src/types';
-import { InfoIcon, ChevronDownIcon } from '@chakra-ui/icons';
+import { InfoIcon } from '@chakra-ui/icons';
 import { ChainBuilderContext } from '@usecannon/builder';
 import { isEmpty } from 'lodash';
 import { useQueryIpfsDataParsed } from '@/hooks/ipfs';
@@ -20,10 +20,6 @@ import { ApiPackage } from '@usecannon/api/dist/src/types';
 export const DeploymentExplorer: FC<{
   pkg: ApiPackage;
 }> = ({ pkg }) => {
-  const [show, setShow] = React.useState(false);
-
-  const handleToggle = () => setShow(!show);
-
   const deploymentData = useQueryIpfsDataParsed<DeploymentInfo>(
     pkg?.deployUrl,
     !!pkg?.deployUrl
@@ -51,7 +47,7 @@ export const DeploymentExplorer: FC<{
     for (const key in obj) {
       if (obj[key] && typeof obj[key] === 'object') {
         // If the current object has both address and abi keys
-        if ((obj[key].address && obj[key].abi)) {
+        if (obj[key].address && obj[key].abi) {
           if (
             obj[key].deployedOn.startsWith('deploy') ||
             obj[key].deployedOn.startsWith('contract') ||
@@ -63,23 +59,29 @@ export const DeploymentExplorer: FC<{
             obj[key].deployedOn.includes('pull') ||
             obj[key].deployedOn.includes('run')
           ) {
-            mergedContracts[obj[key].contractName || '⚠ Unknown Contract Name'] = obj[key];
+            mergedContracts[
+              obj[key].contractName || '⚠ Unknown Contract Name'
+            ] = obj[key];
           }
         }
 
         if (obj[key].artifacts && obj[key].artifacts.imports) {
-          for (let k in obj[key].artifacts.imports[key.split('.')[1]].contracts) {
+          for (const k in obj[key].artifacts.imports[key.split('.')[1]]
+            .contracts) {
             if (
               key.includes('provision') ||
               key.includes('clone') ||
               key.includes('import') ||
               key.includes('pull')
             ) {
-              obj[key].artifacts.imports[key.split('.')[1]].contracts[k].deployedOn = key;
+              obj[key].artifacts.imports[key.split('.')[1]].contracts[
+                k
+              ].deployedOn = key;
 
               // Change deployedOn title to parent package
-              mergedContracts[obj[key].contractName || '⚠ Unknown Contract Name'] = obj[key].artifacts.imports[key.split('.')[1]].contracts[k];
-
+              mergedContracts[
+                obj[key].contractName || '⚠ Unknown Contract Name'
+              ] = obj[key].artifacts.imports[key.split('.')[1]].contracts[k];
             }
           }
         }
@@ -95,7 +97,6 @@ export const DeploymentExplorer: FC<{
   const contractState: ChainBuilderContext['contracts'] = deploymentInfo?.state
     ? mergeArtifactsContracts(deploymentInfo.state)
     : {};
-
 
   function mergeInvoke(obj: any, mergedInvokes: any = {}): any {
     for (const key in obj) {

--- a/packages/website/src/features/Packages/DeploymentExplorer.tsx
+++ b/packages/website/src/features/Packages/DeploymentExplorer.tsx
@@ -103,25 +103,27 @@ export const DeploymentExplorer: FC<{
   // Filter and sort based on search term
   const contractEntries = Object.entries(contractState);
   const sortedEntries = contractEntries
-    .filter(([key, user]) =>
-      Object.values(user).some(value =>
-        typeof value === 'string' && value.includes(searchTerm)
+    .filter(([, user]) =>
+      Object.values(user).some(
+        (value) => typeof value === 'string' && value.includes(searchTerm)
       )
     )
-    .sort(([keyA, userA], [keyB, userB]) => {
+    .sort(([, userA], [, userB]) => {
       // Calculate match scores based on search term position
       const scoreA = Math.min(
-        ...Object.values(userA).filter(v => typeof v === 'string').map(v => (v as string).indexOf(searchTerm))
+        ...Object.values(userA)
+          .filter((v) => typeof v === 'string')
+          .map((v) => (v as string).indexOf(searchTerm))
       );
       const scoreB = Math.min(
-        ...Object.values(userB).filter(v => typeof v === 'string').map(v => (v as string).indexOf(searchTerm))
+        ...Object.values(userB)
+          .filter((v) => typeof v === 'string')
+          .map((v) => (v as string).indexOf(searchTerm))
       );
       return scoreA - scoreB;
     });
 
   const filteredContractState = Object.fromEntries(sortedEntries);
-
-  console.log(filteredContractState)
 
   function mergeInvoke(obj: any, mergedInvokes: any = {}): any {
     for (const key in obj) {
@@ -200,13 +202,18 @@ export const DeploymentExplorer: FC<{
         </Box>
       ) : deploymentInfo ? (
         <Box>
-          <Flex p={6} mb={1} justifyContent={'space-between'} direction={['column', 'column', 'row']}>
+          <Flex
+            p={6}
+            mb={1}
+            justifyContent={'space-between'}
+            direction={['column', 'column', 'row']}
+          >
             <Heading size="md">Contract Deployments</Heading>
             <Box>
               <SearchInput onSearchChange={setSearchTerm}></SearchInput>
             </Box>
           </Flex>
-          {(!isEmpty(filteredContractState)) && !isEmpty(addressesAbis) ? (
+          {!isEmpty(filteredContractState) && !isEmpty(addressesAbis) ? (
             <Box mt={2}>
               <Box maxW="100%" overflowX="auto">
                 <ContractsTable
@@ -217,8 +224,13 @@ export const DeploymentExplorer: FC<{
             </Box>
           ) : (
             <Box mt={6}>
-              <Flex px={4} mb={3} justifyContent={'center'} direction={['column', 'column', 'row']}>
-                <Heading size='sm'> No Contracts Found</Heading>
+              <Flex
+                px={4}
+                mb={3}
+                justifyContent={'center'}
+                direction={['column', 'column', 'row']}
+              >
+                <Heading size="sm"> No Contracts Found</Heading>
               </Flex>
             </Box>
           )}
@@ -256,9 +268,8 @@ export const DeploymentExplorer: FC<{
         <Box textAlign="center" py="20" opacity="0.5">
           Unable to retrieve deployment data
         </Box>
-      )
-      }
-    </Box >
+      )}
+    </Box>
   ) : (
     <Box textAlign="center" py="20" opacity="0.5">
       No metadata is associated with this package

--- a/packages/website/src/features/Packages/DeploymentExplorer.tsx
+++ b/packages/website/src/features/Packages/DeploymentExplorer.tsx
@@ -38,7 +38,6 @@ export const DeploymentExplorer: FC<{
   const handleContractCollapse = () => setShowContracts(!showContracts);
   const handleInvokeCollapse = () => setShowInvoke(!showInvoke);
 
-
   const deploymentData = useQueryIpfsDataParsed<DeploymentInfo>(
     pkg?.deployUrl,
     !!pkg?.deployUrl
@@ -80,7 +79,7 @@ export const DeploymentExplorer: FC<{
         // If the current object has both address and abi keys
         if (obj[key].address && obj[key].abi) {
           if (
-            stepDefinitions.some(step => obj[key].deployedOn.includes(step))
+            stepDefinitions.some((step) => obj[key].deployedOn.includes(step))
           ) {
             mergedContracts[
               obj[key].contractName || '⚠ Unknown Contract Name'
@@ -92,7 +91,8 @@ export const DeploymentExplorer: FC<{
         if (obj[key].artifacts && obj[key].artifacts.imports) {
           const step = key.split('.')[1];
           for (const contract in obj[key].artifacts.imports[step].contracts) {
-            obj[key].artifacts.imports[step].contracts[contract].deployedOn = key;
+            obj[key].artifacts.imports[step].contracts[contract].deployedOn =
+              key;
 
             // Change deployedOn title to parent package
             mergedContracts[
@@ -124,7 +124,9 @@ export const DeploymentExplorer: FC<{
       )
       .filter(([, val]) =>
         Object.values(val).some(
-          (v) => typeof v === 'string' && v.toLowerCase().includes(contractSearchTerm.toLowerCase())
+          (v) =>
+            typeof v === 'string' &&
+            v.toLowerCase().includes(contractSearchTerm.toLowerCase())
         )
       )
   );
@@ -151,11 +153,15 @@ export const DeploymentExplorer: FC<{
     : {};
 
   const invokeEntries = Object.entries(invokeState);
-  const filteredInvokeState = Object.fromEntries(invokeEntries.filter(([, func]) =>
-    Object.values(func).some(
-      (value) => typeof value === 'string' && value.toLowerCase().includes(invokeSearchTerm.toLowerCase())
+  const filteredInvokeState = Object.fromEntries(
+    invokeEntries.filter(([, func]) =>
+      Object.values(func).some(
+        (value) =>
+          typeof value === 'string' &&
+          value.toLowerCase().includes(invokeSearchTerm.toLowerCase())
+      )
     )
-  ))
+  );
 
   const addressesAbis = deploymentInfo?.state
     ? extractAddressesAbis(deploymentInfo.state)
@@ -274,11 +280,13 @@ export const DeploymentExplorer: FC<{
           </Flex>
 
           <Collapse in={showInvoke}>
-
             {!isEmpty(invokeState) ? (
               <Box>
                 <Box maxW="100%" overflowX="auto">
-                  <InvokesTable invokeState={filteredInvokeState} chainId={pkg.chainId} />
+                  <InvokesTable
+                    invokeState={filteredInvokeState}
+                    chainId={pkg.chainId}
+                  />
                 </Box>
               </Box>
             ) : (

--- a/packages/website/src/features/Packages/PackageAccordionHelper/index.tsx
+++ b/packages/website/src/features/Packages/PackageAccordionHelper/index.tsx
@@ -51,6 +51,9 @@ export default function PackageAccordionHelper({
     return null;
   }
 
+  /** Removing any potential run steps from the definition so it doesnt get registered in ChainDefinition */
+  const { ['run']: _, ...filteredDefinition } = deploymentInfo.def as any;
+
   return (
     <CustomAccordion allowToggle={!isLoading}>
       <CustomAccordionItem
@@ -91,7 +94,7 @@ export default function PackageAccordionHelper({
             name={name}
             chainId={packagesQuery.data.chainId}
             preset={packagesQuery.data.preset}
-            chainDefinition={new ChainDefinition(deploymentInfo.def)}
+            chainDefinition={new ChainDefinition(filteredDefinition)}
             deploymentState={state}
             version={packagesQuery.data.version}
           />

--- a/packages/website/src/features/Packages/PackageAccordionHelper/index.tsx
+++ b/packages/website/src/features/Packages/PackageAccordionHelper/index.tsx
@@ -52,6 +52,7 @@ export default function PackageAccordionHelper({
   }
 
   /** Removing any potential run steps from the definition so it doesnt get registered in ChainDefinition */
+  //eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { ['run']: _, ...filteredDefinition } = deploymentInfo.def as any;
 
   return (


### PR DESCRIPTION
https://www.loom.com/share/74000c82035b479baa3d79bbcc1b3fe5


Also added search bar:
https://www.loom.com/share/ae9a2cc03b2d4de1b44e549ed9c52e3a

The search bar above enables searching for any value under each column, so Operations, contract names and addresses, as well as specific transaction hashes.

Also fixes a bug where if a package has a run step in its definition it would break the site

Example: https://usecannon.com/packages/synthetix/2/1-main

fixes https://linear.app/usecannon/issue/CAN-472/show-any-contracts-that-are-deployed-on-contract-page-front