### PR TITLE
chore(cli): rename `setupAnvil` in favor of `ensureFoundryCompatibility`

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -16,7 +16,7 @@ import _ from 'lodash';
 import * as viem from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { ANVIL_FIRST_ADDRESS } from '../constants';
-import { setupAnvil } from '../helpers';
+import { ensureFoundryCompatibility } from '../helpers';
 import { getMainLoader } from '../loader';
 import { createDefaultReadRegistry } from '../registry';
 import { CannonRpcNode, getProvider } from '../rpc';
@@ -55,7 +55,8 @@ const INSTRUCTIONS = green(
 );
 
 export async function run(packages: PackageSpecification[], options: RunOptions): Promise<void> {
-  await setupAnvil();
+  // ensure foundry compatibility
+  await ensureFoundryCompatibility();
 
   // Start the rpc server
   const node = options.node;

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -5,16 +5,16 @@ import untildify from 'untildify';
 import prompts from 'prompts';
 import { bold, gray, green, italic, yellow } from 'chalk';
 
-import { setupAnvil } from '../helpers';
+import { ensureFoundryCompatibility } from '../helpers';
 import { CLI_SETTINGS_STORE } from '../constants';
 import { resolveCliSettings } from '../settings';
 import { log } from '../util/console';
 
 export async function setup() {
-  // Setup Anvil
-  await setupAnvil();
+  // ensure foundry compatibility
+  await ensureFoundryCompatibility();
 
-  // Exit if settings is already configured
+  // exit if settings is already configured
   if (process.env.CANNON_SETTINGS) {
     log('Your Cannon settings are being explicitly defined as follows:');
     log(JSON.stringify(process.env.CANNON_SETTINGS));

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -65,7 +65,17 @@ export async function filterSettings(settings: any) {
   return filteredSettings;
 }
 
-export async function setupAnvil(): Promise<void> {
+/**
+ * Installs or upgrades Foundry to ensure compatibility with Cannon.
+ *
+ * This function checks the current version of Anvil (a component of Foundry) and prompts the user
+ * to upgrade if necessary. If Foundry is not installed, it prompts for installation.
+ *
+ * @throws Will exit the process if the user declines to install or upgrade when necessary.
+ * @returns {Promise<void>}
+ */
+
+export async function ensureFoundryCompatibility(): Promise<void> {
   // TODO Setup anvil using https://github.com/foundry-rs/hardhat/tree/develop/packages/easy-foundryup
   //      It also works when the necessary foundry binary is not on PATH
   const versionDate = await getAnvilVersionDate();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,7 +21,7 @@ import * as viem from 'viem';
 import pkg from '../package.json';
 import { interact } from './commands/interact';
 import commandsConfig from './commands/config';
-import { checkCannonVersion, ensureChainIdConsistency, getPackageInfo, setupAnvil } from './helpers';
+import { checkCannonVersion, ensureChainIdConsistency, getPackageInfo, ensureFoundryCompatibility } from './helpers';
 import { getMainLoader } from './loader';
 import { installPlugin, listInstalledPlugins, removePlugin } from './plugins';
 import { createDefaultReadRegistry } from './registry';
@@ -157,7 +157,8 @@ function configureRun(program: Command) {
 applyCommandsConfig(program.command('build'), commandsConfig.build)
   .showHelpAfterError('Use --help for more information.')
   .action(async (cannonfile, settings, options) => {
-    await setupAnvil();
+    // ensure foundry compatibility
+    await ensureFoundryCompatibility();
 
     // backwards compatibility for --port flag
     if (options.port !== ANVIL_PORT_DEFAULT_VALUE) {


### PR DESCRIPTION
Rename `setupAnvil` in favor of `ensureFoundryCompatibility` throughout the cli package.