### PR TITLE
chore(website): backport ipfs misc order

### DIFF
--- a/packages/builder/src/ipfs.ts
+++ b/packages/builder/src/ipfs.ts
@@ -24,6 +24,12 @@ export async function getContentCID(value: string | Buffer): Promise<string> {
   return Hash.of(value);
 }
 
+export async function getContentUrl(content?: any): Promise<string | null> {
+  if (!content) return null;
+  const buffer = compress(JSON.stringify(content));
+  return 'ipfs://' + (await getContentCID(Buffer.from(buffer)));
+}
+
 export function setAxiosRetries(totalRetries = 3) {
   axiosRetry(axios, {
     retries: totalRetries,

--- a/packages/builder/src/steps/clone.ts
+++ b/packages/builder/src/steps/clone.ts
@@ -7,6 +7,7 @@ import { computeTemplateAccesses, mergeTemplateAccesses } from '../access-record
 import { build, createInitialContext, getOutputs } from '../builder';
 import { CANNON_CHAIN_ID } from '../constants';
 import { ChainDefinition } from '../definition';
+import { getContentUrl } from '../ipfs';
 import { PackageReference } from '../package-reference';
 import { ChainBuilderRuntime, Events } from '../runtime';
 import { cloneSchema } from '../schemas';
@@ -238,7 +239,7 @@ const cloneSpec = {
       };
     }
 
-    const newMiscUrl = await importRuntime.recordMisc();
+    const newMiscUrl = await getContentUrl(importRuntime.misc);
 
     debug(`[clone.${importLabel}]`, 'new misc:', newMiscUrl);
 
@@ -255,6 +256,12 @@ const cloneSpec = {
       status: partialDeploy ? 'partial' : 'complete',
       chainId,
     });
+
+    const uploadedMiscUrl = await importRuntime.recordMisc();
+
+    if (newMiscUrl && newMiscUrl !== uploadedMiscUrl) {
+      throw new Error(`Misc url mismatch: ${newMiscUrl} | ${uploadedMiscUrl}`);
+    }
 
     if (!newSubDeployUrl) {
       debug(`[clone.${importLabel}]`, 'warn: cannot record built state for import nested state');


### PR DESCRIPTION
Backport to `v2.17` the fix added here: https://github.com/usecannon/cannon/pull/1420/files#diff-950232bdec873b2ee3a9f82132b20b978b8ae9fcf3be3a475e613efee95046f6R260