### PR TITLE
fix(cli): foundry contractName compatibility

### DIFF
--- a/packages/cli/src/foundry.ts
+++ b/packages/cli/src/foundry.ts
@@ -134,7 +134,7 @@ export async function getFoundryArtifact(name: string, baseDir = '', includeSour
     };
 
     return {
-      contractName: name,
+      contractName: inputContractName,
       sourceName: artifact.ast.absolutePath,
       abi: artifact.abi,
       bytecode: artifact.bytecode.object,
@@ -145,7 +145,7 @@ export async function getFoundryArtifact(name: string, baseDir = '', includeSour
   }
 
   return {
-    contractName: inputContractName!,
+    contractName: inputContractName,
     sourceName: artifact.ast.absolutePath,
     abi: artifact.abi,
     bytecode: artifact.bytecode.object,


### PR DESCRIPTION
Fix compatibility when foundry saves artifacts with `contactName` including fully qualified name, e.g. `contractName: "src/Example.sol:Example"` instead of only the actual contract name.