### PR TITLE
chore(builder): switch to Viem's setCode for Ganache

### DIFF
--- a/packages/builder/src/helpers.ts
+++ b/packages/builder/src/helpers.ts
@@ -65,14 +65,5 @@ export async function getCannonContract(args: {
 export async function loadPrecompiles(provider: viem.TestClient) {
   const precompiles = await import('./precompiles');
 
-  for (const precompileCall of precompiles.default)
-    if (provider.mode === 'ganache') {
-      await provider.request({
-        // @ts-ignore: evm_setAccountCode is not currently implemented in Viem.
-        method: 'evm_setAccountCode',
-        params: [precompileCall.address, precompileCall.bytecode],
-      });
-    } else {
-      await provider.setCode(precompileCall);
-    }
+  for (const precompileCall of precompiles.default) await provider.setCode(precompileCall);
 }


### PR DESCRIPTION
This PR aims to remove a workaround that was implemented when Viem did not yet include the setCode function for Ganache. Related PR: https://github.com/wevm/viem/pull/2636