### PR TITLE
fix(cli): forge test param with fork-url

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "npmClient": "pnpm",
   "packages": ["packages/*"],
   "exact": true,
-  "version": "2.18.0"
+  "version": "2.18.1"
 }

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usecannon/builder",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "Assembles cannonfile.toml manifests into cannon packages.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usecannon/cli",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "Utility for instantly loading cannon packages in standalone contexts",
   "main": "dist/src/index.js",
   "scripts": {

--- a/packages/cli/src/commands/config/forge/common/evm.ts
+++ b/packages/cli/src/commands/config/forge/common/evm.ts
@@ -2,10 +2,6 @@ import type { Option as ForgeEVMOption } from '../../types';
 
 export const forgeEvmOptions: ForgeEVMOption[] = [
   {
-    flags: '--forge.rpc-url <url>',
-    description: 'Fetch state over a remote endpoint instead of starting from an empty state.',
-  },
-  {
     flags: '--forge.fork-url <url>',
     description:
       'Fetch state over a remote endpoint. If you want to fetch state from a specific block number, see --forge.fork-block-number.',

--- a/packages/hardhat-cannon/package.json
+++ b/packages/hardhat-cannon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-cannon",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "Agnostic chain construction. Select the protocols and configuration you need to quickly and easily verify your project",
   "author": "Synthetix",
   "license": "MIT",


### PR DESCRIPTION
This PR fixes a bug where the `cannon test` command with `--rpc-url` was conflicting and throwing the following error:
```bash
> cannon test cannon.toml --rpc-url https://ethereum-sepolia-rpc.publicnode.com
error: the argument '--fork-url <URL>' cannot be used multiple times
```