### PR TITLE
fix(builder): ctx timestamp type

### DIFF
--- a/packages/builder/src/builder.test.ts
+++ b/packages/builder/src/builder.test.ts
@@ -317,7 +317,7 @@ describe('builder.ts', () => {
       expect(ctx.chainId).toBe(5);
       expect(ctx.package).toBe(pkg);
       expect(ctx.overrideSettings.baz).toStrictEqual('boop');
-      expect(parseInt(ctx.timestamp)).toBeCloseTo(Date.now() / 1000, -2);
+      expect(ctx.timestamp).toBeCloseTo(Date.now() / 1000, -2);
       expect(ctx.contracts).toStrictEqual({});
       expect(ctx.txns).toStrictEqual({});
       expect(ctx.imports).toStrictEqual({});

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -24,7 +24,7 @@ export async function createInitialContext(
 ): Promise<ChainBuilderContext> {
   const preCtx: PreChainBuilderContext = {
     package: pkg,
-    timestamp: Math.floor(Date.now() / 1000).toString(),
+    timestamp: Math.floor(Date.now() / 1000),
     chainId,
     overrideSettings: opts,
   };

--- a/packages/builder/src/types.test.ts
+++ b/packages/builder/src/types.test.ts
@@ -109,7 +109,7 @@ describe('types.ts', () => {
 
       const combinedCtx = combineCtx(ctxs);
 
-      expect(combinedCtx.timestamp).toEqual(Math.floor(CUR_TIME / 1000).toString());
+      expect(combinedCtx.timestamp).toEqual(Math.floor(CUR_TIME / 1000));
       expect(Object.keys(combinedCtx.contracts)).toEqual(expect.arrayContaining(['fake', 'fake2', 'faker', 'faker2']));
       expect(Object.keys(combinedCtx.txns)).toEqual(expect.arrayContaining(['fake']));
       expect(Object.keys(combinedCtx.settings)).toEqual(expect.arrayContaining(['fake']));

--- a/packages/builder/src/types.test.ts
+++ b/packages/builder/src/types.test.ts
@@ -75,7 +75,7 @@ describe('types.ts', () => {
           },
         },
         {
-          timestamp: '0',
+          timestamp: 0,
           chainId: 0,
           package: {},
           overrideSettings: {},

--- a/packages/builder/src/types.test.ts
+++ b/packages/builder/src/types.test.ts
@@ -17,7 +17,7 @@ describe('types.ts', () => {
     it('combines context array', () => {
       const ctxs: ChainBuilderContext[] = [
         {
-          timestamp: '0',
+          timestamp: 0,
           chainId: 0,
           package: {},
           overrideSettings: {
@@ -63,7 +63,7 @@ describe('types.ts', () => {
           settings: {},
         },
         {
-          timestamp: '0',
+          timestamp: 0,
           chainId: 0,
           package: {},
           overrideSettings: {},

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -72,7 +72,7 @@ export interface PreChainBuilderContext {
 
   package: any;
 
-  timestamp: string;
+  timestamp: number;
 
   overrideSettings: { [label: string]: string };
 }
@@ -309,7 +309,7 @@ export type DeploymentState = { [label: string]: StepState };
 export function combineCtx(ctxs: ChainBuilderContext[]): ChainBuilderContext {
   const ctx = _.clone(ctxs[0]);
 
-  ctx.timestamp = Math.floor(Date.now() / 1000).toString(); //(await this.provider.getBlock(await this.provider.getBlockNumber())).timestamp.toString();
+  ctx.timestamp = Math.floor(Date.now() / 1000);
 
   // merge all blockchain outputs
   for (const additionalCtx of ctxs.slice(1)) {

--- a/packages/builder/src/util.test.ts
+++ b/packages/builder/src/util.test.ts
@@ -140,7 +140,7 @@ describe('util.ts', () => {
     settings: {},
     txns: {},
     chainId: 0,
-    timestamp: '0',
+    timestamp: 0,
     package: {},
   };
 

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -218,11 +218,12 @@ export async function loadCannonfile(filepath: string) {
   const def = new ChainDefinition(rawDef, true);
   const pkg = loadPackageJson(path.join(path.dirname(path.resolve(filepath)), 'package.json'));
 
+  // TODO: there should be a helper in the builder to create the initial ctx
   const ctx: ChainBuilderContext = {
     package: pkg,
     chainId: CANNON_CHAIN_ID,
     settings: {},
-    timestamp: '0',
+    timestamp: 0,
 
     contracts: {},
     txns: {},

--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -175,7 +175,7 @@ function QueueFromGitOps() {
   const ctx: ChainBuilderContext = {
     chainId: 0,
     package: {},
-    timestamp: '0',
+    timestamp: 0,
     settings: {},
     contracts: {},
     txns: {},

--- a/packages/website/src/helpers/cannon.ts
+++ b/packages/website/src/helpers/cannon.ts
@@ -46,7 +46,7 @@ export async function loadCannonfile(repo: string, ref: string, filepath: string
     package: {},
     chainId: CANNON_CHAIN_ID,
     settings: {},
-    timestamp: '0',
+    timestamp: 0,
     contracts: {},
     txns: {},
     imports: {},


### PR DESCRIPTION
Closes https://linear.app/usecannon/issue/CAN-538/on-cannonfiles-the-timestamp-variable-should-be-of-type-number

This PR fixes the necessity on having to cast the `timestamp` variable to `number` on cannonfiles on cases like this one:
<img width="354" alt="Screenshot_2024-09-16_at_3 42 59_PM" src="https://github.com/user-attachments/assets/c5d6ee25-2e9a-4061-9bff-d0c456aed1e1">
