### PR TITLE
feat(ci): add a github action to backmerge everything added on main to dev

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -19,8 +19,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'Cannon Bot'
+          git config user.email 'noreply@usecannon.com'
 
       - name: Merge main into dev
         id: merge

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const branchName = `backmerge/main-to-dev-${Date.now()}`;
+            const branchName = `backmerge/main-to-dev-${{ github.sha }}`;
             await exec.exec('git', ['checkout', '-b', branchName]);
             await exec.exec('git', ['push', 'origin', branchName]);
 

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -52,3 +52,19 @@ jobs:
               head: branchName,
               base: 'dev'
             });
+
+            // Request review from Core Contributors team
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.data.number,
+              team_reviewers: ['core-contributors']
+            });
+
+            // Enable auto-merge
+            await github.rest.pulls.updateBranch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.data.number,
+              merge_method: 'merge'
+            });

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,54 @@
+name: Backmerge main to dev
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backmerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Important: fetch all history
+          ref: dev # Checkout dev branch
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Merge main into dev
+        id: merge
+        continue-on-error: true
+        run: |
+          git fetch origin main
+          git merge origin/main --no-edit
+
+      - name: Push if merge successful
+        if: steps.merge.outcome == 'success'
+        run: git push origin dev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create PR on merge conflict
+        if: steps.merge.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branchName = `backmerge/main-to-dev-${Date.now()}`;
+            await exec.exec('git', ['checkout', '-b', branchName]);
+            await exec.exec('git', ['push', 'origin', branchName]);
+
+            const pr = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'chore(ci): backmerge main → dev',
+              body: 'Automatic merge from main to dev failed. This PR was created to help resolve conflicts.',
+              head: branchName,
+              base: 'dev'
+            });


### PR DESCRIPTION
# Add Automated Backmerge Workflow

This PR adds a GitHub Action workflow that automatically merges changes from `main` back to `dev` branch.

## Features
- Automatically triggers when changes are pushed to `main`
- Attempts to merge `main` into `dev` automatically
- If merge succeeds, pushes directly to `dev`
- If conflicts occur:
  - Creates a new branch `backmerge/main-to-dev-{timestamp}`
  - Opens a PR from this branch to `dev`
  - Allows manual conflict resolution through PR interface

## Why
- Keeps `dev` branch up-to-date with `main`
- Reduces manual work for developers
- Provides clear process for handling merge conflicts
- Maintains clean git history