### PR TITLE
fix(cli): cannot build on Cannon network with --dry-run

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import {
+  CANNON_CHAIN_ID,
   CannonStorage,
   ChainBuilderRuntime,
   ChainDefinition,
@@ -159,6 +160,12 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
   .action(async (cannonfile, settings, options) => {
     // ensure foundry compatibility
     await ensureFoundryCompatibility();
+
+    // throw an error if chain id is undefined and dry run is true
+    // chain id undefined means the user wants to use Cannon Network
+    if (options.chainId === undefined && options.dryRun) {
+      throw new Error('Cannot build on Cannon Network with --dry-run flag.');
+    }
 
     // backwards compatibility for --port flag
     if (options.port !== ANVIL_PORT_DEFAULT_VALUE) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,6 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import {
-  CANNON_CHAIN_ID,
   CannonStorage,
   ChainBuilderRuntime,
   ChainDefinition,


### PR DESCRIPTION
Running `cannon build` with `--dry-run` without specifying the `--chain-id` should throw an error.

Bug:

```
cannon build mintable-token.cannonfile.toml --dry-run
Building the foundry project...
forge build succeeded

Anvil instance running on: http://127.0.0.1:61073

shutting down existing anvil subprocess 24191
/usr/local/lib/node_modules/@usecannon/cli/dist/src/rpc.js:69
        throw new Error('Cannot set both an anvil forkUrl and a proxy provider connection');
              ^

Error: Cannot set both an anvil forkUrl and a proxy provider connection
    at runRpc (/usr/local/lib/node_modules/@usecannon/cli/dist/src/rpc.js:69:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ChildProcess.<anonymous> (/usr/local/lib/node_modules/@usecannon/cli/dist/src/rpc.js:81:25)

Node.js v20.16.0
```