### PR TITLE
hotfix(docs): fix cannonfile spec docs

### DIFF
--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -880,29 +880,29 @@ export const chainDefinitionSchema = z
         'Turns off inclusion of source code in packages. When set to true, Cannon cannot verify contracts on Etherscan. Defaults to false.'
       )
       .optional(),
+    /**
+     * Description for the package
+     */
+    description: z.string().describe('Description for the package').optional(),
+    /**
+     * Keywords for search indexing
+     */
+    keywords: z.array(z.string()).describe('Keywords for search indexing').optional(),
+    /**
+     * Any deployers that could publish this package. Will be used for automatic version management.
+     */
+    deployers: z
+      .array(
+        z.string().refine((val) => !!val.match(RegExp(/^0x[a-fA-F0-9]{40}$/, 'gm')), {
+          message: 'Invalid Ethereum address',
+        })
+      )
+      .describe('Any deployers that could publish this package. Will be used for automatic version management.')
+      .optional(),
   })
   .merge(
     z
       .object({
-        /**
-         * Description for the package
-         */
-        description: z.string().describe('Description for the package'),
-        /**
-         * Keywords for search indexing
-         */
-        keywords: z.array(z.string()).describe('Keywords for search indexing'),
-        /**
-         * Any deployers that could publish this package. Will be used for automatic version management.
-         */
-        deployers: z
-          .array(
-            z.string().refine((val) => !!val.match(RegExp(/^0x[a-fA-F0-9]{40}$/, 'gm')), {
-              message: 'Invalid Ethereum address',
-            })
-          )
-          .optional()
-          .describe('Any deployers that could publish this package. Will be used for automatic version management.'),
         /**
          * Object that allows the definition of values for use in next operations
          * ```toml

--- a/packages/website/src/features/Docs/DocsCannonfilesPage.tsx
+++ b/packages/website/src/features/Docs/DocsCannonfilesPage.tsx
@@ -243,8 +243,8 @@ const DocsCannonfilesPage: FC = () => {
               title="Cannonfile Spec"
               links={[
                 { href: '#cannonfile-metadata', text: 'Metadata' },
-                { href: '#utilities', text: 'Utilities' },
                 { href: '#constants', text: 'Constants' },
+                { href: '#utilities', text: 'Utilities' },
                 ...Array.from(cannonfileSpecs, ([key]) => key)
                   .filter(
                     (key) =>

--- a/packages/website/src/features/Docs/DocsCannonfilesPage.tsx
+++ b/packages/website/src/features/Docs/DocsCannonfilesPage.tsx
@@ -126,15 +126,15 @@ const deploymentDataExample = {
 interface LinkItem {
   href: string;
   text: string;
+  monospace?: boolean;
 }
 
 interface SectionProps {
   title: string;
   links: LinkItem[];
-  monospace?: boolean;
 }
 
-const Section: FC<SectionProps> = ({ title, links, monospace }) => (
+const Section: FC<SectionProps> = ({ title, links }) => (
   <Box my={4}>
     <Heading
       fontWeight="500"
@@ -158,9 +158,9 @@ const Section: FC<SectionProps> = ({ title, links, monospace }) => (
           px="2"
           cursor="pointer"
           fontSize="sm"
+          fontFamily={link.monospace ? 'var(--font-mono)' : undefined}
           _hover={{ background: 'gray.800' }}
           href={link.href}
-          fontFamily={monospace ? 'monospace' : 'var(--font-miriam)'}
         >
           {link.text}
         </Link>
@@ -242,8 +242,8 @@ const DocsCannonfilesPage: FC = () => {
             <Section
               title="Cannonfile Spec"
               links={[
-                { href: '#cannonfile-metadata', text: 'Cannonfile Metadata' },
-                { href: '#utilities', text: 'Utility Functions' },
+                { href: '#cannonfile-metadata', text: 'Metadata' },
+                { href: '#utilities', text: 'Utilities' },
                 { href: '#constants', text: 'Constants' },
                 ...Array.from(cannonfileSpecs, ([key]) => key)
                   .filter(

--- a/packages/website/src/features/Docs/DocsCannonfilesPage.tsx
+++ b/packages/website/src/features/Docs/DocsCannonfilesPage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { CommandPreview } from '@/components/CommandPreview';
 import { CustomSpinner } from '@/components/CustomSpinner';
 import { useCannonfileSpecs } from '@/hooks/cannonfileSpecs';
 import {
@@ -151,12 +152,14 @@ interface LinkItem {
 interface SectionProps {
   title: string;
   links: LinkItem[];
+  monospace?: boolean;
 }
 
-const Section: FC<SectionProps> = ({ title, links }) => (
+const Section: FC<SectionProps> = ({ title, links, monospace }) => (
   <Box my={4}>
     <Heading
       fontWeight="500"
+      fontFamily={monospace ? 'var(--font-mono)' : 'var(--font-miriam)'}
       size="sm"
       color="gray.200"
       letterSpacing="0.1px"
@@ -246,9 +249,10 @@ const DocsCannonfilesPage: FC = () => {
         >
           <Box px={3} pb={2}>
             <Section
-              title="Cannonfile Specification"
+              title="Cannonfile Spec"
               links={[
                 { href: '#cannonfile-metadata', text: 'Cannonfile Metadata' },
+                { href: '#utilities', text: 'Utility Functions' },
                 { href: '#constants', text: 'Constants' },
                 ...Array.from(cannonfileSpecs, ([key]) => key)
                   .filter(
@@ -259,6 +263,7 @@ const DocsCannonfilesPage: FC = () => {
                   .map((key) => ({
                     href: `#${key}`,
                     text: key as string,
+                    monospace: true,
                   })),
               ]}
             />
@@ -424,45 +429,64 @@ const DocsCannonfilesPage: FC = () => {
                 <CustomTable
                   data={[
                     {
-                      key: 'Zero',
-                      dataType: 'number',
-                      value: 'The BigNumber value representing "0".',
+                      key: 'AddressZero | zeroAddress',
+                      dataType: 'string',
+                      value:
+                        'Zero Addres string: "0x0000000000000000000000000000000000000000".',
                     },
                     {
-                      key: 'One',
-                      dataType: 'number',
-                      value: 'The BigNumber value representing "1".',
+                      key: 'HashZero | zeroHash',
+                      dataType: 'string',
+                      value:
+                        'Zero hash value: "0x0000000000000000000000000000000000000000000000000000000000000000"',
                     },
                     {
-                      key: 'Two',
-                      dataType: 'number',
-                      value: 'The BigNumber value representing "2".',
-                    },
-                    {
-                      key: 'WeiPerEther',
+                      key: 'maxInt8...256',
                       dataType: 'number',
                       value:
-                        'The BigNumber value representing "1000000000000000000", which is the number of Wei per Ether.',
+                        'BigNumber values representing from maxInt8 to maxInt256.',
                     },
                     {
-                      key: 'MaxUint256',
+                      key: 'minInt8...256',
                       dataType: 'number',
                       value:
-                        'The BigNumber value representing the maximum uint256 value.',
+                        'BigNumber values representing from minInt8 to minInt256.',
                     },
                     {
-                      key: 'MinInt256',
+                      key: 'maxUint8...256',
                       dataType: 'number',
                       value:
-                        'The BigNumber value representing the minimum int256 value.',
-                    },
-                    {
-                      key: 'MaxInt256',
-                      dataType: 'number',
-                      value:
-                        'The BigNumber value representing the maximum int256 value.',
+                        'BigNumber values representing from maxUint8 to maxUint256.',
                     },
                   ]}
+                />
+              </Box>
+              <Box mb={16} id="utilities">
+                <Heading mb={4} fontSize="lg">
+                  Utilities
+                  <Link
+                    color="gray.300"
+                    ml={2}
+                    textDecoration="none"
+                    _hover={{ textDecoration: 'underline' }}
+                    href={'#constants'}
+                  >
+                    #
+                  </Link>
+                </Heading>
+                <Text mb="4">
+                  <Link
+                    href="https://viem.sh/docs/utilities/getAddress"
+                    isExternal
+                  >
+                    Viem.sh
+                  </Link>{' '}
+                  utility functions are available inside interpolation values,
+                  e.g.:
+                </Text>
+                <CommandPreview
+                  backgroundColor="black"
+                  command={'args = ["<%=  keccak256(\'some string\') %>"]'}
                 />
               </Box>
               {Array.from(cannonfileSpecs)

--- a/packages/website/src/features/Docs/DocsCannonfilesPage.tsx
+++ b/packages/website/src/features/Docs/DocsCannonfilesPage.tsx
@@ -122,27 +122,6 @@ const deploymentDataExample = {
   },
   miscUrl: 'ipfs://Qm...',
 };
-interface CustomLinkProps {
-  href: string;
-  children: React.ReactNode;
-}
-
-const CustomLink: FC<CustomLinkProps> = ({ href, children }) => (
-  <Link
-    display="block"
-    textDecoration="none"
-    borderRadius="md"
-    mb={0.5}
-    py={0.5}
-    px="2"
-    cursor="pointer"
-    fontSize="sm"
-    _hover={{ background: 'gray.800' }}
-    href={href}
-  >
-    {children}
-  </Link>
-);
 
 interface LinkItem {
   href: string;
@@ -159,7 +138,6 @@ const Section: FC<SectionProps> = ({ title, links, monospace }) => (
   <Box my={4}>
     <Heading
       fontWeight="500"
-      fontFamily={monospace ? 'var(--font-mono)' : 'var(--font-miriam)'}
       size="sm"
       color="gray.200"
       letterSpacing="0.1px"
@@ -170,9 +148,22 @@ const Section: FC<SectionProps> = ({ title, links, monospace }) => (
     </Heading>
     <Box mb={6}>
       {links.map((link, index) => (
-        <CustomLink key={index} href={link.href}>
+        <Link
+          key={index}
+          display="block"
+          textDecoration="none"
+          borderRadius="md"
+          mb={0.5}
+          py={0.5}
+          px="2"
+          cursor="pointer"
+          fontSize="sm"
+          _hover={{ background: 'gray.800' }}
+          href={link.href}
+          fontFamily={monospace ? 'monospace' : 'var(--font-miriam)'}
+        >
           {link.text}
-        </CustomLink>
+        </Link>
       ))}
     </Box>
   </Box>
@@ -262,7 +253,7 @@ const DocsCannonfilesPage: FC = () => {
                   )
                   .map((key) => ({
                     href: `#${key}`,
-                    text: key as string,
+                    text: `[${key}.*]`,
                     monospace: true,
                   })),
               ]}
@@ -504,7 +495,7 @@ const DocsCannonfilesPage: FC = () => {
                   <Box key={key} id={key} mb={16}>
                     <Heading mb={4} fontSize="lg">
                       <Code px={0} fontSize="lg">
-                        {key}
+                        [{key}.*]
                       </Code>
                       <Link
                         color="gray.300"

--- a/packages/website/src/hooks/cannonfileSpecs.ts
+++ b/packages/website/src/hooks/cannonfileSpecs.ts
@@ -70,13 +70,14 @@ async function fetchCannonfileSpecs() {
 
   const result = new Map<string, CannonfileSpec>();
 
-  const metadataKeys = ['name', 'preset', 'version', 'description', 'keywords', 'privateSourceCode'];
+  const metadataKeys = ['name', 'preset', 'version', 'description', 'keywords', 'privateSourceCode', 'deployers'];
   const metadataSpecs: Spec[] = [];
   for (const key of metadataKeys) {
     metadataSpecs.push(await getSpec(chainDefinitionJsonSchema, key));
   }
+
   result.set('metadata', {
-    description: 'Provide metadata for your Cannonfile.',
+    description: 'Provide metadata for your Cannonfile. These are the top-most attributes on your Cannonfile.',
     specs: metadataSpecs,
   });
 


### PR DESCRIPTION
This PR includes changes on the https://website-lrrh8g5w8-cannon.vercel.app/learn/cannonfile section.
1. Fixes the `deployers` key documentation
2. Updates the `Constants` section with real data
3. Adds a section for `Utilities`
4. When referencing step types, instead of writing `pull` write it as `[pull.*]` to make it more clear that is a step name and differentiate it from other sections