### PR TITLE
fix(website): rawcannofile height issue

### DIFF
--- a/packages/website/src/features/Packages/CannonfileExplorer.tsx
+++ b/packages/website/src/features/Packages/CannonfileExplorer.tsx
@@ -231,7 +231,9 @@ export const CannonfileExplorer: FC<{ pkg: ApiPackage }> = ({ pkg }) => {
                 )}
               </div>
 
-              <div className={`${displayMode === 3 ? 'h-full' : 'hidden'} `}>
+              <div
+                className={`${displayMode === 3 ? 'h-screen mr-4' : 'hidden'} `}
+              >
                 <CodePreview
                   code={stringify(processedDeploymentInfo as any)}
                   language="ini"


### PR DESCRIPTION
Fixed the height on Raw Cannonfile tab properly
Also adjusted the codes's width to avoid overlapping with scroll bars.

<img width="1464" alt="Screenshot 2025-01-21 at 12 21 47" src="https://github.com/user-attachments/assets/d2caed73-446a-41ce-8af1-2f94b3b822a0" />
