### PR TITLE
fix(website): layout change for mobile

### DIFF
--- a/packages/website/src/components/IpfsSpinner.tsx
+++ b/packages/website/src/components/IpfsSpinner.tsx
@@ -8,8 +8,10 @@ interface IpfsSpinnerProps {
 
 export function IpfsSpinner({ ipfsUrl }: IpfsSpinnerProps) {
   return (
-    <div className="flex flex-col items-center justify-center text-center">
-      <CustomSpinner />
+    <div className="flex flex-col items-center justify-center text-center h-screen w-full">
+      <div className="flex items-center justify-center flex-shrink-0">
+        <CustomSpinner />
+      </div>
       <p className="text-sm mt-5 mb-1 text-gray-400">
         Fetching {ipfsUrl ? ipfsUrl : 'via IPFS'}
       </p>

--- a/packages/website/src/features/Search/PackageCard/PackageCardExpandable.tsx
+++ b/packages/website/src/features/Search/PackageCard/PackageCardExpandable.tsx
@@ -1,10 +1,11 @@
-import { Link2Icon } from '@radix-ui/react-icons';
+import { Link2Icon, PinBottomIcon, PinTopIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
 import { FC, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Switch } from '@/components/ui/switch';
 import PackageTable from './PackageTable';
+import { Pin } from 'lucide-react';
 
 interface IPackageCardProps {
   pkgs: any[];
@@ -40,23 +41,35 @@ export const PackageCardExpandable: FC<IPackageCardProps> = ({
           className="flex items-center gap-1"
           onClick={(e) => e.stopPropagation()}
         >
-          <Switch
-            className="scale-75"
-            checked={!isOpen}
-            onCheckedChange={(checked) => setIsOpen(!checked)}
-          />
-          <p
-            onClick={(checked) => setIsOpen(!checked)}
-            className={cn(
-              'text-xs cursor-pointer',
-              isOpen && 'text-muted-foreground'
-            )}
+          <div
+            onClick={() => setIsOpen(!isOpen)}
+            className="sm:hidden cursor-pointer"
           >
-            <span className="hidden sm:inline">
-              Filter for latest on mainnet
-            </span>
-            <span className="sm:hidden">Filter for latest</span>
-          </p>
+            {isOpen ? (
+              <PinTopIcon className="w-4 h-4" />
+            ) : (
+              <PinBottomIcon className="w-4 h-4" />
+            )}
+          </div>
+          <div className="hidden sm:flex items-center gap-1">
+            <Switch
+              className="scale-75"
+              checked={!isOpen}
+              onCheckedChange={(checked) => setIsOpen(!checked)}
+            />
+            <p
+              onClick={(checked) => setIsOpen(!checked)}
+              className={cn(
+                'text-xs cursor-pointer',
+                isOpen && 'text-muted-foreground'
+              )}
+            >
+              <span className="hidden sm:inline">
+                Filter for latest on mainnet
+              </span>
+              <span className="sm:hidden">Filter for latest</span>
+            </p>
+          </div>
         </div>
       </div>
       <AnimatePresence mode="wait">

--- a/packages/website/src/features/Search/PackageCard/PackageCardExpandable.tsx
+++ b/packages/website/src/features/Search/PackageCard/PackageCardExpandable.tsx
@@ -5,7 +5,6 @@ import { cn } from '@/lib/utils';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Switch } from '@/components/ui/switch';
 import PackageTable from './PackageTable';
-import { Pin } from 'lucide-react';
 
 interface IPackageCardProps {
   pkgs: any[];

--- a/packages/website/src/features/Search/PackageCard/PackageCardExpandable.tsx
+++ b/packages/website/src/features/Search/PackageCard/PackageCardExpandable.tsx
@@ -67,7 +67,6 @@ export const PackageCardExpandable: FC<IPackageCardProps> = ({
               <span className="hidden sm:inline">
                 Filter for latest on mainnet
               </span>
-              <span className="sm:hidden">Filter for latest</span>
             </p>
           </div>
         </div>

--- a/packages/website/src/features/Search/PackageCard/PackageTable.tsx
+++ b/packages/website/src/features/Search/PackageCard/PackageTable.tsx
@@ -53,7 +53,9 @@ const PackageTable: FC<{
   ];
 
   if (latestOnly) {
-    data = data.filter((row: any) => row.version === 'latest');
+    data = data.filter(
+      (row: any) => row.version === 'latest' && row.chain !== 13370
+    );
 
     data = data.filter((row: any) => {
       const matchingChain = getChainById(row.chain);


### PR DESCRIPTION
- fixed [CAN-642](https://linear.app/usecannon/issue/CAN-642/vertically-center-ipfsloaders-under-all-of-the-tabs)
- Replaced the sentence with icons PinBottomIcon and PinTopIcon for mobile
- Showed only mainnet deployments

<img width="409" alt="Screenshot 2025-01-14 at 14 30 54" src="https://github.com/user-attachments/assets/59ae8924-90ac-4cbf-a200-2135866c8e3e" />

<img width="838" alt="Screenshot 2025-01-14 at 14 28 50" src="https://github.com/user-attachments/assets/9f0b371e-14a0-4809-a2e1-0cb6895a23d7" />

<img width="1457" alt="Screenshot 2025-01-14 at 14 31 15" src="https://github.com/user-attachments/assets/223883fa-7d1e-4366-a12c-83522e467c7a" />
