### PR TITLE
fix(website): version dialog preset

### DIFF
--- a/packages/website/postcss.config.js
+++ b/packages/website/postcss.config.js
@@ -3,4 +3,4 @@ module.exports = {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/packages/website/src/components/ui/tooltip.tsx
+++ b/packages/website/src/components/ui/tooltip.tsx
@@ -23,7 +23,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 overflow-hidden rounded-md  bg-hover border-border bg-black px-3 py-1.5 text-xs animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-[1500] overflow-hidden rounded-md  bg-hover border-border bg-black px-3 py-1.5 text-xs animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}

--- a/packages/website/src/features/Search/PackageCard/DataTable.tsx
+++ b/packages/website/src/features/Search/PackageCard/DataTable.tsx
@@ -8,7 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { ArrowRightIcon, CaretSortIcon } from '@radix-ui/react-icons';
+import { ArrowRightIcon, CaretSortIcon, QuestionMarkCircledIcon } from '@radix-ui/react-icons';
 import {
   useReactTable,
   flexRender,
@@ -142,6 +142,18 @@ export function DataTable<Data extends object>({
                             header.getContext()
                           )}
                           <CaretSortIcon className="ml-2 h-4 w-4" />
+                          {header.column.columnDef.accessorKey == 'preset' && (
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger>
+                                  <QuestionMarkCircledIcon className='inline-block whitespace-nowrap'/>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  Presets are useful for distinguishing multiple deployments of the same protocol on the same chain.
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          )}
                         </Button>
                       ) : (
                         flexRender(

--- a/packages/website/src/features/Search/PackageCard/DataTable.tsx
+++ b/packages/website/src/features/Search/PackageCard/DataTable.tsx
@@ -150,7 +150,7 @@ export function DataTable<Data extends object>({
                             <TooltipProvider>
                               <Tooltip>
                                 <TooltipTrigger>
-                                  <QuestionMarkCircledIcon className="inline-block whitespace-nowrap" />
+                                  <QuestionMarkCircledIcon className="inline-block whitespace-nowrap max-w-[250px] items-center justify-center" />
                                 </TooltipTrigger>
                                 <TooltipContent>
                                   Presets are useful for distinguishing multiple

--- a/packages/website/src/features/Search/PackageCard/DataTable.tsx
+++ b/packages/website/src/features/Search/PackageCard/DataTable.tsx
@@ -8,7 +8,11 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { ArrowRightIcon, CaretSortIcon, QuestionMarkCircledIcon } from '@radix-ui/react-icons';
+import {
+  ArrowRightIcon,
+  CaretSortIcon,
+  QuestionMarkCircledIcon,
+} from '@radix-ui/react-icons';
 import {
   useReactTable,
   flexRender,
@@ -146,10 +150,12 @@ export function DataTable<Data extends object>({
                             <TooltipProvider>
                               <Tooltip>
                                 <TooltipTrigger>
-                                  <QuestionMarkCircledIcon className='inline-block whitespace-nowrap'/>
+                                  <QuestionMarkCircledIcon className="inline-block whitespace-nowrap" />
                                 </TooltipTrigger>
                                 <TooltipContent>
-                                  Presets are useful for distinguishing multiple deployments of the same protocol on the same chain.
+                                  Presets are useful for distinguishing multiple
+                                  deployments of the same protocol on the same
+                                  chain.
                                 </TooltipContent>
                               </Tooltip>
                             </TooltipProvider>

--- a/packages/website/src/features/Search/PackageCard/DataTable.tsx
+++ b/packages/website/src/features/Search/PackageCard/DataTable.tsx
@@ -139,7 +139,7 @@ export function DataTable<Data extends object>({
                         <Button
                           variant="ghost"
                           onClick={header.column.getToggleSortingHandler()}
-                          className="h-8 px-2 -ml-2"
+                          className="h-8 px-2 -ml-2 inline-flex items-center justify-center"
                         >
                           {flexRender(
                             header.column.columnDef.header,
@@ -150,9 +150,9 @@ export function DataTable<Data extends object>({
                             <TooltipProvider>
                               <Tooltip>
                                 <TooltipTrigger>
-                                  <QuestionMarkCircledIcon className="inline-block whitespace-nowrap max-w-[250px] items-center justify-center" />
+                                  <QuestionMarkCircledIcon className="inline-block whitespace-nowrap align-sub" />
                                 </TooltipTrigger>
-                                <TooltipContent>
+                                <TooltipContent className="max-w-sm text-center">
                                   Presets are useful for distinguishing multiple
                                   deployments of the same protocol on the same
                                   chain.

--- a/packages/website/tailwind.config.js
+++ b/packages/website/tailwind.config.js
@@ -1,100 +1,97 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-    darkMode: ["class"],
-    content: [
-    "./src/**/*.{js,ts,jsx,tsx,mdx}"
-  ],
+  darkMode: ['class'],
+  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
-  	extend: {
-  		container: {
-  			center: 'true'
-  		},
-  		fontFamily: {
-  			miriam: ['var(--font-miriam)'],
-  			inter: ['var(--font-inter)'],
-  			outfit: ['var(--font-outfit)']
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			},
-  			sidebar: {
-  				DEFAULT: 'hsl(var(--sidebar-background))',
-  				foreground: 'hsl(var(--sidebar-foreground))',
-  				primary: 'hsl(var(--sidebar-primary))',
-  				'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-  				accent: 'hsl(var(--sidebar-accent))',
-  				'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-  				border: 'hsl(var(--sidebar-border))',
-  				ring: 'hsl(var(--sidebar-ring))'
-  			}
-  		},
-  		keyframes: {
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			}
-  		},
-  		animation: {
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
-  		}
-  	}
+    extend: {
+      container: {
+        center: 'true',
+      },
+      fontFamily: {
+        miriam: ['var(--font-miriam)'],
+        inter: ['var(--font-inter)'],
+        outfit: ['var(--font-outfit)'],
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        chart: {
+          1: 'hsl(var(--chart-1))',
+          2: 'hsl(var(--chart-2))',
+          3: 'hsl(var(--chart-3))',
+          4: 'hsl(var(--chart-4))',
+          5: 'hsl(var(--chart-5))',
+        },
+        sidebar: {
+          DEFAULT: 'hsl(var(--sidebar-background))',
+          foreground: 'hsl(var(--sidebar-foreground))',
+          primary: 'hsl(var(--sidebar-primary))',
+          'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+          accent: 'hsl(var(--sidebar-accent))',
+          'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+          border: 'hsl(var(--sidebar-border))',
+          ring: 'hsl(var(--sidebar-ring))',
+        },
+      },
+      keyframes: {
+        'accordion-down': {
+          from: {
+            height: '0',
+          },
+          to: {
+            height: 'var(--radix-accordion-content-height)',
+          },
+        },
+        'accordion-up': {
+          from: {
+            height: 'var(--radix-accordion-content-height)',
+          },
+          to: {
+            height: '0',
+          },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+    },
   },
-  plugins: [require("tailwindcss-animate")],
-}
-
+  plugins: [require('tailwindcss-animate')],
+};


### PR DESCRIPTION
Added the tooltips next to "Preset" in the table header
Also fixed z tag to prevent tooltip content under a modal

<img width="726" alt="Screenshot 2024-12-03 at 15 26 38" src="https://github.com/user-attachments/assets/249de02c-fed8-4f87-bcf8-66047013b16d">
