### PR TITLE
add `--no-request-size-limit` to default anvil options

### DIFF
--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -57,6 +57,8 @@ export async function runRpc(anvilOptions: AnvilOptions, rpcOptions: RpcOptions 
     anvilOptions.accounts = 1;
   }
 
+  anvilOptions.noRequestSizeLimit = true;
+
   if (anvilOptions.forkUrl && rpcOptions.forkProvider) {
     throw new Error('Cannot set both an anvil forkUrl and a proxy provider connection');
   }

--- a/packages/cli/src/util/anvil.ts
+++ b/packages/cli/src/util/anvil.ts
@@ -65,6 +65,10 @@ export type AnvilOptions = {
    */
   noStorageCaching?: boolean | undefined;
   /**
+   * Disables request size limit
+   */
+  noRequestSizeLimit?: boolean | undefined;
+  /**
    * Number of retry requests for spurious networks (timed out requests).
    *
    * @defaultValue 5


### PR DESCRIPTION
some packages have gotten so big, they no longer fit in the standard request size for anvil. Thanksully, anvil now provides an escape hatch for this. Let's use it.