### PR TITLE
fix(website): interact render of objects

### DIFF
--- a/packages/website/src/components/AbiParameterPreview.tsx
+++ b/packages/website/src/components/AbiParameterPreview.tsx
@@ -1,0 +1,210 @@
+import * as viem from 'viem';
+import { isNil, isObject } from 'lodash';
+import { Snippet } from '@/components/snippet';
+import { ClipboardButton } from '@/components/ClipboardButton';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+interface Props {
+  abiParameter: viem.AbiParameter;
+  value?: unknown;
+}
+
+export function AbiParameterPreview({ abiParameter, value }: Props) {
+  const { type, name } = abiParameter;
+  const val = isNil(value) ? _renderEmptyValue(abiParameter) : value;
+  const tooltipText = _encodeArgTooltip(type, val);
+
+  return (
+    <div>
+      <Label>
+        {name && <span>{name}</span>}
+        {type && (
+          <span className="text-xs text-muted-foreground font-mono">
+            {' '}
+            {type}
+          </span>
+        )}
+      </Label>
+      {type.endsWith('[]') || type === 'tuple' ? (
+        <Snippet>
+          <code>{_encodeArg(type, val)}</code>
+        </Snippet>
+      ) : (
+        <div className="group relative">
+          {tooltipText && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Input
+                    type="text"
+                    className="focus:border-muted-foreground/40 focus:ring-0 hover:border-muted-foreground/40 font-mono"
+                    readOnly
+                    value={_encodeArg(type, val)}
+                  />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="text-xs font-mono">{tooltipText}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+          {!tooltipText && (
+            <Input
+              type="text"
+              className="focus:border-muted-foreground/40 focus:ring-0 hover:border-muted-foreground/40 font-mono"
+              readOnly
+              value={_encodeArg(type, val)}
+            />
+          )}
+          <div className="absolute right-0 top-1">
+            <ClipboardButton text={val} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function _hasComponentsKey(
+  item: viem.AbiParameter
+): item is viem.AbiParameter & { components: readonly viem.AbiParameter[] } {
+  return (
+    isObject(item) && 'components' in item && Array.isArray(item.components)
+  );
+}
+
+function _isNumberType(type: string): boolean {
+  if (typeof type !== 'string') {
+    throw new Error(`Invalid type given to assert "${type}"`);
+  }
+
+  if (type.endsWith('[]')) {
+    return false;
+  }
+
+  return (
+    type.startsWith('uint') ||
+    type.startsWith('int') ||
+    type.startsWith('fixed') ||
+    type.startsWith('ufixed')
+  );
+}
+
+function _renderEmptyValue(abiParameter: viem.AbiParameter): any {
+  const { type } = abiParameter;
+
+  if (type.endsWith('[]')) {
+    return [];
+  } else if (_isNumberType(type)) {
+    return '0';
+  } else if (type.startsWith('bool')) {
+    return false;
+  } else if (type === 'address' || type === 'function') {
+    return viem.zeroAddress.toString();
+  } else if (type === 'bytes') {
+    return '0x';
+  } else if (type.startsWith('bytes')) {
+    const size = Number(type.slice(5)) * 2 || 0;
+    const bytes = Array.from({ length: size }, () => '0');
+    return `0x${bytes.join('')}`;
+  } else if (type.startsWith('string')) {
+    return '';
+  } else if (type === 'tuple') {
+    const result: { [key: string]: unknown } = {};
+
+    if (_hasComponentsKey(abiParameter)) {
+      for (const component of abiParameter.components) {
+        if (typeof component.name === 'string' && component.name) {
+          result[component.name] = _renderEmptyValue(component);
+        }
+      }
+    }
+
+    return result;
+  } else {
+    return '(no result)';
+  }
+}
+
+function _encodeArg(type: string, val: string): string {
+  if (type.endsWith('[]')) {
+    const values = Array.isArray(val) ? val : [val];
+    const results = values.map((v) => _encodeArg(type.slice(0, -2), v));
+
+    const isTuple = type.startsWith('tuple');
+    return JSON.stringify(
+      results.map((v) => (isTuple ? JSON.parse(v) : v)),
+      (_, v) => (typeof v === 'bigint' ? v.toString() : v),
+      2
+    );
+  }
+
+  if (type.startsWith('bytes') && val.startsWith('0x')) {
+    try {
+      const b = viem.hexToBytes(val as viem.Hex);
+      const t = b.findIndex((v) => v < 0x20);
+      if (b[t] != 0 || b.slice(t).find((v) => v != 0) || t === 0) {
+        // this doesn't look like a terminated ascii hex string. leave it as hex
+        return val;
+      }
+
+      return viem.bytesToString(viem.trim(b, { dir: 'right' }));
+    } catch (err) {
+      return val.toString();
+    }
+  } else if (type == 'tuple') {
+    // TODO: use a lib?
+    return JSON.stringify(
+      val,
+      (_, v) => (typeof v === 'bigint' ? v.toString() : v),
+      2
+    );
+  } else if (type == 'bool') {
+    return val ? 'true' : 'false';
+  } else if (type.startsWith('uint') || type.startsWith('int')) {
+    return val ? BigInt(val).toString() : '0';
+  }
+
+  return val.toString();
+}
+
+function _encodeArgTooltip(type: string, val: string): string {
+  if (Array.isArray(val)) {
+    if (!type.endsWith('[]')) {
+      throw Error(`Invalid arg type "${type}" and val "${val}"`);
+    }
+
+    const arrayTooltip = `["${val
+      .map((v) => _encodeArgTooltip(type.slice(0, -2), v))
+      .join('", "')}"]`;
+    return arrayTooltip === _encodeArg(type, val) ? '' : arrayTooltip;
+  }
+
+  if (type.startsWith('bytes') && val.startsWith('0x')) {
+    const bytesTooltip = val.toString();
+    return bytesTooltip === _encodeArg(type, val) ? '' : bytesTooltip;
+  } else if (type == 'tuple') {
+    const tupleTooltip = JSON.stringify(val, (_, v) =>
+      typeof v === 'bigint' ? v.toString() : v
+    );
+    return tupleTooltip === _encodeArg(type, val) ? '' : tupleTooltip;
+  } else if (type == 'bool') {
+    const boolTooltip = val ? 'true' : 'false';
+    return boolTooltip === _encodeArg(type, val) ? '' : boolTooltip;
+  } else if (['int256', 'uint256', 'int128', 'uint128'].includes(type)) {
+    if (!val) return '';
+    const etherValue = `${viem.formatEther(
+      BigInt(val)
+    )} assuming 18 decimal places`;
+    return etherValue === _encodeArg(type, val) ? '' : etherValue;
+  }
+
+  return '';
+}

--- a/packages/website/src/components/layouts/SidebarLayout.tsx
+++ b/packages/website/src/components/layouts/SidebarLayout.tsx
@@ -94,7 +94,7 @@ export function SidebarLayout({
       {sidebarContent && (
         <Sidebar
           style={sidebarStyles}
-          className={`z-[49] sticky w-[280px] md:w-[280px] shrink-0 overflow-y-auto ${
+          className={`z-[49] sticky w-[280px] shrink-0 overflow-y-auto ${
             borderlessSidebar ? 'border-none' : 'border-r border-border'
           }`}
         >
@@ -109,7 +109,7 @@ export function SidebarLayout({
 
       {/* Main content */}
       <main
-        className={`cannon-page-main-content overflow-y-${mainContentOverflowY} flex-1`}
+        className={`cannon-page-main-content w-[calc(100vw-280px)] overflow-y-${mainContentOverflowY} flex-1`}
       >
         {/* container p-4 md:px-6 lg:px-8 ml-0 */}
         {children}

--- a/packages/website/src/components/snippet.tsx
+++ b/packages/website/src/components/snippet.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { codeToHtml } from 'shiki';
 import { Check, Copy } from 'react-feather';
 import { Button } from '@/components/ui/button';
 
 export const Snippet = ({ ...props }: React.HTMLAttributes<HTMLPreElement>) => {
-  const [hasCopied, setHasCopied] = React.useState(false);
-  const [html, setHtml] = React.useState('');
+  const [hasCopied, setHasCopied] = useState(false);
+  const [html, setHtml] = useState('');
   const command = (props.children as any).props.children as string;
 
   // Handle the async code highlighting
-  React.useEffect(() => {
+  useEffect(() => {
     const highlightCode = async () => {
       if (!command) return;
 

--- a/packages/website/src/features/Docs/DocsCannonfilesPage.tsx
+++ b/packages/website/src/features/Docs/DocsCannonfilesPage.tsx
@@ -47,7 +47,7 @@ const artifactDataExample = {
   },
 };
 
-const deploymentDataExample = {
+export const deploymentDataExample = {
   generator: 'cannon cli 2.15.0',
   timestamp: 1718767889,
   def: {

--- a/packages/website/src/features/Header/Header.tsx
+++ b/packages/website/src/features/Header/Header.tsx
@@ -57,7 +57,7 @@ export const Header = () => {
 
   const isHomePage = router.pathname === '/';
   const mainClassName = cn(
-    'z-50 top-0 h-[var(--header-height)] transition-colors duration-200',
+    'z-50 top-0 h-[var(--header-height)] transition-colors duration-200 position-relative',
     isHomePage
       ? 'fixed left-0 right-0 bg-transparent'
       : 'w-full sticky border-b border-border bg-black'

--- a/packages/website/src/features/Packages/Abi.tsx
+++ b/packages/website/src/features/Packages/Abi.tsx
@@ -243,7 +243,7 @@ export const Abi: FC<{
           mainContentOverflowY="visible"
         >
           {/* Methods Interactions */}
-          <div className="flex flex-col p-3 gap-4 flex-1 overflow-x-auto">
+          <div className="flex flex-col p-3 gap-4 flex-1">
             {isLoading ? (
               <div className="flex items-center justify-center flex-1">
                 <CustomSpinner />

--- a/packages/website/src/features/Packages/Function.tsx
+++ b/packages/website/src/features/Packages/Function.tsx
@@ -321,6 +321,9 @@ export const Function: FC<FunctionProps> = ({
     });
   };
 
+  console.log('value', methodCallOrQueuedResult?.value);
+  console.log('f.outputs', f.outputs);
+
   const renderFunctionContent = () => (
     <div
       className={cn(
@@ -612,16 +615,15 @@ export const Function: FC<FunctionProps> = ({
                       initial={{ opacity: 0 }}
                       animate={{ opacity: 1 }}
                       exit={{ opacity: 0 }}
-                      className="absolute z-10 top-0 left-0 bg-background/75 w-full h-full flex items-center justify-center text-muted-foreground"
+                      className="absolute z-10 top-0 left-0 bg-background/100 w-full h-full flex items-center justify-center text-muted-foreground"
                     >
                       {loading ? (
                         <CustomSpinner className="h-8 w-8" />
                       ) : (
                         <>
                           {isFunctionReadOnly
-                            ? 'Call the view function '
-                            : 'Simulate the transaction '}
-                          for output
+                            ? 'Call the view function for output'
+                            : 'Simulate the transaction for output'}
                         </>
                       )}
                     </motion.div>
@@ -655,7 +657,7 @@ export const Function: FC<FunctionProps> = ({
             onClick={() => setIsOpen(!isOpen)}
           >
             {f.name && (
-              <h2 className="text-sm font-mono flex items-center max-w-full">
+              <h2 className="text-sm font-mono flex items-center">
                 <span className="break-all">
                   {toFunctionSignature(f)}
                   <Link

--- a/packages/website/src/features/Packages/Function.tsx
+++ b/packages/website/src/features/Packages/Function.tsx
@@ -321,9 +321,6 @@ export const Function: FC<FunctionProps> = ({
     });
   };
 
-  console.log('value', methodCallOrQueuedResult?.value);
-  console.log('f.outputs', f.outputs);
-
   const renderFunctionContent = () => (
     <div
       className={cn(
@@ -630,7 +627,7 @@ export const Function: FC<FunctionProps> = ({
                   )}
               </AnimatePresence>
               <FunctionOutput
-                methodResult={methodCallOrQueuedResult?.value || null}
+                methodResult={methodCallOrQueuedResult?.value as string}
                 abiParameters={f.outputs}
               />
             </div>

--- a/packages/website/src/features/Packages/FunctionOutput.tsx
+++ b/packages/website/src/features/Packages/FunctionOutput.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { AbiParameter } from 'abitype';
-import { isArray, isObject } from 'lodash';
-import { formatEther } from 'viem';
+import { isObject, isNil, isPlainObject } from 'lodash';
+import * as viem from 'viem';
 import ClipboardButton from '@/components/ClipboardButton';
 import { cn } from '@/lib/utils';
 import {
@@ -11,15 +11,28 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-const isArrayOutput = (
+function _isArrayAbiParameter(
   value: AbiParameter | readonly AbiParameter[]
-): value is readonly AbiParameter[] => isArray(value);
+): value is readonly AbiParameter[] {
+  return Array.isArray(value);
+}
 
-const hasComponentsKey = (
+function _isNumberString(value: string): boolean {
+  try {
+    BigInt(value);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function _hasComponentsKey(
   item: AbiParameter
-): item is AbiParameter & { components: readonly AbiParameter[] } => {
-  return 'components' in item && isArray(item.components);
-};
+): item is AbiParameter & { components: readonly AbiParameter[] } {
+  return (
+    isObject(item) && 'components' in item && Array.isArray(item.components)
+  );
+}
 
 const ItemLabel: FC<{ name: string; type: string }> = ({ name, type }) => (
   <div className="flex items-center gap-1 text-sm mb-0">
@@ -28,214 +41,253 @@ const ItemLabel: FC<{ name: string; type: string }> = ({ name, type }) => (
   </div>
 );
 
-const resultText = (
-  name: string | undefined,
-  type: string,
+function _isNumberType(type: string): boolean {
+  return (
+    type.startsWith('uint') ||
+    type.startsWith('int') ||
+    type.startsWith('fixed') ||
+    type.startsWith('ufixed')
+  );
+}
+
+function _renderEmptyValue(type: string): string {
+  if (_isNumberType(type)) {
+    return '0';
+  } else if (type.startsWith('bool')) {
+    return 'false';
+  } else if (type === 'address' || type === 'function') {
+    return viem.zeroAddress.toString();
+  } else if (type.startsWith('bytes')) {
+    return '0x';
+  } else if (type.startsWith('string')) {
+    return '""';
+  } else {
+    return '(could not render result)';
+  }
+}
+
+function _renderResultText(
+  name: AbiParameter['name'],
+  type: AbiParameter['type'],
   value: any
-): string => {
-  if (typeof value !== 'object') {
-    return String(value);
-  } else if (value !== null && value !== undefined) {
+): string {
+  console.log({ name, type, value });
+  if (isNil(value)) {
+    return _renderEmptyValue(type);
+  } else if (Array.isArray(value)) {
     const resultItem = value.find(
       (item: any) => name !== undefined && name in item
     );
-    const result: string =
+
+    const result =
       resultItem && name !== undefined ? String(resultItem[name]) : '';
 
     return result;
+  } else if (isPlainObject(value)) {
+    return JSON.stringify(value);
+  } else {
+    return String(value);
   }
+}
 
-  switch (type) {
-    case 'string':
-      return '(empty string)';
-    case 'boolean':
-    case 'bool':
-      return '(false)';
-    case 'uint256':
-    case 'int256':
-    case 'uint128':
-    case 'int128':
-      return '0';
-    default:
-      return '(no result)';
+function _renderValue(abiParameter: AbiParameter, value: any) {
+  const result = _renderResultText(abiParameter.name, abiParameter.type, value);
+
+  return (
+    <>
+      <div
+        className={cn(
+          'flex items-center gap-2 justify-items-center py-2',
+          'data-[tooltip-id]:float'
+        )}
+        data-tooltip-id={`${abiParameter.name}${abiParameter.type}`}
+      >
+        {_isNumberType(abiParameter.type) && _isNumberString(result) ? (
+          <div className="flex gap-2 items-center">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex gap-2 items-center">
+                    <span className="text-sm">{result}</span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {`${viem
+                    .formatEther(
+                      BigInt(
+                        _renderResultText(
+                          abiParameter.name,
+                          abiParameter.type,
+                          value
+                        )
+                      )
+                    )
+                    .toString()} wei`}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <ClipboardButton
+              text={_renderResultText(
+                abiParameter.name,
+                abiParameter.type,
+                value
+              )}
+            />
+          </div>
+        ) : (
+          <span className="text-sm">
+            {result}
+            <ClipboardButton text={result} />
+          </span>
+        )}
+      </div>
+    </>
+  );
+}
+
+function _renderOutput(
+  abiParameter: AbiParameter,
+  value: { [key: string]: any },
+  index?: number
+) {
+  const isTuple = abiParameter.type === 'tuple';
+  const isTupleArray = abiParameter.type === 'tuple[]';
+  const isAddressArray = abiParameter.type === 'address[]';
+
+  const hasComponents = _hasComponentsKey(abiParameter);
+  const isValidValue = Boolean(value);
+
+  const isNamedParameter =
+    isObject(value) && abiParameter.name && abiParameter.name in value;
+
+  if (isTuple && hasComponents && isValidValue) {
+    return (
+      <div className="pl-4">
+        {Object.values(abiParameter).map((component: any, resIdx: number) => {
+          return (
+            <FunctionOutput
+              abiParameters={component}
+              methodResult={value}
+              key={resIdx}
+            />
+          );
+        })}
+      </div>
+    );
+  } else if (isTupleArray && hasComponents && isValidValue) {
+    return Array.isArray(value)
+      ? value.map((tupleItem, tupleIndex) => (
+          <div key={tupleIndex} className="pl-4">
+            <span className="text-xs text-muted-foreground font-mono">
+              tuple[{tupleIndex}]
+            </span>
+            {abiParameter.components.map(
+              (component: AbiParameter, compIdx: number) => (
+                <FunctionOutput
+                  key={compIdx}
+                  abiParameters={component}
+                  methodResult={
+                    Array.isArray(tupleItem) ? tupleItem[compIdx] : tupleItem
+                  }
+                />
+              )
+            )}
+          </div>
+        ))
+      : null;
+  } else {
+    if (isNamedParameter && abiParameter.name) {
+      const outputValue = value[abiParameter.name];
+      return (
+        <span className="block pt-1 pb-2 text-xs">
+          {String(outputValue)}
+          <ClipboardButton text={outputValue} />
+        </span>
+      );
+    } else if (Array.isArray(value)) {
+      if (isAddressArray) {
+        return (
+          <div>
+            {value.map((val, idx) => (
+              <span className="text-xs block mt-2" key={idx}>
+                {val}
+                <ClipboardButton text={val} />
+              </span>
+            ))}
+          </div>
+        );
+      } else if (index !== undefined) {
+        return _renderValue(abiParameter, value[index]);
+      } else {
+        return value.map((val, idx) => (
+          <span className="text-sm block" key={idx}>
+            {_renderResultText(abiParameter.name, abiParameter.type, val)}
+            <ClipboardButton
+              text={_renderResultText(
+                abiParameter.name,
+                abiParameter.type,
+                val
+              )}
+            />
+          </span>
+        ));
+      }
+    } else {
+      return _renderValue(abiParameter, value);
+    }
   }
-};
+}
 
 export const FunctionOutput: FC<{
   abiParameters: AbiParameter | readonly AbiParameter[];
   methodResult: any;
 }> = ({ abiParameters, methodResult }) => {
-  const renderValue = (abiParameter: AbiParameter, value: any) => {
+  if (isNil(abiParameters)) return null;
+
+  if (
+    Array.isArray(abiParameters) &&
+    (!Array.isArray(methodResult) ||
+      abiParameters.length !== methodResult.length)
+  ) {
+    console.log('!!!', { abiParameters, methodResult });
     return (
-      <>
-        <div
-          className={cn(
-            'flex items-center gap-2 justify-items-center py-2',
-            'data-[tooltip-id]:float'
-          )}
-          data-tooltip-id={`${abiParameter.name}${abiParameter.type}`}
-        >
-          {(abiParameter.type.includes('int128') ||
-            abiParameter.type.includes('int256')) &&
-          value ? (
-            <div className="flex gap-2 items-center">
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="flex gap-2 items-center">
-                      <span className="text-sm">
-                        {resultText(
-                          abiParameter.name,
-                          abiParameter.type,
-                          value
-                        )}
-                      </span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {`${formatEther(
-                      BigInt(
-                        resultText(abiParameter.name, abiParameter.type, value)
-                      )
-                    ).toString()} wei`}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              <ClipboardButton
-                text={resultText(abiParameter.name, abiParameter.type, value)}
-              />
-            </div>
-          ) : (
-            <span className="text-sm">
-              {resultText(abiParameter.name, abiParameter.type, value)}
-              <ClipboardButton
-                text={resultText(abiParameter.name, abiParameter.type, value)}
-              />
-            </span>
-          )}
-        </div>
-      </>
+      <div className="flex flex-1 items-center h-full py-4">
+        <span className="text-sm m-auto text-muted-foreground">
+          There was an error rendering the output.
+        </span>
+      </div>
     );
-  };
+  }
 
-  const renderOutput = (
-    abiParameter: AbiParameter,
-    value: { [key: string]: any },
-    index?: number
-  ) => {
-    const isTuple = abiParameter.type === 'tuple';
-    const isTupleArray = abiParameter.type === 'tuple[]';
-    const isAddressArray = abiParameter.type === 'address[]';
-
-    const hasComponents = hasComponentsKey(abiParameter);
-    const isValidValue = Boolean(value);
-
-    const isNamedParameter =
-      isObject(value) && abiParameter.name && abiParameter.name in value;
-
-    if (isTuple && hasComponents && isValidValue) {
+  if (_isArrayAbiParameter(abiParameters)) {
+    if (abiParameters.length === 0) {
       return (
-        <div className="pl-4">
-          {Object.values(abiParameter).map((component: any, resIdx: number) => {
-            return (
-              <FunctionOutput
-                abiParameters={component}
-                methodResult={value}
-                key={resIdx}
-              />
-            );
-          })}
-        </div>
-      );
-    } else if (isTupleArray && hasComponents && isValidValue) {
-      return isArray(value)
-        ? value.map((tupleItem, tupleIndex) => (
-            <div key={tupleIndex} className="pl-4">
-              <span className="text-xs text-muted-foreground font-mono">
-                tuple[{tupleIndex}]
-              </span>
-              {abiParameter.components.map(
-                (component: AbiParameter, compIdx: number) => (
-                  <FunctionOutput
-                    key={compIdx}
-                    abiParameters={component}
-                    methodResult={
-                      isArray(tupleItem) ? tupleItem[compIdx] : tupleItem
-                    }
-                  />
-                )
-              )}
-            </div>
-          ))
-        : null;
-    } else {
-      if (isNamedParameter && abiParameter.name) {
-        const outputValue = value[abiParameter.name];
-        return (
-          <span className="block pt-1 pb-2 text-xs">
-            {String(outputValue)}
-            <ClipboardButton text={outputValue} />
-          </span>
-        );
-      } else if (isArray(value)) {
-        if (isAddressArray) {
-          return (
-            <div>
-              {value.map((val, idx) => (
-                <span className="text-xs block mt-2" key={idx}>
-                  {String(val)}
-                  <ClipboardButton text={String(val)} />
-                </span>
-              ))}
-            </div>
-          );
-        } else if (index !== undefined) {
-          return renderValue(abiParameter, value[index]);
-        } else {
-          return value.map((val, idx) => (
-            <span className="text-sm block" key={idx}>
-              {resultText(abiParameter.name, abiParameter.type, val)}
-              <ClipboardButton
-                text={resultText(abiParameter.name, abiParameter.type, val)}
-              />
-            </span>
-          ));
-        }
-      } else {
-        return renderValue(abiParameter, value);
-      }
-    }
-  };
-
-  return (
-    <>
-      {(abiParameters as Array<any>).length == 0 && methodResult === null && (
         <div className="flex flex-1 items-center h-full py-4">
           <span className="text-sm m-auto text-muted-foreground">
-            {"This function doesn't return any values."}
+            This function doesn&apos;t return any values.
           </span>
         </div>
-      )}
-      {isArrayOutput(abiParameters)
-        ? abiParameters.map((abiParameter, index) => (
-            <div className="overflow-x-scroll py-2" key={index}>
-              <ItemLabel
-                name={abiParameter.name || ''}
-                type={abiParameter.internalType || ''}
-              />
-              {renderOutput(abiParameter, methodResult, index)}
-            </div>
-          ))
-        : abiParameters.name !== undefined &&
-          abiParameters.type !== undefined && (
-            <div className="overflow-x-scroll py-2">
-              <ItemLabel
-                name={abiParameters.name || ''}
-                type={abiParameters.internalType || ''}
-              />
-              {renderOutput(abiParameters, methodResult)}
-            </div>
-          )}
-    </>
+      );
+    } else {
+      return abiParameters.map((abiParameter, index) => (
+        <div className="overflow-x-scroll py-2" key={index}>
+          <ItemLabel
+            name={abiParameter.name || ''}
+            type={abiParameter.internalType || ''}
+          />
+          {_renderOutput(abiParameter, methodResult, index)}
+        </div>
+      ));
+    }
+  }
+
+  return (
+    <div className="overflow-x-scroll py-2">
+      <ItemLabel
+        name={abiParameters.name || ''}
+        type={abiParameters.internalType || ''}
+      />
+      {_renderOutput(abiParameters, methodResult)}
+    </div>
   );
 };

--- a/packages/website/src/features/Packages/FunctionOutput.tsx
+++ b/packages/website/src/features/Packages/FunctionOutput.tsx
@@ -1,15 +1,7 @@
-import { FC } from 'react';
-import { AbiParameter } from 'abitype';
-import { isObject, isNil, isPlainObject } from 'lodash';
 import * as viem from 'viem';
-import ClipboardButton from '@/components/ClipboardButton';
-import { cn } from '@/lib/utils';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+import { AbiParameterPreview } from '@/components/AbiParameterPreview';
+
+type AbiParameter = viem.AbiParameter;
 
 function _isArrayAbiParameter(
   value: AbiParameter | readonly AbiParameter[]
@@ -17,266 +9,27 @@ function _isArrayAbiParameter(
   return Array.isArray(value);
 }
 
-function _isNumberString(value: string): boolean {
-  try {
-    BigInt(value);
-    return true;
-  } catch (_) {
-    return false;
-  }
+interface Props {
+  abiParameters: viem.AbiParameter | readonly viem.AbiParameter[];
+  methodResult?: string;
 }
 
-function _hasComponentsKey(
-  item: AbiParameter
-): item is AbiParameter & { components: readonly AbiParameter[] } {
-  return (
-    isObject(item) && 'components' in item && Array.isArray(item.components)
-  );
-}
-
-const ItemLabel: FC<{ name: string; type: string }> = ({ name, type }) => (
-  <div className="flex items-center gap-1 text-sm mb-0">
-    {name?.length ? <span className="pr-1 font-semibold">{name}</span> : null}
-    <span className="text-xs text-muted-foreground font-mono">{type}</span>
-  </div>
-);
-
-function _isNumberType(type: string): boolean {
-  if (typeof type !== 'string') {
-    debugger;
-    throw new Error(`Invalid type given to assert "${type}"`);
-  }
-  return (
-    type.startsWith('uint') ||
-    type.startsWith('int') ||
-    type.startsWith('fixed') ||
-    type.startsWith('ufixed')
-  );
-}
-
-function _renderEmptyValue(type: string): string {
-  if (_isNumberType(type)) {
-    return '0';
-  } else if (type.startsWith('bool')) {
-    return 'false';
-  } else if (type === 'address' || type === 'function') {
-    return viem.zeroAddress.toString();
-  } else if (type.startsWith('bytes')) {
-    return '0x';
-  } else if (type.startsWith('string')) {
-    return '""';
-  } else {
-    return '(could not render result)';
-  }
-}
-
-function _renderResultText(
-  name: AbiParameter['name'],
-  type: AbiParameter['type'],
-  value: any
-): string {
-  if (isNil(value)) {
-    return _renderEmptyValue(type);
-  } else if (Array.isArray(value)) {
-    const resultItem = value.find(
-      (item: any) => name !== undefined && name in item
-    );
-
-    const result =
-      resultItem && name !== undefined ? String(resultItem[name]) : '';
-
-    return result;
-  } else if (isPlainObject(value)) {
-    return JSON.stringify(value);
-  } else {
-    return String(value);
-  }
-}
-
-function _renderValue(abiParameter: AbiParameter, value: any) {
-  const result = _renderResultText(abiParameter.name, abiParameter.type, value);
-
-  return (
-    <>
-      <div
-        className={cn(
-          'flex items-center gap-2 justify-items-center py-2',
-          'data-[tooltip-id]:float'
-        )}
-        data-tooltip-id={`${abiParameter.name}${abiParameter.type}`}
-      >
-        {_isNumberType(abiParameter.type) && _isNumberString(result) ? (
-          <div className="flex gap-2 items-center">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex gap-2 items-center">
-                    <span className="text-sm">{result}</span>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {`${viem
-                    .formatEther(
-                      BigInt(
-                        _renderResultText(
-                          abiParameter.name,
-                          abiParameter.type,
-                          value
-                        )
-                      )
-                    )
-                    .toString()} wei`}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-            <ClipboardButton
-              text={_renderResultText(
-                abiParameter.name,
-                abiParameter.type,
-                value
-              )}
-            />
-          </div>
-        ) : (
-          <span className="text-sm">
-            {result}
-            <ClipboardButton text={result} />
-          </span>
-        )}
-      </div>
-    </>
-  );
-}
-
-function _renderOutput(
-  abiParameter: AbiParameter,
-  value: { [key: string]: any },
-  indent = 0
-) {
-  const isTuple = abiParameter.type === 'tuple';
-  const isTupleArray = abiParameter.type === 'tuple[]';
-  const isAddressArray = abiParameter.type === 'address[]';
-
-  const hasComponents = _hasComponentsKey(abiParameter);
-  const isValidValue = Boolean(value);
-
-  const isNamedParameter =
-    isObject(value) && abiParameter.name && abiParameter.name in value;
-
-  if (isTuple && hasComponents && isValidValue) {
-    debugger;
-    return (
-      <div className={`pl-${4 * (indent + 1)}`}>
-        {Object.values(abiParameter).map((component: any, resIdx: number) => {
-          return (
-            <FunctionOutput
-              abiParameters={component}
-              methodResult={value}
-              indent={indent + 1}
-              key={resIdx}
-            />
-          );
-        })}
-      </div>
-    );
-  } else if (isTupleArray && hasComponents && isValidValue) {
-    return Array.isArray(value)
-      ? value.map((tupleItem, tupleIndex) => (
-          <div key={tupleIndex} className="pl-4">
-            <span className="text-xs text-muted-foreground font-mono">
-              tuple[{tupleIndex}]
-            </span>
-            {abiParameter.components.map(
-              (component: AbiParameter, compIdx: number) => (
-                <FunctionOutput
-                  key={compIdx}
-                  abiParameters={component}
-                  methodResult={
-                    Array.isArray(tupleItem) ? tupleItem[compIdx] : tupleItem
-                  }
-                  indent={indent + 1}
-                />
-              )
-            )}
-          </div>
-        ))
-      : null;
-  } else {
-    if (isNamedParameter && abiParameter.name) {
-      const outputValue = value[abiParameter.name];
-      return (
-        <span className="block pt-1 pb-2 text-xs">
-          {String(outputValue)}
-          <ClipboardButton text={outputValue} />
-        </span>
-      );
-    } else if (Array.isArray(value)) {
-      if (isAddressArray) {
-        return (
-          <div>
-            {value.map((val, idx) => (
-              <span className="text-xs block mt-2" key={idx}>
-                {val}
-                <ClipboardButton text={val} />
-              </span>
-            ))}
-          </div>
-        );
-      } else {
-        return value.map((val, idx) => (
-          <span className="text-sm block" key={idx}>
-            {_renderResultText(abiParameter.name, abiParameter.type, val)}
-            <ClipboardButton
-              text={_renderResultText(
-                abiParameter.name,
-                abiParameter.type,
-                val
-              )}
-            />
-          </span>
-        ));
-      }
-    } else {
-      return _renderValue(abiParameter, value);
-    }
-  }
-}
-
-export const FunctionOutput: FC<{
-  abiParameters: AbiParameter | readonly AbiParameter[];
-  methodResult: any;
-  indent?: number;
-}> = ({ abiParameters, methodResult, indent = 0 }) => {
-  if (isNil(abiParameters)) return null;
-
+export function FunctionOutput({ abiParameters, methodResult }: Props) {
   if (_isArrayAbiParameter(abiParameters)) {
-    if (abiParameters.length === 0) {
-      return (
-        <div className="flex flex-1 items-center h-full py-4">
-          <span className="text-sm m-auto text-muted-foreground">
-            This function doesn&apos;t return any values.
-          </span>
-        </div>
-      );
-    } else {
-      return abiParameters.map((abiParameter, index) => (
-        <FunctionOutput
-          abiParameters={abiParameter}
-          methodResult={methodResult?.[index]}
-          indent={indent + 1}
-          key={index}
-        />
-      ));
-    }
+    return abiParameters.map((abiParameter, index) => (
+      <AbiParameterPreview
+        key={`${abiParameter.name}-${index}`}
+        abiParameter={abiParameter}
+        value={methodResult?.[index]}
+      />
+    ));
   }
 
   return (
-    <div className="overflow-x-scroll py-2">
-      <ItemLabel
-        name={abiParameters.name || ''}
-        type={abiParameters.internalType || ''}
-      />
-      {_renderOutput(abiParameters, methodResult, indent)}
-    </div>
+    <AbiParameterPreview
+      key={`${abiParameters.name}-${methodResult}`}
+      abiParameter={abiParameters}
+      value={methodResult}
+    />
   );
-};
+}

--- a/packages/website/src/pages/_app.tsx
+++ b/packages/website/src/pages/_app.tsx
@@ -96,8 +96,11 @@ export default function RootLayout({
       <Providers>
         <Header />
 
-        <div className={'cannon-main'} style={cannonMainStyles}>
-          <div className={'cannon-layout flex relative'} style={layoutStyles}>
+        <div className="cannon-main" style={cannonMainStyles}>
+          <div
+            className="cannon-layout flex relative max-w-dvw"
+            style={layoutStyles}
+          >
             {getLayout(<Component {...pageProps} />)}
             <NoSsrE2EWalletConnector />
           </div>


### PR DESCRIPTION
This PR refactors the Abi Input renderer from the TransactionDisplay component into a separate component, which then it is reutilised for rendering interact outputs. Effectively fixing some rendering bugs for rendering arrays and objects which were already solved on the TX view.

It also fixes the rendering of non-values for objects and arrays, generating an template result with zeroed values (working the same way as Solidity).