### PR TITLE
fix(cli): process exit code on partial deployments

### DIFF
--- a/packages/cli/bin/cannon.js
+++ b/packages/cli/bin/cannon.js
@@ -6,7 +6,7 @@ const cli = require('../dist/src');
 cli.default
   .parseAsync()
   .then(() => {
-    process.exit(0);
+    process.exit();
   })
   .catch((err) => {
     if (err.message) {
@@ -16,5 +16,5 @@ cli.default
     //eslint-disable-next-line no-console
     console.error(err);
 
-    process.exit(1);
+    process.exit(process.exitCode || 1);
   });

--- a/packages/cli/bin/cannon.ts
+++ b/packages/cli/bin/cannon.ts
@@ -6,7 +6,7 @@ import cli from '../src';
 cli
   .parseAsync()
   .then(() => {
-    process.exit(0);
+    process.exit();
   })
   .catch((err) => {
     if (err.message) {
@@ -16,5 +16,5 @@ cli
     //eslint-disable-next-line no-console
     console.error(err);
 
-    process.exit(1);
+    process.exit(process.exitCode || 1);
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -223,7 +223,11 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
     const pickedCliSettings = _.pick(cliSettings, Object.keys(options));
     const mergedOptions = _.assign({}, options, pickedCliSettings);
 
-    const [node, pkgSpec, outputs, runtime] = await doBuild(cannonfile, settings, mergedOptions);
+    const [node, pkgSpec, outputs, runtime, deployInfo] = await doBuild(cannonfile, settings, mergedOptions);
+
+    if (deployInfo.status !== 'complete') {
+      process.exitCode = deployInfo.status === 'partial' ? 10 : 11;
+    }
 
     if (options.writeDeployments) {
       await writeModuleDeployments(path.join(process.cwd(), options.writeDeployments), '', outputs);
@@ -244,6 +248,8 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
     }
 
     node?.kill();
+
+    console.log('exit code', process.exitCode);
   });
 
 applyCommandsConfig(program.command('verify'), commandsConfig.verify).action(async function (packageRef, options) {

--- a/packages/cli/src/util/build.ts
+++ b/packages/cli/src/util/build.ts
@@ -1,5 +1,12 @@
 import path from 'node:path';
-import { CANNON_CHAIN_ID, CannonError, CannonSigner, ChainArtifacts, ChainBuilderRuntime } from '@usecannon/builder';
+import {
+  CANNON_CHAIN_ID,
+  CannonError,
+  CannonSigner,
+  ChainArtifacts,
+  ChainBuilderRuntime,
+  DeploymentInfo,
+} from '@usecannon/builder';
 import Debug from 'debug';
 import * as viem from 'viem';
 import { PackageSpecification } from '../types';
@@ -35,7 +42,7 @@ export async function doBuild(
   cannonfile: string,
   settings: string[],
   options: Record<string, any>
-): Promise<[CannonRpcNode | null, PackageSpecification, ChainArtifacts, ChainBuilderRuntime]> {
+): Promise<[CannonRpcNode | null, PackageSpecification, ChainArtifacts, ChainBuilderRuntime, DeploymentInfo]> {
   // Set debug level
   setDebugLevel(options);
   debug('do build called with', cannonfile, settings, filterSettings(options));
@@ -81,9 +88,9 @@ export async function doBuild(
 
   const { build } = await import('../commands/build');
 
-  const { outputs, runtime } = await build(buildConfig);
+  const { outputs, runtime, deployInfo } = await build(buildConfig);
 
-  return [node, buildConfig.packageDefinition, outputs, runtime];
+  return [node, buildConfig.packageDefinition, outputs, runtime, deployInfo];
 }
 
 /**

--- a/packages/cli/test/e2e/series.bats
+++ b/packages/cli/test/e2e/series.bats
@@ -101,7 +101,7 @@ teardown() {
   set_custom_config
   run build-foundry-partial.sh
   echo $output
-  assert_success
+  assert_failure 10
   assert_output --partial "Your deployment was not fully completed. Please inspect the issues listed above and resolve as necessary."
   assert_file_exists "$CANNON_DIRECTORY/tags/oracle-manager_latest_1-with-owned-greeter.txt"
   assert_file_exists "$CANNON_DIRECTORY/tags/owned-greeter_1.0.0_1-main.txt"


### PR DESCRIPTION
Now, when building and finishing with a partial deployment the process exit code is going to be different to `0`.