### PR TITLE
fix(website): protocol fallback

### DIFF
--- a/packages/website/src/hooks/ipfs.ts
+++ b/packages/website/src/hooks/ipfs.ts
@@ -47,8 +47,10 @@ function useFetchIpfsData<T>({
           responseType: 'arraybuffer',
           signal,
         })
+        // In case the file fetch failed, let's try using the public ipfs.io gateway
         .catch(async (err) => {
           addLog('error', `IPFS Error: ${err.message}`);
+          // Use the same protocol as the users', http on development and https on production
           const protocol = window.location.protocol.startsWith('http') ? window.location.protocol : 'http:';
           const gatewayQueryUrl = `${protocol}//ipfs.io/ipfs/${cid}`;
           addLog('info', `Querying IPFS as HTTP gateway: ${gatewayQueryUrl}`);

--- a/packages/website/src/hooks/ipfs.ts
+++ b/packages/website/src/hooks/ipfs.ts
@@ -49,8 +49,8 @@ function useFetchIpfsData<T>({
         })
         .catch(async (err) => {
           addLog('error', `IPFS Error: ${err.message}`);
-          //const gatewayQueryUrl = `${ipfsQueryUrl}${cid}`;
-          const gatewayQueryUrl = `http://ipfs.io/ipfs/${cid}`;
+          const protocol = window.location.protocol.startsWith('http') ? window.location.protocol : 'http:';
+          const gatewayQueryUrl = `${protocol}//ipfs.io/ipfs/${cid}`;
           addLog('info', `Querying IPFS as HTTP gateway: ${gatewayQueryUrl}`);
           return await axios.get<ArrayBuffer>(gatewayQueryUrl, {
             responseType: 'arraybuffer',


### PR DESCRIPTION
This PR fixes an error on IPFS file fetch that made it not work when on `https://usecannon.com` because of the following restriction:
<img width="749" alt="Screenshot 2024-09-17 at 10 01 38" src="https://github.com/user-attachments/assets/787232e4-7f2c-4886-b62b-ac44ef31da5c">
