### PR TITLE
fix(website): manually estimate gas from cost of individual txns

### DIFF
--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -402,7 +402,7 @@ export default function QueueFromGitOps() {
   let totalGas = BigInt(0);
 
   for (const step of buildState.result?.safeSteps || []) {
-    totalGas += BigInt(step.gas.toString());
+    totalGas += BigInt(step.gas.toString()) + BigInt(50000);
   }
 
   const toast = useToast();

--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -402,7 +402,7 @@ export default function QueueFromGitOps() {
   let totalGas = BigInt(0);
 
   for (const step of buildState.result?.safeSteps || []) {
-    totalGas += BigInt(step.gas.toString()) + BigInt(50000);
+    totalGas += BigInt(step.gas.toString()) + BigInt(50_000);
   }
 
   const toast = useToast();

--- a/packages/website/src/hooks/backend.ts
+++ b/packages/website/src/hooks/backend.ts
@@ -240,7 +240,7 @@ export function useTxnStager(
       safeTxn.refundReceiver,
       '0x' + execSig.map((s) => s.slice(2)).join(''),
     ],
-      gas: BigInt(Math.floor((parseInt(safeTxn.safeTxGas) + 500000) * 1.1))
+    gas: BigInt(Math.floor((parseInt(safeTxn.safeTxGas) + 500000) * 1.1)),
   };
 
   const stageTxnMutate = useSimulateContract(execTransactionData);

--- a/packages/website/src/hooks/backend.ts
+++ b/packages/website/src/hooks/backend.ts
@@ -240,6 +240,7 @@ export function useTxnStager(
       safeTxn.refundReceiver,
       '0x' + execSig.map((s) => s.slice(2)).join(''),
     ],
+      gas: BigInt(Math.floor((parseInt(safeTxn.safeTxGas) + 500000) * 1.1))
   };
 
   const stageTxnMutate = useSimulateContract(execTransactionData);

--- a/packages/website/src/hooks/backend.ts
+++ b/packages/website/src/hooks/backend.ts
@@ -240,7 +240,7 @@ export function useTxnStager(
       safeTxn.refundReceiver,
       '0x' + execSig.map((s) => s.slice(2)).join(''),
     ],
-    gas: BigInt(Math.floor((parseInt(safeTxn.safeTxGas) + 500000) * 1.1)),
+    gas: BigInt(Math.floor((parseInt(safeTxn.safeTxGas) + 500_000) * 1.1)),
   };
 
   const stageTxnMutate = useSimulateContract(execTransactionData);


### PR DESCRIPTION
rather than trying to use the regular `estimateGas` facilities which can be unreliable, we compute the total gas that should be required by adding the component cost of the multicall txns and expected costs of safe execution and multicall. the sum is the gas estimate, which should be much more accurate