### PR TITLE
fix(build): add clean command before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint:fix:js": "prettier --write '{packages,examples}/**/*.{js,ts}' && eslint --fix '{packages,examples}/**/*.{js,ts}'",
     "lint:fix:sol": "prettier --write '{packages,examples}/*/{contracts,src}/**/*.sol'",
     "lint:fix": "pnpm run '/^lint:fix:(js|sol)/'",
-    "build": "pnpm -r --filter @usecannon/builder --filter @usecannon/cli --filter hardhat-cannon --filter @usecannon/api run build",
+    "build": "pnpm -r --if-present run clean && pnpm -r --filter @usecannon/builder --filter @usecannon/cli --filter hardhat-cannon --filter @usecannon/api run build",
     "watch": "pnpm -r --parallel --filter @usecannon/builder --filter @usecannon/cli run watch",
     "version-alpha": "lerna version prerelease --no-private",
     "version-patch": "lerna version patch --no-private",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "db-prepare": "cp ../indexer/src/db.ts ./src/db/keys.ts",
     "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf ./dist",
     "start": "node dist/src/index.js",
     "dev": "NODE_ENV=development ts-node-dev src/index.ts"
   },

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -12,6 +12,7 @@
     "test": "jest",
     "build": "tsc -p tsconfig.build.json && rollup -c",
     "watch": "tsc -p tsconfig.build.json -w",
+    "clean": "rm -rf ./dist",
     "prepublishOnly": "npm run build",
     "docgen": "typedoc"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "watch": "tsc -p tsconfig.build.json -w",
+    "clean": "rm -rf ./dist",
     "prepublishOnly": "pnpm run build",
     "test": "jest",
     "test-e2e-prepare": "git submodule update --init --recursive",

--- a/packages/hardhat-cannon/package.json
+++ b/packages/hardhat-cannon/package.json
@@ -17,6 +17,7 @@
     "lint": "tslint --config tslint.json --project tsconfig.json",
     "build": "tsc",
     "watch": "tsc -w",
+    "clean": "rm -rf ./dist",
     "prepublishOnly": "pnpm run build"
   },
   "files": [

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf ./dist",
     "start": "node dist/index.js"
   },
   "author": "",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Contract registry for Cannon images",
   "scripts": {
+    "clean": "rm -rf ./cache ./artifacts ./typechain-types",
     "test": "hardhat compile && hardhat --network hardhat test",
     "coverage": "hardhat coverage"
   },

--- a/packages/repo/package.json
+++ b/packages/repo/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf ./dist",
     "start": "node dist/index.js"
   },
   "repository": {

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "clean": "rm -rf ./out ./.next",
     "analyze": "ANALYZE=true pnpm run build",
     "tsc:build": "tsc",
     "start": "next start",


### PR DESCRIPTION
This PR makes sure that we are not adding unused files from previous builds on a new published package to npm.

It can happen when we run build on a package because it won't delete files from the `dist` folder that was deleted from `src`, so, it would be added to the npm package publish.