### PR TITLE
fix(website): remove white border on the destructive state

### DIFF
--- a/packages/website/src/features/Packages/FunctionInput/AddressInput.tsx
+++ b/packages/website/src/features/Packages/FunctionInput/AddressInput.tsx
@@ -27,7 +27,7 @@ export const AddressInput: FC<{
       className={cn(
         'bg-background',
         isInvalid
-          ? 'border-destructive focus:border-destructive'
+          ? 'border-destructive focus:border-destructive focus-visible:ring-destructive'
           : 'border-input'
       )}
       placeholder="0x0000000000000000000000000000000000000000"

--- a/packages/website/src/features/Packages/FunctionInput/ByteInput.tsx
+++ b/packages/website/src/features/Packages/FunctionInput/ByteInput.tsx
@@ -56,8 +56,10 @@ export const ByteInput: FC<{
           <Input
             type="text"
             className={cn(
-              'bg-background border-input',
-              isInvalid && 'border-destructive focus:border-destructive'
+              'bg-background',
+              isInvalid
+                ? 'border-destructive focus:border-destructive focus-visible:ring-destructive'
+                : 'border-input'
             )}
             placeholder="0x0000000000000000000000000000000000000000"
             value={updateValue}


### PR DESCRIPTION
Fixed [CAN-667](https://linear.app/usecannon/issue/CAN-667/remove-white-border-keep-just-red-on-destructive-state-for)

<img width="590" alt="Screenshot 2025-01-15 at 12 17 43" src="https://github.com/user-attachments/assets/a1c8c8bb-4197-459a-93c0-244c236e4e6f" />

<img width="586" alt="Screenshot 2025-01-15 at 12 05 05" src="https://github.com/user-attachments/assets/fe94f8b8-92ea-441f-ba84-4186672850b9" />

