### PR TITLE
fix(website): explore page scroll

### DIFF
--- a/packages/website/src/features/Search/PackageCard/DataTable.tsx
+++ b/packages/website/src/features/Search/PackageCard/DataTable.tsx
@@ -187,6 +187,8 @@ export function DataTable<Data extends object>({
                 return (
                   <Td
                     key={cell.id}
+                    position="relative"
+                    overflow="hidden"
                     isNumeric={meta?.isNumeric}
                     borderColor="gray.600"
                     borderBottom={

--- a/packages/website/src/features/Search/SearchPage.tsx
+++ b/packages/website/src/features/Search/SearchPage.tsx
@@ -88,7 +88,7 @@ export const SearchPage = () => {
   const groupedPackages = groupBy(packagesQuery?.data?.data, 'name');
 
   return (
-    <Flex flex="1" direction="column" maxHeight="100%" maxWidth="100%">
+    <Flex flex="1" direction="column" maxWidth="100vw">
       <Flex flex="1" direction={['column', 'column', 'row']}>
         <Flex
           flexDirection="column"
@@ -104,7 +104,6 @@ export const SearchPage = () => {
             px={4}
             pb={[0, 0, 4]}
             maxHeight={{ base: '210px', md: 'none' }}
-            overflowY="scroll"
             position="relative" // Added to position the pseudo-element
             sx={{
               '&::after': {
@@ -187,7 +186,7 @@ export const SearchPage = () => {
               </Text>
             </Flex>
           ) : (
-            <Box px={[0, 0, 4]} pt={isSmall ? 4 : 8}>
+            <Box px={0} pt={isSmall ? 4 : 8}>
               <Container ml={0} maxWidth="container.xl">
                 {Object.values(groupedPackages).map((pkgs: any) => (
                   <Box mb="8" key={pkgs[0].name}>


### PR DESCRIPTION
Closes https://linear.app/usecannon/issue/CAN-525/y-scroll-on-explore-page-is-wonky