### PR TITLE
hotfix(website): show upgrade from input

### DIFF
--- a/packages/website/src/features/Deploy/CannonFileInput.tsx
+++ b/packages/website/src/features/Deploy/CannonFileInput.tsx
@@ -6,8 +6,6 @@ import { FormControl, FormDescription, FormItem } from '@/components/ui/form';
 import { CustomSpinner } from '@/components/CustomSpinner';
 import { cn } from '@/lib/utils';
 
-// TODO: Fix error. Check when it is the main input or when is is the secondary input.
-
 // Define interface for component props
 interface CannonFileInputProps {
   cannonfileUrlInput: string;

--- a/packages/website/src/features/Deploy/PrevDeploymentStatus.tsx
+++ b/packages/website/src/features/Deploy/PrevDeploymentStatus.tsx
@@ -1,4 +1,5 @@
 import NextLink from 'next/link';
+import { getIpfsCid, getIpfsUrl } from '@usecannon/builder';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
 export function PrevDeploymentStatus({
@@ -15,14 +16,13 @@ export function PrevDeploymentStatus({
           <AlertDescription>
             Previous Deployment:{' '}
             <NextLink
-              href={`/ipfs?cid=${prevDeployLocation.replace(
-                'ipfs://',
-                ''
+              href={`/ipfs?cid=${getIpfsCid(
+                prevDeployLocation
               )}&compressed=true`}
               className="text-primary hover:underline"
               target="_blank"
             >
-              {prevDeployLocation.replace('ipfs://', '')}
+              {getIpfsUrl(prevDeployLocation)}
             </NextLink>
           </AlertDescription>
         </Alert>

--- a/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
+++ b/packages/website/src/features/Deploy/QueueFromGitOpsPage.tsx
@@ -72,7 +72,7 @@ export default function QueueFromGitOps() {
     cannonfileUrlInput,
     partialDeployIpfs,
     chainId,
-    prevPackageReference: prevPackageReference,
+    prevPackageReference,
   });
 
   const {
@@ -108,15 +108,15 @@ export default function QueueFromGitOps() {
   useEffect(() => {
     if (!cannonDefInfo.def) return;
 
-    const def = cannonDefInfo.def.toJson();
-
-    if (hasDeployers && !def) {
-      const { name, preset } = def;
-      const { fullPackageRef } = PackageReference.from(name, 'latest', preset);
-      setPreviousPackageInput(fullPackageRef);
-    } else {
-      setPreviousPackageInput('');
+    // After loading the deployment info, set a default value for the upgradeFrom field
+    if (hasDeployers || !cannonDefInfo?.def) {
+      return setPreviousPackageInput('');
     }
+
+    const def = cannonDefInfo.def.toJson();
+    const { name, preset } = def;
+    const { fullPackageRef } = PackageReference.from(name, 'latest', preset);
+    setPreviousPackageInput(fullPackageRef);
   }, [hasDeployers, cannonDefInfo.def]);
 
   // Upload artifacts to IPFS when the build is successful
@@ -194,15 +194,8 @@ export default function QueueFromGitOps() {
                 }
               />
             </div>
-            {/* Deployment alert status  */}
-            {selectedDeployType == 'git' && onChainPrevPkgQuery.isFetched && (
-              <PrevDeploymentStatus
-                prevDeployLocation={prevDeployLocation}
-                tomlRequiresPrevPackage={requiresPrevPackage}
-              />
-            )}
             {/* Hash: Prev deployment Input */}
-            {cannonDefInfo?.def && requiresPrevPackage && (
+            {cannonDefInfo?.def && !hasDeployers && (
               <div className="mb-4">
                 <PreviousPackageInput
                   previousPackageInput={previousPackageInput}
@@ -211,6 +204,13 @@ export default function QueueFromGitOps() {
                   onChainPrevPkgQuery={onChainPrevPkgQuery}
                 />
               </div>
+            )}
+            {/* Deployment alert status  */}
+            {selectedDeployType == 'git' && onChainPrevPkgQuery.isFetched && (
+              <PrevDeploymentStatus
+                prevDeployLocation={prevDeployLocation}
+                tomlRequiresPrevPackage={requiresPrevPackage}
+              />
             )}
             {/* Hash: CannonFile to compare with prev deployment */}
             {selectedDeployType == 'partial' &&

--- a/packages/website/src/features/Deploy/hooks/useCannonPackage.ts
+++ b/packages/website/src/features/Deploy/hooks/useCannonPackage.ts
@@ -4,7 +4,7 @@ import {
   useCannonFindUpgradeFromUrl,
 } from '@/hooks/cannon';
 import { useGitDetailsFromCannonfile } from '@/features/Deploy/hooks/useGitDetailsFromCannonfile';
-import { ChainBuilderContext, PackageReference } from '@usecannon/builder';
+import { ChainBuilderContext, getIpfsUrl, PackageReference } from '@usecannon/builder';
 
 // TODO: is there any way to make a better context? maybe this means we should get rid of name using context?
 const ctx: ChainBuilderContext = {
@@ -134,7 +134,7 @@ export function useCannonPackage({
 }) {
   // If the user enters a partial deploy IPFS hash
   // TODO: check if ipfs:// is needed or if it's duplicated
-  const _partialDeployInputIpfs = partialDeployInputIpfs ? `ipfs://${partialDeployInputIpfs}` : '';
+  const _partialDeployInputIpfs = getIpfsUrl(partialDeployInputIpfs) || undefined;
   const partialDeployInfo = useFetchCannonPackage(_partialDeployInputIpfs, chainId);
 
   // Get a cannon definition combining the git and partial deploy info
@@ -158,13 +158,12 @@ export function useCannonPackage({
   // Derived states
   // ----------------------------
 
-  const hasDeployers = Boolean(cannonDefInfo?.def?.getDeployers()?.length);
+  const hasDeployers = !!cannonDefInfo?.def?.getDeployers()?.length;
 
   // Check if the cannonfile requires a previous package
   const requiresPrevPackage = Boolean(
-    cannonDefInfo?.def &&
-      !hasDeployers &&
-      cannonDefInfo.def.allActionNames.some((item) => item.startsWith('deploy.') || item.startsWith('contract.'))
+    !hasDeployers &&
+      cannonDefInfo.def?.allActionNames.some((item) => item.startsWith('deploy.') || item.startsWith('contract.'))
   );
 
   const isLoading =
@@ -179,7 +178,7 @@ export function useCannonPackage({
       : null;
 
   const loaded = getLoadedState({
-    partialDeployInputIpfs: _partialDeployInputIpfs,
+    partialDeployInputIpfs: _partialDeployInputIpfs || '',
     partialDeployInfo,
     cannonfileUrlInput,
     cannonDefInfo,


### PR DESCRIPTION
This PR fixes a bug that caused to not show the "Previous Package" input when deploying without using the `deployers =` params:
<img width="771" alt="Screenshot 2025-02-03 at 15 49 18" src="https://github.com/user-attachments/assets/daeaef6f-8cec-4cd3-9095-74ac14e4438a" />
