### PR TITLE
fix(cli): remove @ipfs: protocol compatibility

### DIFF
--- a/packages/builder/src/ipfs.ts
+++ b/packages/builder/src/ipfs.ts
@@ -47,7 +47,7 @@ export function getIpfsCid(str: any): string | null {
 }
 
 export function getIpfsUrl(str: any): string | null {
-  const cid = parseIpfsCid(str);
+  const cid = getIpfsCid(str);
   return cid ? `ipfs://${cid}` : null;
 }
 

--- a/packages/builder/src/ipfs.ts
+++ b/packages/builder/src/ipfs.ts
@@ -42,6 +42,15 @@ export function parseIpfsCid(cid: any) {
   return cid.trim().match(CID_REGEX)?.groups?.cid || null;
 }
 
+export function getIpfsCid(str: any): string | null {
+  return parseIpfsUrl(str) || parseIpfsCid(str);
+}
+
+export function getIpfsUrl(str: any): string | null {
+  const cid = parseIpfsCid(str);
+  return cid ? `ipfs://${cid}` : null;
+}
+
 export async function prepareFormData(info: any) {
   const data = JSON.stringify(info);
   const buf = compress(data);

--- a/packages/builder/src/registry.test.ts
+++ b/packages/builder/src/registry.test.ts
@@ -16,14 +16,6 @@ describe('registry.ts', () => {
     }
 
     describe('getUrl()', () => {
-      it('applies url alteration for "@ipfs" prefixed cannon packages', async () => {
-        const registry = new FakeCannonRegistry();
-
-        const url = await registry.getUrl('@ipfs:Qmwohoo', 13370);
-
-        expect(url).toBe('ipfs://Qmwohoo');
-      });
-
       it('applies url alteration for "Qm" hashes', async () => {
         const registry = new FakeCannonRegistry();
 
@@ -181,12 +173,6 @@ describe('registry.ts', () => {
     });
 
     describe('getUrl()', () => {
-      it('calls (and returns) from super first', async () => {
-        const url = await registry.getUrl('@ipfs:Qmwohoo', 13370);
-
-        expect(url).toBe('ipfs://Qmwohoo');
-      });
-
       it('calls `getPackageUrl`', async () => {
         const provider = makeFakeProvider();
         const registry = createRegistry({ provider });

--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -9,6 +9,7 @@ import CannonRegistryAbi from './abis/CannonRegistry';
 import { prepareMulticall, TxData } from './multicall';
 import { PackageReference } from './package-reference';
 import { CannonSigner } from './types';
+import { getIpfsUrl } from './ipfs';
 
 const debug = Debug('cannon:builder:registry');
 
@@ -29,14 +30,7 @@ export abstract class CannonRegistry {
   // in general a "catchall" is that if the fullPackageRef is an ipfs url (ex. ipfs://Qm..) , then that is a direct service resolve.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getUrl(serviceRef: string, chainId: number): Promise<string | null> {
-    // Check if its an ipfs hash / url, if so we make sure to remove any incorrectly appended presets (like @main);
-    if (serviceRef.startsWith('@ipfs:') || serviceRef.startsWith('ipfs://') || serviceRef.startsWith('Qm')) {
-      const ref = serviceRef.replace('@ipfs:', 'ipfs://');
-      const result = ref.startsWith('Qm') ? 'ipfs://' + ref : ref;
-      return result.indexOf('@') !== -1 ? result.slice(0, result.indexOf('@')) : result;
-    }
-
-    return null;
+    return getIpfsUrl(serviceRef);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -29,6 +29,7 @@ import {
   findUpgradeFromPackage,
   ChainBuilderContext,
   RawChainDefinition,
+  getIpfsUrl,
 } from '@usecannon/builder';
 import _ from 'lodash';
 import { useEffect, useReducer, useState, useMemo } from 'react';
@@ -434,9 +435,8 @@ export function useCannonPackage(urlOrRef?: string | PackageReference, chainId?:
   const registryQuery = useQuery({
     queryKey: ['cannon', 'registry-url', normalizedUrlOrRef, packageChainId],
     queryFn: async () => {
-      if (normalizedUrlOrRef?.startsWith('ipfs://')) return { url: normalizedUrlOrRef };
-      if (normalizedUrlOrRef?.startsWith('@ipfs:')) return { url: normalizedUrlOrRef.replace('@ipfs:', 'ipfs://') };
-
+      const ipfsUrl = getIpfsUrl(normalizedUrlOrRef);
+      if (ipfsUrl) return { url: ipfsUrl };
       const url = await registry.getUrl(normalizedUrlOrRef!, packageChainId);
       if (!url) throw new Error(`package not found: ${normalizedUrlOrRef} (${packageChainId})`);
       return { url };


### PR DESCRIPTION
The protocol format was intended from the beginning to have custom storage protocols, but we ended up deciding on not doing that and is not necessary anymore.