### PR TITLE
feat(cli): Enhance CLI command help

### DIFF
--- a/packages/cli/src/util/commands-config.ts
+++ b/packages/cli/src/util/commands-config.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { createCommandHelp } from './create-command-help';
+import { formatCommandHelp } from './format-command-help';
 import { parsePackageArguments, parsePackagesArguments } from './params';
 import type { Command as CommandConfig } from '../commands/config/types';
 
@@ -53,11 +53,7 @@ export const applyCommandsConfig = (command: Command, config: CommandConfig) => 
 
   // override the help output to add a header for anvil and forge options
   const originalHelpInformation = command.helpInformation.bind(command);
-  command.helpInformation = () => {
-    let helpText = originalHelpInformation();
-    helpText = createCommandHelp(helpText);
-    return helpText;
-  };
+  command.helpInformation = () => formatCommandHelp(originalHelpInformation());
 
   return command;
 };

--- a/packages/cli/src/util/format-command-help.test.ts
+++ b/packages/cli/src/util/format-command-help.test.ts
@@ -1,6 +1,6 @@
-import { createCommandHelp } from './create-command-help';
+import { formatCommandHelp } from './format-command-help';
 
-describe('createCommandHelp', () => {
+describe('formatCommandHelp', () => {
   it('should group Anvil options', () => {
     const input = `
       --option1 Description1
@@ -8,7 +8,7 @@ describe('createCommandHelp', () => {
       --anvil.option2 AnvilDescription2
       --option2 Description2
     `;
-    const result = createCommandHelp(input);
+    const result = formatCommandHelp(input);
     expect(result).toContain('Anvil Options:');
     expect(result.indexOf('--anvil.option1')).toBeGreaterThan(result.indexOf('Anvil Options:'));
     expect(result.indexOf('--anvil.option2')).toBeGreaterThan(result.indexOf('Anvil Options:'));
@@ -21,7 +21,7 @@ describe('createCommandHelp', () => {
       --forge.option2 ForgeDescription2
       --option2 Description2
     `;
-    const result = createCommandHelp(input);
+    const result = formatCommandHelp(input);
     expect(result).toContain('Forge Options:');
     expect(result.indexOf('--forge.option1')).toBeGreaterThan(result.indexOf('Forge Options:'));
     expect(result.indexOf('--forge.option2')).toBeGreaterThan(result.indexOf('Forge Options:'));
@@ -34,7 +34,7 @@ describe('createCommandHelp', () => {
       --anvil.option1 AnvilDescription1
       -h, --help Show help
     `;
-    const result = createCommandHelp(input);
+    const result = formatCommandHelp(input);
     const helpIndex = result.indexOf('-h, --help');
     const option2Index = result.indexOf('--option2');
     const anvilOptionIndex = result.indexOf('--anvil.option1');
@@ -47,7 +47,7 @@ describe('createCommandHelp', () => {
       --option1 Description1
       --option2 Description2
     `;
-    const result = createCommandHelp(input);
+    const result = formatCommandHelp(input);
     expect(result).toBe(input);
   });
 });

--- a/packages/cli/src/util/format-command-help.ts
+++ b/packages/cli/src/util/format-command-help.ts
@@ -1,4 +1,4 @@
-export function createCommandHelp(inputText: string): string {
+export function formatCommandHelp(inputText: string): string {
   const lines = inputText.split('\n');
   const optionGroups = [
     { prefix: '--anvil.', header: 'Anvil Options:' },


### PR DESCRIPTION
This PR enhances the CLI command help output by introducing custom formatting.

Before:

```
dcannon build --help
Usage: cannon build [options] [cannonfile] [settings...]

Build a package from a Cannonfile.

Arguments:
  cannonfile                                  Path to a cannonfile (default: "cannonfile.toml")
  settings                                    Custom settings for building the cannonfile

Options:
  -n --rpc-url [url]                          RPC endpoint to execute the deployment on
  --provider-url [url]                        (DEPRECATED) RPC endpoint to fork off of
  -c --chain-id <number>                      The chain id to run against
  --port <number>                             Port which the JSON-RPC server will be exposed. [default: 0] (default: "0")
  -p --preset <preset>                        (DEPRECATED) The preset label for storing the build with the given settings. Declare a preset in your cannonfile instead.
  --dry-run                                   Simulate building on a local fork rather than deploying on the real network
  --keep-alive                                After completing build, leave RPC open and switch into run mode. Has no effect on live network deployment.
  --private-key [key]                         Specify a comma separated list of private keys which may be needed to sign a transaction
  --wipe                                      Clear the existing deployment state and start this deploy from scratch.
  --upgrade-from [cannon-package:0.0.1]       Specify a package to use as a new base for the deployment.
  --registry-priority <registry>              Change the default registry to read from first. Default: onchain
  --gas-price <gasPrice>                      The gas price used by all transactions processed by this build. Expressed in GWEI.
  --max-gas-fee <maxGasFee>                   Specify max fee per gas (EIP-1559) for all transactions processed by this build. Expressed in GWEI.
  --max-priority-gas-fee <maxpriorityGasFee>  Specify max fee per gas (EIP-1559) for all transactions processed by this build. Expressed in GWEI.
  --skip-compile                              Skip the compilation step and use the existing artifacts
  --write-script <writeScript>                (Experimental) Path to write all the actions taken as a script that can be later executed
  -w --write-deployments <writeDeployments>   Path to write the deployments data (address and ABIs), like "./deployments"
  --write-script-format <writeScriptFormat>   (Experimental) Format in which to write the actions script (Options: json, ethers) (default: "ethers")
  -q --quiet                                  Suppress extra logging
  -v                                          Print logs for builder, equivalent to DEBUG=cannon:builder
  -vv                                         Print logs for builder and its definition section, equivalent to DEBUG=cannon:builder, cannon:builder:definition
  -vvv                                        Print logs for builder and its all sub sections, equivalent to DEBUG=cannon:builder*
  -vvvv                                       Print all cannon logs, equivalent to DEBUG=cannon:*
  --anvil.accounts <number>                   Number of dev accounts to generate and configure
  --anvil.block-time <number>                 Block time in seconds for interval mining
  --anvil.balance <number>                    The balance of every dev account in Ether
  --anvil.config-out <path>                   Writes output of `anvil` as json to user-specified file
  --anvil.derivation-path <path>              Sets the derivation path of the child key to be derived.
  --anvil.dump-state <path>                   Dump the state and block environment of chain on exit to the given file.
  --anvil.hardfork <string>                   The EVM hardfork to use.
  --anvil.init <path>                         Initialize the genesis block with the given `genesis.json` file
  --anvil.ipc [<path>]                        Launch an ipc server at the given path or default path = `/tmp/anvil.ipc`
  --anvil.load-state <path>                   Initialize the chain from a previously saved state snapshot
  --anvil.mnemonic <string>                   BIP39 mnemonic phrase used for generating accounts. Cannot be used if `mnemonic_random` or `mnemonic_seed` are used
  --anvil.max-persisted-states <number>       Max number of states to persist on disk.
  --anvil.mixed-mining                        Enable mixed mining
  --anvil.mnemonic-random [<number>]          Automatically generates a BIP39 mnemonic phrase, and derives accounts from it. Cannot be used with other `mnemonic` options.
  --anvil.mnemonic-seed-unsafe <string>       Generates a BIP39 mnemonic phrase from a given seed. Cannot be used with other `mnemonic` options.
  --anvil.no-mining                           Disable auto and interval mining, and mine on demand instead
  --anvil.order <string>                      How transactions are sorted in the mempool
  --anvil.port <number>                       Port number to listen on [default: 0] (default: "0")
  --anvil.preserve-historical-states          Preserve historical state snapshots when dumping the state.
  --anvil.prune-history <number>              Don't keep full chain history. If a number argument is specified, at most this number of states is kept in memory.
  --anvil.state-interval <number>             Interval in seconds at which the state and block environment is to be dumped to disk.
  --anvil.silent                              Don't print anything on startup and don't print logs
  --anvil.slots-in-an-epoch <number>          Slots in an epoch
  --anvil.state <path>                        This is an alias for both --load-state and --dump-state.
  --anvil.timestamp <number>                  The timestamp of the genesis block
  --anvil.transaction-block-keeper <number>   Number of blocks with transactions to keep in memory
  --anvil.version                             Print version
  --anvil.allow-origin <string>               The cors `allow_origin` header
  --anvil.host <string>                       The hosts the server will listen on
  --anvil.no-cors                             Disable CORS
  --anvil.no-request-size-limit               Disable the default request body size limit. At time of writing the default limit is 2MB
  --anvil.compute-units-per-second <number>   Sets the number of assumed available compute units per second for this provider
  --anvil.fork-url <url>                      Fetch state over a remote endpoint instead of starting from an empty state.
  --anvil.fork-block-number <number>          Fetch state from a specific block number over a remote endpoint.
  --anvil.fork-chain-id <number>              Specify chain id to skip fetching it from remote endpoint. This enables offline-start mode.
  --anvil.fork-header <string>                Headers to use for the rpc client, e.g. "User-Agent: test-agent"
  --anvil.fork-retry-backoff <number>         Initial retry backoff on encountering errors.
  --anvil.fork-transaction-hash <string>      Fetch state from a specific transaction hash over a remote endpoint.
  --anvil.no-rate-limit                       Disables rate limiting for this node's provider.
  --anvil.no-storage-caching                  Explicitly disables the use of RPC caching.
  --anvil.retries <number>                    Number of retry requests for spurious networks (timed out requests)
  --anvil.timeout <number>                    Timeout in ms for requests sent to remote JSON-RPC server in forking mode.
  --anvil.block-base-fee-per-gas <number>     The base fee in a block
  --anvil.chain-id <number>                   The chain ID [default: 13370]
  --anvil.code-size-limit <number>            EIP-170: Contract code size limit in bytes. Useful to increase this because of tests.
  --anvil.disable-block-gas-limit             Disable the `call.gas_limit <= block.gas_limit` constraint
  --anvil.disable-code-size-limit             Disable EIP-170: Contract code size limit
  --anvil.gas-limit <number>                  The block gas limit
  --anvil.gas-price <number>                  The gas price
  --anvil.alphanet                            Enable Alphanet features
  --anvil.auto-impersonate                    Enable autoImpersonate on startup
  --anvil.disable-console-log                 Disable printing of `console.log` invocations to stdout
  --anvil.disable-default-create2-deployer    Disable the default create2 deployer
  --anvil.memory-limit <number>               The memory limit per EVM execution in bytes
  --anvil.optimism                            Run an Optimism chain
  --anvil.steps-tracing                       Enable steps tracing used for debug calls returning geth-style traces
  --forge.names                               Print compiled contract names.
  --forge.sizes                               Print compiled non-test contract sizes, exiting with code 1 if any of them are above the size limit.
  --forge.skip                                Skip compilation of non-essential contract directories like test or script.
  --forge.ignored-error-codes <error_codes>   Ignore solc warnings by error code.
  --forge.deny-warnings                       Warnings will trigger a compiler error.
  --forge.no-auto-detect                      Do not auto-detect solc.
  --forge.use <solc_version>                  Specify the solc version, or a path to a local solc, to build with.
  --forge.offline                             Do not access the network. Missing solc versions will not be installed.
  --forge.via-ir                              Use the Yul intermediate representation compilation pipeline.
  --forge.no-metadata                         Do not append any metadata to the bytecode.
  --forge.silent                              Don't print anything on startup.
  --forge.ast                                 Includes the AST as JSON in the compiler output.
  --forge.evm-version <version>               The target EVM version.
  --forge.optimize                            Activate the Solidity optimizer.
  --forge.optimizer-runs <runs>               The number of optimizer runs.
  --forge.extra-output <selector>             Extra output to include in the contract’s artifact.
  --forge.extra-output-files <selector>       Extra output to write to separate files.
  --forge.out <path>                          The path to the contract artifacts folder.
  --forge.revert-strings <revert>             Revert string configuration. [default, strip, debug, verboseDebug]
  --forge.build-info                          Generate build info files.
  --forge.build-info-path <path>              Output path to directory where build info files will be written.
  --forge.root <path>                         The project's root path.
  --forge.contracts <path>                    The contracts source directory.
  --forge.remappings <remappings>             The project's remappings, in the format <source>=<dest>.
  --forge.remappings-env <env>                The project's remappings from the environment.
  --forge.cache-path <path>                   The path to the compiler cache.
  --forge.lib-paths <path>                    The path to the library folder.
  --forge.hardhat                             Use the Hardhat-style project layout.
  --forge.config-path <file>                  Path to the config file.
  -h, --help                                  display help for command
```

After
```
dcannon build --help
Usage: cannon build [options] [cannonfile] [settings...]

Build a package from a Cannonfile.

Arguments:
  cannonfile                                  Path to a cannonfile (default: "cannonfile.toml")
  settings                                    Custom settings for building the cannonfile

Options:
  -n --rpc-url [url]                          RPC endpoint to execute the deployment on
  --provider-url [url]                        (DEPRECATED) RPC endpoint to fork off of
  -c --chain-id <number>                      The chain id to run against
  --port <number>                             Port which the JSON-RPC server will be exposed. [default: 0] (default: "0")
  -p --preset <preset>                        (DEPRECATED) The preset label for storing the build with the given settings. Declare a preset in your cannonfile instead.
  --dry-run                                   Simulate building on a local fork rather than deploying on the real network
  --keep-alive                                After completing build, leave RPC open and switch into run mode. Has no effect on live network deployment.
  --private-key [key]                         Specify a comma separated list of private keys which may be needed to sign a transaction
  --wipe                                      Clear the existing deployment state and start this deploy from scratch.
  --upgrade-from [cannon-package:0.0.1]       Specify a package to use as a new base for the deployment.
  --registry-priority <registry>              Change the default registry to read from first. Default: onchain
  --gas-price <gasPrice>                      The gas price used by all transactions processed by this build. Expressed in GWEI.
  --max-gas-fee <maxGasFee>                   Specify max fee per gas (EIP-1559) for all transactions processed by this build. Expressed in GWEI.
  --max-priority-gas-fee <maxpriorityGasFee>  Specify max fee per gas (EIP-1559) for all transactions processed by this build. Expressed in GWEI.
  --skip-compile                              Skip the compilation step and use the existing artifacts
  --write-script <writeScript>                (Experimental) Path to write all the actions taken as a script that can be later executed
  -w --write-deployments <writeDeployments>   Path to write the deployments data (address and ABIs), like "./deployments"
  --write-script-format <writeScriptFormat>   (Experimental) Format in which to write the actions script (Options: json, ethers) (default: "ethers")
  -q --quiet                                  Suppress extra logging
  -v                                          Print logs for builder, equivalent to DEBUG=cannon:builder
  -vv                                         Print logs for builder and its definition section, equivalent to DEBUG=cannon:builder, cannon:builder:definition
  -vvv                                        Print logs for builder and its all sub sections, equivalent to DEBUG=cannon:builder*
  -vvvv                                       Print all cannon logs, equivalent to DEBUG=cannon:*
  -h, --help                                  display help for command

Anvil Options:
  --anvil.accounts <number>                   Number of dev accounts to generate and configure
  --anvil.block-time <number>                 Block time in seconds for interval mining
  --anvil.balance <number>                    The balance of every dev account in Ether
  --anvil.config-out <path>                   Writes output of `anvil` as json to user-specified file
  --anvil.derivation-path <path>              Sets the derivation path of the child key to be derived.
  --anvil.dump-state <path>                   Dump the state and block environment of chain on exit to the given file.
  --anvil.hardfork <string>                   The EVM hardfork to use.
  --anvil.init <path>                         Initialize the genesis block with the given `genesis.json` file
  --anvil.ipc [<path>]                        Launch an ipc server at the given path or default path = `/tmp/anvil.ipc`
  --anvil.load-state <path>                   Initialize the chain from a previously saved state snapshot
  --anvil.mnemonic <string>                   BIP39 mnemonic phrase used for generating accounts. Cannot be used if `mnemonic_random` or `mnemonic_seed` are used
  --anvil.max-persisted-states <number>       Max number of states to persist on disk.
  --anvil.mixed-mining                        Enable mixed mining
  --anvil.mnemonic-random [<number>]          Automatically generates a BIP39 mnemonic phrase, and derives accounts from it. Cannot be used with other `mnemonic` options.
  --anvil.mnemonic-seed-unsafe <string>       Generates a BIP39 mnemonic phrase from a given seed. Cannot be used with other `mnemonic` options.
  --anvil.no-mining                           Disable auto and interval mining, and mine on demand instead
  --anvil.order <string>                      How transactions are sorted in the mempool
  --anvil.port <number>                       Port number to listen on [default: 0] (default: "0")
  --anvil.preserve-historical-states          Preserve historical state snapshots when dumping the state.
  --anvil.prune-history <number>              Don't keep full chain history. If a number argument is specified, at most this number of states is kept in memory.
  --anvil.state-interval <number>             Interval in seconds at which the state and block environment is to be dumped to disk.
  --anvil.silent                              Don't print anything on startup and don't print logs
  --anvil.slots-in-an-epoch <number>          Slots in an epoch
  --anvil.state <path>                        This is an alias for both --load-state and --dump-state.
  --anvil.timestamp <number>                  The timestamp of the genesis block
  --anvil.transaction-block-keeper <number>   Number of blocks with transactions to keep in memory
  --anvil.version                             Print version
  --anvil.allow-origin <string>               The cors `allow_origin` header
  --anvil.host <string>                       The hosts the server will listen on
  --anvil.no-cors                             Disable CORS
  --anvil.no-request-size-limit               Disable the default request body size limit. At time of writing the default limit is 2MB
  --anvil.compute-units-per-second <number>   Sets the number of assumed available compute units per second for this provider
  --anvil.fork-url <url>                      Fetch state over a remote endpoint instead of starting from an empty state.
  --anvil.fork-block-number <number>          Fetch state from a specific block number over a remote endpoint.
  --anvil.fork-chain-id <number>              Specify chain id to skip fetching it from remote endpoint. This enables offline-start mode.
  --anvil.fork-header <string>                Headers to use for the rpc client, e.g. "User-Agent: test-agent"
  --anvil.fork-retry-backoff <number>         Initial retry backoff on encountering errors.
  --anvil.fork-transaction-hash <string>      Fetch state from a specific transaction hash over a remote endpoint.
  --anvil.no-rate-limit                       Disables rate limiting for this node's provider.
  --anvil.no-storage-caching                  Explicitly disables the use of RPC caching.
  --anvil.retries <number>                    Number of retry requests for spurious networks (timed out requests)
  --anvil.timeout <number>                    Timeout in ms for requests sent to remote JSON-RPC server in forking mode.
  --anvil.block-base-fee-per-gas <number>     The base fee in a block
  --anvil.chain-id <number>                   The chain ID [default: 13370]
  --anvil.code-size-limit <number>            EIP-170: Contract code size limit in bytes. Useful to increase this because of tests.
  --anvil.disable-block-gas-limit             Disable the `call.gas_limit <= block.gas_limit` constraint
  --anvil.disable-code-size-limit             Disable EIP-170: Contract code size limit
  --anvil.gas-limit <number>                  The block gas limit
  --anvil.gas-price <number>                  The gas price
  --anvil.alphanet                            Enable Alphanet features
  --anvil.auto-impersonate                    Enable autoImpersonate on startup
  --anvil.disable-console-log                 Disable printing of `console.log` invocations to stdout
  --anvil.disable-default-create2-deployer    Disable the default create2 deployer
  --anvil.memory-limit <number>               The memory limit per EVM execution in bytes
  --anvil.optimism                            Run an Optimism chain
  --anvil.steps-tracing                       Enable steps tracing used for debug calls returning geth-style traces

Forge Options:
  --forge.names                               Print compiled contract names.
  --forge.sizes                               Print compiled non-test contract sizes, exiting with code 1 if any of them are above the size limit.
  --forge.skip                                Skip compilation of non-essential contract directories like test or script.
  --forge.ignored-error-codes <error_codes>   Ignore solc warnings by error code.
  --forge.deny-warnings                       Warnings will trigger a compiler error.
  --forge.no-auto-detect                      Do not auto-detect solc.
  --forge.use <solc_version>                  Specify the solc version, or a path to a local solc, to build with.
  --forge.offline                             Do not access the network. Missing solc versions will not be installed.
  --forge.via-ir                              Use the Yul intermediate representation compilation pipeline.
  --forge.no-metadata                         Do not append any metadata to the bytecode.
  --forge.silent                              Don't print anything on startup.
  --forge.ast                                 Includes the AST as JSON in the compiler output.
  --forge.evm-version <version>               The target EVM version.
  --forge.optimize                            Activate the Solidity optimizer.
  --forge.optimizer-runs <runs>               The number of optimizer runs.
  --forge.extra-output <selector>             Extra output to include in the contract’s artifact.
  --forge.extra-output-files <selector>       Extra output to write to separate files.
  --forge.out <path>                          The path to the contract artifacts folder.
  --forge.revert-strings <revert>             Revert string configuration. [default, strip, debug, verboseDebug]
  --forge.build-info                          Generate build info files.
  --forge.build-info-path <path>              Output path to directory where build info files will be written.
  --forge.root <path>                         The project's root path.
  --forge.contracts <path>                    The contracts source directory.
  --forge.remappings <remappings>             The project's remappings, in the format <source>=<dest>.
  --forge.remappings-env <env>                The project's remappings from the environment.
  --forge.cache-path <path>                   The path to the compiler cache.
  --forge.lib-paths <path>                    The path to the library folder.
  --forge.hardhat                             Use the Hardhat-style project layout.
  --forge.config-path <file>                  Path to the config file.`
  ```
  
 Closes https://linear.app/usecannon/issue/CAN-568/better-output-for-help-flag