### PR TITLE
chore(ci): remove upload to ipfs from pull requests

### DIFF
--- a/.github/workflows/upload-to-ipfs.yml
+++ b/.github/workflows/upload-to-ipfs.yml
@@ -1,8 +1,6 @@
 name: Upload Website to IPFS
 
-on:
-  pull_request:
-    branches: [main, alpha, dev]
+on: workflow_dispatch
 
 jobs:
   upload-ipfs:


### PR DESCRIPTION
This PR remoces the "Upload Website to IPFS" github action from Pull Requests, but still let's the user execute it from the repo settings.