### PR TITLE
fix(cli): correct chain id handling in publish command when using package reference

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -366,7 +366,7 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
       throw new Error('A valid Chain Id is required.');
     }
 
-    options.chainId = chainIdPrompt.value;
+    chainId = Number(chainIdPrompt.value);
   }
 
   const isDefaultRegistryChains =


### PR DESCRIPTION
I introduced a bug – not yet released – where the publish command doesn't properly manage the chain ID when users provide a package reference and do not use the `--chain-id` flag.