### PR TITLE
fix(cli): cypress binary was missing

### DIFF
--- a/.github/workflows/website-e2e.yml
+++ b/.github/workflows/website-e2e.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           runTests: false
 
-      - name: Cypress verify and install - if needed.
+      - name: Cypress verify
         run: pnpm cypress verify || pnpm cypress install
         working-directory: packages/website
 


### PR DESCRIPTION
This PR should fix the issue we've been having with Cypress running in CI, due to the switch to pnpm workspaces.

Closes https://linear.app/usecannon/issue/CAN-550/cypress-binary-is-missing-in-ci