### PR TITLE
chore(cli): refactor `configureSigners` function

### DIFF
--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -108,7 +108,11 @@ export const commandsConfig: CommandsConfig = {
       },
       {
         flags: '--dry-run',
-        description: 'Simulate building on a local fork rather than deploying on the real network',
+        description: 'Simulate building on a local fork rather than deploying on the real network. Impersonate all signers.',
+      },
+      {
+        flags: '--impersonate <address>',
+        description: 'Impersonate transactions from given signers. Only works with --dry-run',
       },
       {
         flags: '--keep-alive',

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -108,11 +108,7 @@ export const commandsConfig: CommandsConfig = {
       },
       {
         flags: '--dry-run',
-        description: 'Simulate building on a local fork rather than deploying on the real network. Impersonate all signers.',
-      },
-      {
-        flags: '--impersonate <address>',
-        description: 'Impersonate transactions from given signers. Only works with --dry-run',
+        description: 'Simulate building on a local fork rather than deploying on the real network.',
       },
       {
         flags: '--keep-alive',


### PR DESCRIPTION
This PR aims to simplify the code around configuring signers, improving readability while maintaining the same behavior.