### PR TITLE
fix(cli): Incorrect display of `privateSourceCode` in CLI output

### DIFF
--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -877,7 +877,7 @@ export const chainDefinitionSchema = z
     privateSourceCode: z
       .boolean()
       .describe(
-        'Turns off inclusion of source code in packages. When set to true, Cannon cannot verify contracts on Etherscan.'
+        'Turns off inclusion of source code in packages. When set to true, Cannon cannot verify contracts on Etherscan. Defaults to false.'
       )
       .optional(),
   })

--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -79,9 +79,9 @@ describe('build', () => {
     let provider: viem.PublicClient & viem.WalletClient & viem.TestClient;
 
     beforeEach(() => {
-      jest
-        .spyOn(helpers, 'loadCannonfile')
-        .mockResolvedValue({ def: { danglingDependencies: {}, getDeployers: () => [] } } as any);
+      jest.spyOn(helpers, 'loadCannonfile').mockResolvedValue({
+        def: { danglingDependencies: {}, getDeployers: () => [], isPublicSourceCode: () => false },
+      } as any);
       provider = makeFakeProvider();
       jest.spyOn(buildCommand, 'build').mockResolvedValue({ outputs: {}, provider, runtime: {} as any });
       jest.spyOn(utilProvider, 'resolveProvider').mockResolvedValue({ provider: provider as any, signers: [] });

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -81,7 +81,6 @@ export async function build({
   writeScript,
   writeScriptFormat = 'ethers',
 }: Params): Promise<{ outputs: ChainArtifacts; provider: viem.PublicClient; runtime: ChainBuilderRuntime }> {
-  console.log('privateSourceCode: ', privateSourceCode);
   if (wipe && upgradeFrom) {
     throw new Error('wipe and upgradeFrom are mutually exclusive. Please specify one or the other');
   }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -49,7 +49,7 @@ interface Params {
   wipe?: boolean;
   persist?: boolean;
   plugins?: boolean;
-  publicSourceCode?: boolean;
+  privateSourceCode?: boolean;
   rpcUrl?: string;
   registryPriority?: 'local' | 'onchain' | 'offline';
   gasPrice?: bigint;
@@ -72,7 +72,7 @@ export async function build({
   wipe = false,
   persist = true,
   plugins = true,
-  publicSourceCode = false,
+  privateSourceCode = false,
   rpcUrl,
   registryPriority,
   gasPrice,
@@ -81,6 +81,7 @@ export async function build({
   writeScript,
   writeScriptFormat = 'ethers',
 }: Params): Promise<{ outputs: ChainArtifacts; provider: viem.PublicClient; runtime: ChainBuilderRuntime }> {
+  console.log('privateSourceCode: ', privateSourceCode);
   if (wipe && upgradeFrom) {
     throw new Error('wipe and upgradeFrom are mutually exclusive. Please specify one or the other');
   }
@@ -142,7 +143,8 @@ export async function build({
 
     snapshots: chainId === CANNON_CHAIN_ID,
     allowPartialDeploy: chainId !== CANNON_CHAIN_ID && persist,
-    publicSourceCode,
+    // ChainBuilderRuntime uses publicSourceCode to determine if source code should be included in the package
+    publicSourceCode: !privateSourceCode,
     gasPrice,
     gasFee,
     priorityGasFee,
@@ -217,7 +219,7 @@ export async function build({
   log('Version: ' + cyanBright(`${pkgVersion}`));
   log('Preset: ' + cyanBright(`${preset}`) + (preset == 'main' ? gray(' (default)') : ''));
   log('Chain ID: ' + cyanBright(`${chainId}`));
-  if (publicSourceCode) {
+  if (!privateSourceCode) {
     log(`Private Source Code: ${cyanBright('false')} ${gray('(source code will be included in the package)')}`);
   } else {
     log(`Private Source Code: ${cyanBright('true')} ${gray('(source code will not be included in the resulting package)')}`);

--- a/packages/cli/src/util/build.ts
+++ b/packages/cli/src/util/build.ts
@@ -293,6 +293,7 @@ async function prepareBuildConfig(
     getSigner,
     getDefaultSigner,
     upgradeFrom: options.upgradeFrom,
+    privateSourceCode: !def.isPublicSourceCode(),
     wipe: options.wipe,
     persist: !options.dryRun,
     overrideResolver,

--- a/packages/hardhat-cannon/src/internal/cannon.ts
+++ b/packages/hardhat-cannon/src/internal/cannon.ts
@@ -58,7 +58,7 @@ export async function cannonBuild(options: BuildOptions) {
     pkgInfo: loadPackageJson(path.join(hre.config.paths.root, 'package.json')),
     projectDirectory: hre.config.paths.root,
     registryPriority: options.registryPriority,
-    publicSourceCode: false,
+    privateSourceCode: true,
   });
 
   return { outputs };

--- a/packages/hardhat-cannon/src/tasks/build.ts
+++ b/packages/hardhat-cannon/src/tasks/build.ts
@@ -195,7 +195,7 @@ task(TASK_BUILD, 'Assemble a defined chain and save it to to a state which can b
         persist: !dryRun && hre.network.name !== 'hardhat',
         overrideResolver: dryRun ? await createDryRunRegistry(resolveCliSettings()) : undefined,
         plugins: !!usePlugins,
-        publicSourceCode: hre.config.cannon.publicSourceCode,
+        privateSourceCode: !hre.config.cannon.publicSourceCode,
         writeScript,
         writeScriptFormat,
       } as const;


### PR DESCRIPTION
Bug: The output incorrectly shows that the package is closed source, even though this is not specified in the Cannonfile.



Cannonfile example:

```
name = "example-token"
version = "1.0.0"
description = "Example token"
preset = "main"

[setting.salt]
defaultValue = "salt"

[setting.name]
defaultValue = "Token"

[setting.symbol]
defaultValue = "TKN"

[setting.initialSupply]
defaultValue = "0"

[setting.owner]
defaultValue = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"

[contract.MintableToken]
artifact = "MintableToken"
from = "<%= settings.owner %>"
salt = "<%= settings.salt %>"
args = [
    "<%= settings.name %>",
    "<%= settings.symbol %>",
    "<%= settings.initialSupply %>",
]
create2 = true
highlight = true
```

Build output:
```
Initializing new package...
Name: example-token
Version: 1.0.0
Preset: main (default)
Chain ID: 10
Private Source Code: true (source code will not be included in the resulting package)
```
