### PR TITLE
fix(website): nonce override picker

### DIFF
--- a/packages/website/src/features/Deploy/NoncePicker.tsx
+++ b/packages/website/src/features/Deploy/NoncePicker.tsx
@@ -89,9 +89,11 @@ export default function NoncePicker({ safe, handleChange }: Params) {
               <SelectValue placeholder="Select nonce" />
             </SelectTrigger>
             <SelectContent>
-              {safeTxs.staged.map(({ txn }) => (
-                <SelectItem key={txn._nonce} value={txn._nonce.toString()}>
-                  {txn._nonce}
+              {Array.from(
+                new Set(safeTxs.staged.map(({ txn }) => txn._nonce.toString()))
+              ).map((nonce) => (
+                <SelectItem key={nonce} value={nonce}>
+                  {nonce}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/packages/website/src/features/Deploy/PreviewTransactionsButton.tsx
+++ b/packages/website/src/features/Deploy/PreviewTransactionsButton.tsx
@@ -27,7 +27,7 @@ function PreviewButton({
       <Button
         className="w-full"
         variant="default"
-        disabled={isDisabled}
+        disabled={isDisabled || isDeploying}
         onClick={handlePreviewTxnsClick}
       >
         {buttonText}


### PR DESCRIPTION
This PR fixes the nonce override picker when there are multiple TXs with the same nonce:
<img width="771" alt="Screenshot 2025-01-30 at 14 39 47" src="https://github.com/user-attachments/assets/45e49b1f-1e23-4151-a4e0-222bbf3a79be" />

Also, does not allow to press the preview button when it is loading data.