### PR TITLE
fix(website): Fix flag shown in deploy guide

### DIFF
--- a/packages/website/src/features/GetStarted/SetupSection/FoundryGuide/DeployYourProtocol.tsx
+++ b/packages/website/src/features/GetStarted/SetupSection/FoundryGuide/DeployYourProtocol.tsx
@@ -14,7 +14,7 @@ export const DeployYourProtocol = () => {
       </Heading>
       <Text mb={4}>Deploying is just building on a remote network!</Text>
       <Box mb={4}>
-        <CommandPreview command="cannon build --network REPLACE_WITH_RPC_ENDPOINT --private-key REPLACE_WITH_KEY_THAT_HAS_GAS_TOKENS" />
+        <CommandPreview command="cannon build --rpc-url REPLACE_WITH_RPC_ENDPOINT --private-key REPLACE_WITH_KEY_THAT_HAS_GAS_TOKENS" />
       </Box>
       <Text mb={4}>
         Verify your project&apos;s contracts on&nbsp;


### PR DESCRIPTION
Bug: `--network` is not an available flag in the build command.

<img width="1005" alt="Screenshot 2024-10-25 at 11 31 35 AM" src="https://github.com/user-attachments/assets/fa7bc73e-e500-490c-aeb7-b5f5fdedfedd">
