### PR TITLE
fix(links-guides): fix links to /setup and add test solidity file

### DIFF
--- a/packages/website/guides/test-with-cannon.mdx
+++ b/packages/website/guides/test-with-cannon.mdx
@@ -2,13 +2,13 @@
 title: Test with Cannon
 description: Test your protocol using Cannon.
 before:
-  url: "build-with-cannon"
-  title: "Build with Cannon"
-  description: "Build a protocol using Cannon."
+  url: 'build-with-cannon'
+  title: 'Build with Cannon'
+  description: 'Build a protocol using Cannon.'
 after:
-  url: "deploy-onchain"
-  title: "Deploy Onchain"
-  description: "Deploy your protocol onchain."
+  url: 'deploy-onchain'
+  title: 'Deploy Onchain'
+  description: 'Deploy your protocol onchain.'
 ---
 
 ## Test with Cannon
@@ -28,7 +28,8 @@ By convention, tests in Foundry are located in the `/test` folder and the test f
 
 <Alert variant="warning" className="mt-6">
   <AlertDescription>
-    For more information on how to write and perform tests with Foundry, [review their docs](https://book.getfoundry.sh/forge/tests).
+    For more information on how to write and perform tests with Foundry, [review
+    their docs](https://book.getfoundry.sh/forge/tests).
   </AlertDescription>
 </Alert>
 
@@ -43,7 +44,7 @@ import { Counter } from "../src/Counter.sol";
 
 contract CounterTest is Test {
     Counter public counter;
-    
+
     Counter counter
 
     function setUp() public {
@@ -83,11 +84,11 @@ import { Counter } from "../src/Counter.sol";
 contract CounterTest is Test {
 		using Cannon for Vm;
     Counter public counter;
-    
+
     Counter counter
 
     function setUp() public {
-        counter = Counter(vm.getAddress("Counter")); // Chequear si es el step name o el artifact
+        counter = Counter(vm.getAddress("Counter"));
         counter.setNumber(0);
     }
 
@@ -107,12 +108,13 @@ Cannon runs `forge test` in the background, but the `cannon test` command can re
 
 <Alert variant="warning">
   <AlertDescription>
-    This is a simple case of testing using `cannon test`. Later, we'll see how we can use `usecannon/cannon-std` to interact with the Cannon registry and other contracts deployed in Cannon.
+    This is a simple case of testing using `cannon test`. Later, we'll see how
+    we can use `usecannon/cannon-std` to interact with the Cannon registry and
+    other contracts deployed in Cannon.
   </AlertDescription>
 </Alert>
 
 After running the tests, the CLI will notify us that all tests have passed successfully.
-
 
 ```bash
 Writing deployment artifacts to ./deployments/test
@@ -127,6 +129,7 @@ Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 19.96ms (11.97ms CP
 Ran 1 test suite in 135.12ms (19.96ms CPU time): 2 tests passed, 0 failed, 0 skipped (2 total tests)
 forge exited with code 0
 ```
+
 </TabsContent>
   <TabsContent value="hardhat">
 *Coming soon.*

--- a/packages/website/guides/test-with-cannon.mdx
+++ b/packages/website/guides/test-with-cannon.mdx
@@ -69,6 +69,40 @@ We are going to use the `cannon-std` helper library from Cannon to write tests. 
 forge install usecannon/cannon-std
 ```
 
+```solidity
+// ./test/Counter.t.sol
+
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "cannon-std/Cannon.sol";
+
+import { Test } from "forge-std/Test.sol";
+import { Counter } from "../src/Counter.sol";
+
+contract CounterTest is Test {
+		using Cannon for Vm;
+    Counter public counter;
+    
+    Counter counter
+
+    function setUp() public {
+        counter = Counter(vm.getAddress("Counter")); // Chequear si es el step name o el artifact
+        counter.setNumber(0);
+    }
+
+    function test_Increment() public {
+        counter.increment();
+        assertEq(counter.number(), 1);
+    }
+
+    function testFuzz_SetNumber(uint256 x) public {
+        counter.setNumber(x);
+        assertEq(counter.number(), x);
+    }
+}
+```
+
 Cannon runs `forge test` in the background, but the `cannon test` command can receive a specific cannonfile as an argument to run the test suites. By default, it uses `cannonfile.toml`.
 
 <Alert variant="warning">

--- a/packages/website/guides/test-with-cannon.mdx
+++ b/packages/website/guides/test-with-cannon.mdx
@@ -33,10 +33,9 @@ By convention, tests in Foundry are located in the `/test` folder and the test f
   </AlertDescription>
 </Alert>
 
-In this example, we will use the test created by `forge init` in `test/Counter.t.sol`. Also we are
-going to use the `cannon-std` helper library from Cannon to write tests.
+In this example, we will add the `cannon-std` helper library to the test created by `forge init` in `test/Counter.t.sol`. This library allows us to access data from the build.
 
-This library allows us to access data from the build. To install it, run:
+To install it, run:
 
 ```bash
 forge install usecannon/cannon-std
@@ -48,7 +47,7 @@ forge install usecannon/cannon-std
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "cannon-std/Cannon.sol";
+import "cannon-std/Cannon.sol"; # Import the library
 
 import { Test } from "forge-std/Test.sol";
 import { Counter } from "../src/Counter.sol";
@@ -60,7 +59,7 @@ contract CounterTest is Test {
     Counter counter
 
     function setUp() public {
-        counter = Counter(vm.getAddress("Counter"));
+        counter = Counter(vm.getAddress("Counter")); # Get the address for the built artifact
         counter.setNumber(0);
     }
 
@@ -76,15 +75,13 @@ contract CounterTest is Test {
 }
 ```
 
-Cannon runs `forge test` in the background, but the `cannon test` command can receive a specific cannonfile as an argument to run the test suites. By default, it uses `cannonfile.toml`.
+Now run the tests with:
 
-<Alert variant="warning">
-  <AlertDescription>
-    This is a simple case of testing using `cannon test`. Later, we'll see how
-    we can use `usecannon/cannon-std` to interact with the Cannon registry and
-    other contracts deployed in Cannon.
-  </AlertDescription>
-</Alert>
+```bash
+cannon test
+```
+
+Cannon runs `forge test` after building your cannonfile. By default, it uses `cannonfile.toml`.
 
 After running the tests, the CLI will notify us that all tests have passed successfully.
 

--- a/packages/website/guides/test-with-cannon.mdx
+++ b/packages/website/guides/test-with-cannon.mdx
@@ -33,38 +33,10 @@ By convention, tests in Foundry are located in the `/test` folder and the test f
   </AlertDescription>
 </Alert>
 
-In this example, we will use the test created by `forge init` in `test/Counter.t.sol`.
+In this example, we will use the test created by `forge init` in `test/Counter.t.sol`. Also we are
+going to use the `cannon-std` helper library from Cannon to write tests.
 
-```solidity
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
-
-import { Test } from "forge-std/Test.sol";
-import { Counter } from "../src/Counter.sol";
-
-contract CounterTest is Test {
-    Counter public counter;
-
-    Counter counter
-
-    function setUp() public {
-        counter = new Counter();
-        counter.setNumber(0);
-    }
-
-    function test_Increment() public {
-        counter.increment();
-        assertEq(counter.number(), 1);
-    }
-
-    function testFuzz_SetNumber(uint256 x) public {
-        counter.setNumber(x);
-        assertEq(counter.number(), x);
-    }
-}
-```
-
-We are going to use the `cannon-std` helper library from Cannon to write tests. This library allows us to access data from the build. To install it, run:
+This library allows us to access data from the build. To install it, run:
 
 ```bash
 forge install usecannon/cannon-std

--- a/packages/website/src/features/Docs/DocsLandingPage.tsx
+++ b/packages/website/src/features/Docs/DocsLandingPage.tsx
@@ -198,7 +198,7 @@ const DocsLandingPage = () => {
       </div>
 
       <div className="flex justify-center py-24 lg:py-32">
-        <Link href={`${links.GETSTARTED}/introduction`}>
+        <Link href={`${links.GETSTARTED}/setup`}>
           <Button
             className="font-miriam uppercase tracking-[0.5px] font-bold"
             variant="default"

--- a/packages/website/src/features/HomePage/HomePage.tsx
+++ b/packages/website/src/features/HomePage/HomePage.tsx
@@ -176,7 +176,7 @@ export default function HomePage() {
                   and mainnets. Deploy packages on a local node for development
                   with a single command.
                 </p>
-                <NextLink href={`${links.GETSTARTED}/introduction`}>
+                <NextLink href={`${links.GETSTARTED}/setup`}>
                   <Button
                     className="font-miriam uppercase tracking-wider font-bold"
                     size="lg"

--- a/packages/website/src/pages/learn/guides/index.tsx
+++ b/packages/website/src/pages/learn/guides/index.tsx
@@ -10,7 +10,7 @@ export default function Home() {
   const router = useRouter();
   useEffect(() => {
     router
-      .push(`${links.GETSTARTED}/introduction`)
+      .push(`${links.GETSTARTED}/setup`)
       .then(() => {
         // do nothing
       })


### PR DESCRIPTION
- change links from `/introduction` to `/setup`
- add solidity test file example