### PR TITLE
feat(cli): add --skip-upgrade-record flag

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -48,6 +48,7 @@ interface Params {
   overrideResolver?: CannonRegistry;
   wipe?: boolean;
   persist?: boolean;
+  skipUpgradeRecord?: false;
   plugins?: boolean;
   privateSourceCode?: boolean;
   rpcUrl?: string;
@@ -71,6 +72,7 @@ export async function build({
   overrideResolver,
   wipe = false,
   persist = true,
+  skipUpgradeRecord = false,
   plugins = true,
   privateSourceCode = false,
   rpcUrl,
@@ -446,7 +448,7 @@ export async function build({
     const metaUrl = await runtime.putBlob(metadata);
 
     // write upgrade-from info on-chain
-    if (stepsExecuted && persist) {
+    if (stepsExecuted && persist && !skipUpgradeRecord) {
       for (let i = 0; i < 3; i++) {
         try {
           log(gray('Writing upgrade info...'));

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -125,7 +125,12 @@ export const commandsConfig: CommandsConfig = {
       },
       {
         flags: '--upgrade-from [cannon-package:0.0.1]',
-        description: 'Specify a package to use as a new base for the deployment.',
+        description: 'Specify a package to use as a new base for the deployment',
+      },
+      {
+        flags: '--skip-upgrade-record',
+        description:
+          'Skip step taken at the end of the build to save the execution record on-chain, which would be used for future reference on upgrades',
       },
       {
         flags: '--registry-priority <registry>',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -219,7 +219,7 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
     }
 
     if (options.keepAlive && node) {
-      log(`The local node will continue running at ${node.host}`);
+      log(`The local node will continue running at ${node!.host}`);
 
       const { run } = await import('./commands/run');
 


### PR DESCRIPTION
Add `--skip-upgrade-record` to `cannon build` command in case of an emergency the user does not want to create a record on chain about the build.