### PR TITLE
feat(website): add safe transaction status hook

### DIFF
--- a/packages/website/src/features/Deploy/TransactionStepper.tsx
+++ b/packages/website/src/features/Deploy/TransactionStepper.tsx
@@ -1,7 +1,9 @@
+import { Hash } from 'viem';
 import { ExternalLinkIcon, InfoOutlineIcon } from '@chakra-ui/icons';
 import {
   Box,
   Link,
+  Text,
   Popover,
   PopoverBody,
   PopoverContent,
@@ -24,8 +26,7 @@ import { SafeTransaction } from '@/types/SafeTransaction';
 import { formatDistanceToNow } from 'date-fns';
 import { useEffect, useMemo } from 'react';
 import { useCannonChains } from '@/providers/CannonProvidersProvider';
-import { Hash } from 'viem';
-
+import { useSafeTransactionStatus, SafeTransactionStatus } from '@/hooks/safe';
 type Orientation = 'horizontal' | 'vertical';
 
 const StepTitle = chakra(BaseStepTitle, {
@@ -86,6 +87,15 @@ export function TransactionStepper(props: {
     setActiveStep(step);
   }, [step]);
 
+  const safeTransactionStatus = useSafeTransactionStatus(
+    props.chainId,
+    transactionHash as Hash
+  );
+
+  const isExecutionFailure = useMemo(
+    () => safeTransactionStatus === SafeTransactionStatus.EXECUTION_FAILURE,
+    [safeTransactionStatus]
+  );
   const orientation = useBreakpointValue({
     base: 'vertical' as Orientation,
     md: 'horizontal' as Orientation,
@@ -177,12 +187,18 @@ export function TransactionStepper(props: {
         size="sm"
         index={activeStep}
         orientation={orientation}
-        colorScheme="teal"
+        colorScheme={isExecutionFailure ? 'red' : 'teal'}
       >
         <Step key={1}>
           <StepIndicator
             borderWidth="1px !important"
-            borderColor={activeStep >= 1 ? 'teal.500' : 'gray.200'}
+            borderColor={
+              isExecutionFailure
+                ? 'red.500'
+                : activeStep >= 1
+                ? 'teal.500'
+                : 'gray.200'
+            }
           >
             <StepStatus
               complete={<StepIcon />}
@@ -204,7 +220,13 @@ export function TransactionStepper(props: {
         <Step key={2}>
           <StepIndicator
             borderWidth="1px !important"
-            borderColor={activeStep >= 2 ? 'teal.500' : 'gray.200'}
+            borderColor={
+              isExecutionFailure
+                ? 'red.500'
+                : activeStep >= 2
+                ? 'teal.500'
+                : 'gray.200'
+            }
           >
             <StepStatus
               complete={<StepIcon />}
@@ -251,10 +273,16 @@ export function TransactionStepper(props: {
         <Step key={3}>
           <StepIndicator
             borderWidth="1px !important"
-            borderColor={activeStep >= 3 ? 'teal.500' : 'gray.200'}
+            borderColor={
+              isExecutionFailure
+                ? 'red.500'
+                : activeStep >= 3
+                ? 'teal.500'
+                : 'gray.200'
+            }
           >
             <StepStatus
-              complete={<StepIcon />}
+              complete={isExecutionFailure ? <StepNumber /> : <StepIcon />}
               incomplete={<StepNumber />}
               active={<StepNumber />}
             />
@@ -280,6 +308,7 @@ export function TransactionStepper(props: {
                   >
                     <ExternalLinkIcon transform="translateY(-0.5px)" />
                   </Link>
+                  {isExecutionFailure && <Text>The execution has failed</Text>}
                 </>
               ) : (
                 <>Pending</>


### PR DESCRIPTION
This PR introduces new functionality and improvements to the Safe-related hooks and utilities:

1. Added `useSafeTransactionStatus` hook to fetch and determine the status of a Safe transaction.
2. Added `SafeTransactionStatus` enum to represent transaction execution outcomes.


Closes https://linear.app/usecannon/issue/CAN-484/on-cannon-safe-ui-understand-the-difference-between-success-and


Before:

<img width="1108" alt="Screenshot 2024-09-11 at 5 47 31 PM" src="https://github.com/user-attachments/assets/13257f83-54ee-4ee0-8a6f-d937226339ac">

After:

<img width="1161" alt="Screenshot 2024-09-11 at 5 47 49 PM" src="https://github.com/user-attachments/assets/72b443db-e712-4563-bd6d-d19cd4195abf">
