### PR TITLE
hotfix(cli): forge test param with fork-url

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -689,6 +689,12 @@ applyCommandsConfig(program.command('test'), commandsConfig.test).action(async f
 
   const pickedOptions = pickForgeTestOptions(options);
 
+  // If there is an rpcUrl it was already used to create the node, but we don't need
+  // it after here because the node already includes it.
+  if (pickedOptions.rpcUrl) {
+    delete pickedOptions.rpcUrl;
+  }
+
   const forgeTestArgs = fromFoundryOptionsToArgs(pickedOptions, forgeTestOptions);
 
   const forgeProcess = spawn('forge', [options.forgeCmd, '--fork-url', node!.host, ...forgeTestArgs, ...forgeOptions], {


### PR DESCRIPTION
This PR fixes a bug where the `cannon test` command with `--rpc-url` was conflicting and throwing the following error:
```bash
> cannon test cannon.toml --rpc-url https://ethereum-sepolia-rpc.publicnode.com
error: the argument '--fork-url <URL>' cannot be used multiple times
```