### PR TITLE
fix(builder): validation of template accesses which depend on `chainId`

### DIFF
--- a/examples/sample-foundry-project/cannonfile.toml
+++ b/examples/sample-foundry-project/cannonfile.toml
@@ -1,4 +1,4 @@
-name = "greeter-foundry"
+name = "greeter"
 version = "<%= package.version %>"
 description = "Simple project to verify the functionality of cannon"
 keywords = ["sample", "greeter"]

--- a/examples/sample-foundry-project/package.json
+++ b/examples/sample-foundry-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-foundry-project",
-  "version": "2.11.18",
+  "version": "2.11.20",
   "private": true,
   "scripts": {
     "test": "forge test",

--- a/examples/sample-hardhat-project/cannonfile.consumer.toml
+++ b/examples/sample-hardhat-project/cannonfile.consumer.toml
@@ -15,7 +15,7 @@ options.salt = "second"
 options.msg = "a message from second greeter set"
 
 [invoke.do_change_greeting2]
-target = ["greeters.Greeter"]
+target = ["greeters.Greeterz"]
 func = "setGreeting"
 args = ["<%= settings.change_greeting2 %>"]
 
@@ -40,11 +40,9 @@ args = ["<%= contracts.cloned.address %>", "<%= formatBytes32String('New Greetin
 
 var.NewCloneGreeting.event = "NewGreetingAdded"
 var.NewCloneGreeting.arg = 0
-var.NewCloneGreeting.artifact = "Greeter"
 
 var.OldCloneGreeting.event = "OldGreetingRemoved"
 var.OldCloneGreeting.arg = 0
-var.OldCloneGreeting.artifact = "Greeter"
 
 # test to parse through previous emitted event values
 [invoke.set_new_greeting_for_next_clones]

--- a/packages/builder/src/access-recorder.test.ts
+++ b/packages/builder/src/access-recorder.test.ts
@@ -1,51 +1,52 @@
-import { computeTemplateAccesses } from './access-recorder';
+import { TemplateContext } from './access-recorder';
 
 describe('access-recorder.ts', () => {
-  describe('computeTemplateAccesses()', () => {
+  const templateContext = new TemplateContext({ chainId: 45, timestamp: 0, package: { version: '0.0.0' } });
+  describe('TemplateContext.computeAccesses()', () => {
     it('computes dependency with addition operation', () => {
-      expect(computeTemplateAccesses('<%= settings.value1 + settings.value2 %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= settings.value1 + settings.value2 %>')).toEqual({
         accesses: ['settings.value1', 'settings.value2'],
         unableToCompute: false,
       });
     });
 
     it('computes dependency with addition operation using extras', () => {
-      expect(computeTemplateAccesses('<%= extras.value1 + extras.value2 %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= extras.value1 + extras.value2 %>')).toEqual({
         accesses: ['extras.value1', 'extras.value2'],
         unableToCompute: false,
       });
     });
 
     it('computes dependency with usage of allowed global variables', () => {
-      expect(computeTemplateAccesses('<%= parseEther(String(0.3)) %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= parseEther(String(0.3)) %>')).toEqual({
         accesses: [],
         unableToCompute: false,
       });
     });
 
     it('computes simple addition', () => {
-      expect(computeTemplateAccesses('<%= 1 + 1 %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= 1 + 1 %>')).toEqual({
         accesses: [],
         unableToCompute: false,
       });
     });
 
     it('computes dependency with subtraction operation', () => {
-      expect(computeTemplateAccesses('<%= settings.value1 - settings.value2 %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= settings.value1 - settings.value2 %>')).toEqual({
         accesses: ['settings.value1', 'settings.value2'],
         unableToCompute: false,
       });
     });
 
     it('computes dependency with multiplication operation', () => {
-      expect(computeTemplateAccesses('<%= settings.value1 * settings.value2 %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= settings.value1 * settings.value2 %>')).toEqual({
         accesses: ['settings.value1', 'settings.value2'],
         unableToCompute: false,
       });
     });
 
     it('computes dependency with division operation', () => {
-      expect(computeTemplateAccesses('<%= settings.value1 / settings.value2 %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= settings.value1 / settings.value2 %>')).toEqual({
         accesses: ['settings.value1', 'settings.value2'],
         unableToCompute: false,
       });
@@ -53,7 +54,7 @@ describe('access-recorder.ts', () => {
 
     it('computes dependency with complex math operation', () => {
       expect(
-        computeTemplateAccesses('<%= (settings.value1 + settings.value2) * settings.value3 / settings.value4 %>')
+        templateContext.computeAccesses('<%= (settings.value1 + settings.value2) * settings.value3 / settings.value4 %>')
       ).toEqual({
         accesses: ['settings.value1', 'settings.value2', 'settings.value3', 'settings.value4'],
         unableToCompute: false,
@@ -61,14 +62,14 @@ describe('access-recorder.ts', () => {
     });
 
     it('computes multiple dependencies on different template tags', () => {
-      expect(computeTemplateAccesses('<%= settings.woot %>-<%= settings.woot2 %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= settings.woot %>-<%= settings.woot2 %>')).toEqual({
         accesses: ['settings.woot', 'settings.woot2'],
         unableToCompute: false,
       });
     });
 
     it('computes simple dependency', () => {
-      expect(computeTemplateAccesses('<%= settings.woot %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= settings.woot %>')).toEqual({
         accesses: ['settings.woot'],
         unableToCompute: false,
       });
@@ -76,7 +77,7 @@ describe('access-recorder.ts', () => {
 
     it('computes array dependency', () => {
       expect(
-        computeTemplateAccesses(
+        templateContext.computeAccesses(
           '["<%= settings.camelotSwapPublisherAdmin1 %>","<%= settings.camelotSwapPublisherAdmin2 %>"]'
         )
       ).toEqual({
@@ -86,7 +87,7 @@ describe('access-recorder.ts', () => {
     });
 
     it('computes dependency using simple CannonHelperContext', () => {
-      expect(computeTemplateAccesses('<%= parseEther(settings.woot) %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= parseEther(settings.woot) %>')).toEqual({
         accesses: ['settings.woot'],
         unableToCompute: false,
       });
@@ -94,7 +95,7 @@ describe('access-recorder.ts', () => {
 
     it('computes dependency using complex CannonHelperContext', () => {
       expect(
-        computeTemplateAccesses(
+        templateContext.computeAccesses(
           '<%= defaultAbiCoder.encode(parseEther(settings.woot)) %> + <%= defaultAbiCoder.decode(contracts.compound) %>'
         )
       ).toEqual({
@@ -102,32 +103,39 @@ describe('access-recorder.ts', () => {
         unableToCompute: false,
       });
     });
+
+    it('computes dependency with chainId as a dynamic value search', () => {
+      expect(templateContext.computeAccesses('<%= settings[`my_${chainId}`] %>')).toEqual({
+        accesses: ['settings.my_45'],
+        unableToCompute: false,
+      });
+    })
   });
 
   describe('computeTemplateAccesses() syntax validation', () => {
     it('handles invalid template syntax - unmatched brackets', () => {
-      expect(computeTemplateAccesses('<%= settings.value) %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= settings.value) %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('handles empty template tags', () => {
-      expect(computeTemplateAccesses('<%=%>')).toEqual({
+      expect(templateContext.computeAccesses('<%=%>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('handles multiple template tags with mixed validity', () => {
-      expect(computeTemplateAccesses('<%= settings.valid %> and <% invalid.syntax')).toEqual({
+      expect(templateContext.computeAccesses('<%= settings.valid %> and <% invalid.syntax')).toEqual({
         accesses: ['settings.valid'],
         unableToCompute: false,
       });
     });
 
     it('handles template with only whitespace', () => {
-      expect(computeTemplateAccesses('<%=   %>')).toEqual({
+      expect(templateContext.computeAccesses('<%=   %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
@@ -136,42 +144,42 @@ describe('access-recorder.ts', () => {
 
   describe('computeTemplateAccesses() security', () => {
     it('prevents direct code execution', () => {
-      expect(computeTemplateAccesses('<%= process.exit(1) %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= process.exit(1) %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('prevents access to global objects', () => {
-      expect(computeTemplateAccesses('<%= global.process %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= global.process %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('prevents require/import statements', () => {
-      expect(computeTemplateAccesses('<%= require("fs") %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= require("fs") %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('prevents eval usage', () => {
-      expect(computeTemplateAccesses('<%= eval("console.log(\'REKT\')") %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= eval("console.log(\'REKT\')") %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('prevents Function constructor usage', () => {
-      expect(computeTemplateAccesses('<%= new Function("return process")() %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= new Function("return process")() %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('prevents setTimeout/setInterval usage', () => {
-      expect(computeTemplateAccesses('<%= setTimeout(() => {}, 1000) %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= setTimeout(() => {}, 1000) %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
@@ -179,7 +187,7 @@ describe('access-recorder.ts', () => {
 
     it('prevents overriding console.log', () => {
       expect(
-        computeTemplateAccesses('<%= console.log=function(n){require("fs").writeFileSync("./exploit.log",n)} %>')
+        templateContext.computeAccesses('<%= console.log=function(n){require("fs").writeFileSync("./exploit.log",n)} %>')
       ).toEqual({
         accesses: [],
         unableToCompute: true,
@@ -187,7 +195,7 @@ describe('access-recorder.ts', () => {
     });
 
     it('prevents assignment of values', () => {
-      expect(computeTemplateAccesses('<%= const value = 1 + 2 %>')).toEqual({
+      expect(templateContext.computeAccesses('<%= const value = 1 + 2 %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });

--- a/packages/builder/src/actions.ts
+++ b/packages/builder/src/actions.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { AccessComputationResult } from './access-recorder';
+import { AccessComputationResult, TemplateContext } from './access-recorder';
 import { handleZodErrors } from './error/zod';
 import { ChainBuilderRuntime } from './runtime';
 import { chainDefinitionSchema } from './schemas';
@@ -27,13 +27,13 @@ export interface CannonAction<Config extends RawConfig = any> {
     runtime: ChainBuilderRuntime,
     ctx: ChainBuilderContext,
     config: Config,
-    packageState: PackageState
+    packageState: PackageState,
   ) => Promise<any[] | null>;
 
   /**
    * Returns a list of state keys that this operation consumes (used for dependency inference)
    */
-  getInputs?: (config: Config, possibleFields: string[], packageState: PackageState) => AccessComputationResult;
+  getInputs?: (config: Config, templateContext: TemplateContext, packageState: PackageState) => AccessComputationResult;
 
   /**
    * Returns a list of state keys this operation produces (used for dependency inference)
@@ -44,7 +44,7 @@ export interface CannonAction<Config extends RawConfig = any> {
     runtime: ChainBuilderRuntime,
     ctx: ChainBuilderContext,
     config: Config,
-    packageState: PackageState
+    packageState: PackageState,
   ) => Promise<ChainArtifacts>;
 
   importExisting?: (
@@ -52,7 +52,7 @@ export interface CannonAction<Config extends RawConfig = any> {
     ctx: ChainBuilderContext,
     config: Config,
     packageState: PackageState,
-    existingKeys: string[]
+    existingKeys: string[],
   ) => Promise<ChainArtifacts>;
 
   // Takes in any schema as long as the base type is ZodSchema

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -10,6 +10,7 @@ import { template } from './utils/template';
 
 import { PackageReference } from './package-reference';
 import { ZodIssue } from 'zod';
+import { TemplateContext } from '.';
 
 const debug = Debug('cannon:builder:definition');
 const debugVerbose = Debug('cannon:verbose:builder:definition');
@@ -61,7 +62,9 @@ export function validatePackageVersion(v: string) {
 export class ChainDefinition {
   private raw: RawChainDefinition;
   private sensitiveDependencies: boolean;
+  private accessRecordTemplateContext: TemplateContext;
 
+  readonly clashes: OutputClashCheckResult[];
   readonly allActionNames: string[];
 
   private _roots: Set<string> = new Set();
@@ -75,7 +78,15 @@ export class ChainDefinition {
 
   readonly danglingDependencies = new Set<`${string}:${string}`>();
 
-  constructor(def: RawChainDefinition, sensitiveDependencies = false) {
+  constructor(
+    def: RawChainDefinition,
+    sensitiveDependencies = false,
+    overrides: { chainId: number; timestamp: number; package: { version: string } } = {
+      chainId: 0,
+      timestamp: Date.now(),
+      package: { version: '0.0.0' },
+    },
+  ) {
     debug('begin chain def init');
     this.raw = def;
     this.sensitiveDependencies = sensitiveDependencies;
@@ -107,6 +118,25 @@ export class ChainDefinition {
 
     // do some preindexing
     this.allActionNames = _.sortBy(actions, _.identity);
+
+    // checking for output clashes will also fill out the dependency map
+    this.clashes = this.checkOutputClash();
+
+    const possibleFields: string[] = [];
+    for (const k of this.dependencyFor.keys()) {
+      const baseName = k.split('.')[0];
+      if (
+        baseName !== 'contracts' &&
+        baseName !== 'imports' &&
+        baseName !== 'settings' &&
+        baseName !== 'extras' &&
+        baseName !== 'txns'
+      ) {
+        possibleFields.push(baseName);
+      }
+    }
+
+    this.accessRecordTemplateContext = new TemplateContext(overrides);
 
     debug('finished chain def init');
   }
@@ -153,7 +183,7 @@ export class ChainDefinition {
 
     if (!action) {
       throw new Error(
-        `action kind plugin not installed: "${kind}" (for action: "${n}"). please install the plugin necessary to build this package.`
+        `action kind plugin not installed: "${kind}" (for action: "${n}"). please install the plugin necessary to build this package.`,
       );
     }
 
@@ -173,7 +203,7 @@ export class ChainDefinition {
     n: string,
     runtime: ChainBuilderRuntime,
     ctx: ChainBuilderContext,
-    tainted: boolean
+    tainted: boolean,
   ): Promise<string[] | null> {
     const kind = n.split('.')[0] as keyof typeof ActionKinds;
 
@@ -220,7 +250,7 @@ export class ChainDefinition {
         source: template(d.source, ctx),
         chainId: d.chainId || ctx.chainId,
         preset: d.preset ? template(d.preset, ctx) : 'main',
-      }))
+      })),
     );
   }
 
@@ -254,20 +284,7 @@ export class ChainDefinition {
     }
 
     if (ActionKinds[n].getInputs) {
-      const possibleFields: string[] = [];
-      for (const k of this.dependencyFor.keys()) {
-        const baseName = k.split('.')[0];
-        if (
-          baseName !== 'contracts' &&
-          baseName !== 'imports' &&
-          baseName !== 'settings' &&
-          baseName !== 'extras' &&
-          baseName !== 'txns'
-        ) {
-          possibleFields.push(baseName);
-        }
-      }
-      const accessComputationResults = ActionKinds[n].getInputs!(_.get(this.raw, node), possibleFields, {
+      const accessComputationResults = ActionKinds[n].getInputs!(_.get(this.raw, node), this.accessRecordTemplateContext, {
         ref: null,
         currentLabel: node,
       });
@@ -276,8 +293,8 @@ export class ChainDefinition {
       if (this.sensitiveDependencies && accessComputationResults.unableToCompute && !_.get(this.raw, node).depends) {
         throw new Error(
           `Unable to compute dependencies for [${node}] because of advanced logic in template strings. Specify dependencies manually, like "depends = ['${_.uniq(
-            _.uniq(accessComputationResults.accesses).map((a) => `${this.dependencyFor.get(a)}`)
-          ).join("', '")}']"`
+            _.uniq(accessComputationResults.accesses).map((a) => `${this.dependencyFor.get(a)}`),
+          ).join("', '")}']"`,
         );
       }
 
@@ -325,13 +342,9 @@ export class ChainDefinition {
   initializeComputedDependencies = _.memoize(() => {
     const computeDepsDebug = Debug('cannon:builder:dependencies');
     computeDepsDebug('start compute dependencies');
-    // checking for output clashes will also fill out the dependency map
-    const clashes = this.checkOutputClash();
 
-    computeDepsDebug('finished checking clashes');
-
-    if (clashes.length) {
-      throw new Error(`cannot generate dependency tree: output clashes exist: ${JSON.stringify(clashes)}`);
+    if (this.clashes.length) {
+      throw new Error(`cannot generate dependency tree: output clashes exist: ${JSON.stringify(this.clashes)}`);
     }
 
     // get all dependencies, and filter out the extraneous
@@ -356,8 +369,8 @@ export class ChainDefinition {
           .map((n) => this.getDependencies(n))
           .flatten()
           .uniq()
-          .value()
-      )
+          .value(),
+      ),
     );
 
     if (computeDepsDebug.enabled) {
@@ -403,7 +416,7 @@ export class ChainDefinition {
     const cycle = missing.length ? [] : this.checkCycles();
     // TODO: this check seems to be a bit too sensitive atm
     const extraneousDeps: { node: string; extraneous: string; inDep: string }[] = []; // this.checkExtraneousDependencies();
-    const outputClashes = this.checkOutputClash();
+    const outputClashes = this.clashes;
 
     for (const extDep of extraneousDeps) {
       const deps = this.resolvedDependencies.get(extDep.node)!;
@@ -479,7 +492,7 @@ export class ChainDefinition {
   checkCycles(
     actions = this.allActionNames,
     seenNodes = new Set<string>(),
-    currentPath = new Set<string>()
+    currentPath = new Set<string>(),
   ): string[] | null {
     // resolved dependencies gets set during dependency computation
     this.initializeComputedDependencies();
@@ -689,7 +702,7 @@ export class ChainDefinition {
     }
     return Math.max(
       layers[n].actions.length + 2,
-      _.sumBy(layers[n].depends, (d) => this.getPrintLinesUsed(d, layers))
+      _.sumBy(layers[n].depends, (d) => this.getPrintLinesUsed(d, layers)),
     );
   }
 

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -6,7 +6,7 @@ if (!Object.prototype.hasOwnProperty.call(BigInt.prototype, 'toJSON')) {
 }
 
 export { createInitialContext, build, getArtifacts, addOutputsToContext, getOutputs } from './builder';
-export { computeTemplateAccesses, mergeTemplateAccesses } from './access-recorder';
+export { TemplateContext, mergeTemplateAccesses } from './access-recorder';
 export { registerAction, ActionKinds } from './actions';
 export type { CannonAction, RawChainDefinition } from './actions';
 export { ChainDefinition } from './definition';

--- a/packages/builder/src/steps/clone.test.ts
+++ b/packages/builder/src/steps/clone.test.ts
@@ -5,6 +5,7 @@ import action from './clone';
 import deployAction from './deploy';
 import { fakeCtx, fakeRuntime } from './utils.test.helper';
 import { PackageReference } from '../package-reference';
+import { TemplateContext } from '..';
 
 jest.mock('../loader');
 jest.mock('./deploy');
@@ -60,7 +61,7 @@ describe('steps/clone.ts', () => {
             var: { woot: '<%= settings.b %>', wah: '<%= settings.c %>' },
             options: { woot: '<%= settings.d %>', wah: '<%= settings.e %>', tags: '<%= settings.f %>' },
           },
-          []
+          new TemplateContext({ chainId: 0, timestamp: 0, package: { version: '0.0.0.0' } })
         )
       ).toEqual({
         accesses: ['settings.a', 'settings.b', 'settings.c', 'settings.d', 'settings.e', 'settings.f'],

--- a/packages/builder/src/steps/deploy.test.ts
+++ b/packages/builder/src/steps/deploy.test.ts
@@ -5,6 +5,7 @@ import { ContractArtifact } from '../types';
 import action from './deploy';
 import { fakeCtx, fakeRuntime, makeFakeSigner } from './utils.test.helper';
 import { PackageReference } from '../package-reference';
+import { TemplateContext } from '..';
 
 const DEFAULT_ARACHNID_ADDRESS = '0x4e59b44847b379578588920cA78FbF26c0B4956C';
 
@@ -159,7 +160,7 @@ describe('steps/deploy.ts', () => {
               args: ['<%= contracts.h %>', '<%= contracts.i %>'],
               salt: '<%= contracts.j %>',
             },
-            []
+            new TemplateContext({ chainId: 0, timestamp: 0, package: { version: '0.0.0' }})
           )
           .accesses.sort()
       ).toEqual([

--- a/packages/builder/src/steps/invoke.test.ts
+++ b/packages/builder/src/steps/invoke.test.ts
@@ -3,6 +3,7 @@ import { validateConfig } from '../actions';
 import action from './invoke';
 import { fakeCtx, fakeRuntime } from './utils.test.helper';
 import { PackageReference } from '../package-reference';
+import { TemplateContext } from '..';
 
 describe('steps/invoke.ts', () => {
   const fakeContractInfo = {
@@ -66,7 +67,7 @@ describe('steps/invoke.ts', () => {
 
     it('fails when setting invalid value', () => {
       expect(() => validateConfig(action.validate, { target: 'owner()', invalid: ['something'] })).toThrow(
-        "Unrecognized key(s) in object: 'invalid'"
+        "Unrecognized key(s) in object: 'invalid'",
       );
     });
   });
@@ -110,7 +111,7 @@ describe('steps/invoke.ts', () => {
           target: ['Woot'],
           func: 'something',
         },
-        { ref: null, currentLabel: 'invoke.Invoke' }
+        { ref: null, currentLabel: 'invoke.Invoke' },
       );
 
       expect(result).toContainEqual({
@@ -131,7 +132,7 @@ describe('steps/invoke.ts', () => {
           args: ['split', { wave: 'form' }],
           value: '1234',
         },
-        { ref: null, currentLabel: 'invoke.Invoke' }
+        { ref: null, currentLabel: 'invoke.Invoke' },
       );
 
       expect(result).toContainEqual({
@@ -158,9 +159,9 @@ describe('steps/invoke.ts', () => {
               args: ['<%= contracts.h %>', '<%= contracts.i %>'],
               overrides: { gasLimit: '<%= contracts.j %>' },
             },
-            []
+            new TemplateContext({ chainId: 0, timestamp: 0, package: { version: '0.0.0' } }),
           )
-          .accesses.sort()
+          .accesses.sort(),
       ).toEqual([
         'contracts.a',
         'contracts.b',
@@ -186,8 +187,8 @@ describe('steps/invoke.ts', () => {
             factory: { something: { event: 'whoop', arg: 0 } },
             extra: { else: { event: 'arst', arg: 1 } },
           },
-          { ref: new PackageReference('fun:1.0.0'), currentLabel: 'invoke.Hello' }
-        )
+          { ref: new PackageReference('fun:1.0.0'), currentLabel: 'invoke.Hello' },
+        ),
       ).toEqual(['txns.Hello', 'contracts.something', 'something', 'settings.else', 'extras.else']);
     });
   });
@@ -239,7 +240,7 @@ describe('steps/invoke.ts', () => {
             },
           },
         },
-        { ref: new PackageReference('fun:1.0.0'), currentLabel: 'invoke.something' }
+        { ref: new PackageReference('fun:1.0.0'), currentLabel: 'invoke.something' },
       );
 
       expect(result.contracts).toStrictEqual({

--- a/packages/builder/src/steps/pull.ts
+++ b/packages/builder/src/steps/pull.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import _ from 'lodash';
 import { z } from 'zod';
 import { Events } from '../runtime';
-import { computeTemplateAccesses, mergeTemplateAccesses } from '../access-recorder';
+import { mergeTemplateAccesses } from '../access-recorder';
 import { getOutputs } from '../builder';
 import { ChainDefinition } from '../definition';
 import { PackageReference } from '../package-reference';
@@ -59,9 +59,9 @@ const pullSpec = {
     return config;
   },
 
-  getInputs(config, possibleFields) {
-    let accesses = computeTemplateAccesses(config.source, possibleFields);
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.preset, possibleFields));
+  getInputs(config, templateContext) {
+    let accesses = templateContext.computeAccesses(config.source);
+    accesses = mergeTemplateAccesses(accesses, templateContext.computeAccesses(config.preset));
 
     return accesses;
   },
@@ -82,7 +82,7 @@ const pullSpec = {
       runtime.emit(
         Events.Notice,
         packageState.currentLabel,
-        'To prevent unexpected upgrades, it is strongly recommended to lock the version of the source package by specifying a version in the `source` field.'
+        'To prevent unexpected upgrades, it is strongly recommended to lock the version of the source package by specifying a version in the `source` field.',
       );
     }
 
@@ -92,13 +92,13 @@ const pullSpec = {
 
     if (!deployInfo) {
       throw new Error(
-        `deployment not found: ${source}. please make sure it exists for the cannon network and ${preset} preset.`
+        `deployment not found: ${source}. please make sure it exists for the cannon network and ${preset} preset.`,
       );
     }
 
     if (deployInfo.status === 'partial') {
       throw new Error(
-        `deployment status is incomplete for ${source}. cannot generate artifacts safely. please complete deployment to continue import.`
+        `deployment status is incomplete for ${source}. cannot generate artifacts safely. please complete deployment to continue import.`,
       );
     }
 
@@ -106,7 +106,15 @@ const pullSpec = {
       imports: {
         [importLabel]: {
           url: (await runtime.registry.getUrl(source, chainId))!, // todo: duplication
-          ...(await getOutputs(runtime, new ChainDefinition(deployInfo.def), deployInfo.state))!,
+          ...(await getOutputs(
+            runtime,
+            new ChainDefinition(deployInfo.def, false, {
+              chainId,
+              timestamp: deployInfo.timestamp || 0,
+              package: { version: '0.0.0' },
+            }),
+            deployInfo.state,
+          ))!,
         },
       },
     };

--- a/packages/builder/src/steps/router.ts
+++ b/packages/builder/src/steps/router.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import * as viem from 'viem';
 import { z } from 'zod';
 import { generateRouter } from '@usecannon/router';
-import { computeTemplateAccesses, mergeTemplateAccesses } from '../access-recorder';
+import { mergeTemplateAccesses } from '../access-recorder';
 import { routerSchema } from '../schemas';
 import { ContractMap } from '../types';
 import {
@@ -104,15 +104,15 @@ const routerStep = {
     return config;
   },
 
-  getInputs(config, possibleFields) {
-    let accesses = computeTemplateAccesses(config.from);
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.salt, possibleFields));
+  getInputs(config, templateContext) {
+    let accesses = templateContext.computeAccesses(config.from);
+    accesses = mergeTemplateAccesses(accesses, templateContext.computeAccesses(config.salt));
     accesses.accesses.push(
-      ...config.contracts.map((c) => (c.includes('.') ? `imports.${c.split('.')[0]}` : `contracts.${c}`))
+      ...config.contracts.map((c) => (c.includes('.') ? `imports.${c.split('.')[0]}` : `contracts.${c}`)),
     );
 
     if (config?.overrides) {
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.overrides.gasLimit, possibleFields));
+      accesses = mergeTemplateAccesses(accesses, templateContext.computeAccesses(config.overrides.gasLimit));
     }
 
     return accesses;

--- a/packages/builder/src/steps/var.ts
+++ b/packages/builder/src/steps/var.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug';
 import _ from 'lodash';
 import { z } from 'zod';
-import { computeTemplateAccesses, mergeTemplateAccesses } from '../access-recorder';
+import { mergeTemplateAccesses } from '../access-recorder';
 import { varSchema } from '../schemas';
 import { template } from '../utils/template';
 import { CannonAction } from '../actions';
@@ -42,11 +42,11 @@ const varSpec = {
     return config;
   },
 
-  getInputs(config, possibleFields) {
-    let accesses = computeTemplateAccesses('', possibleFields);
+  getInputs(config, templateContext) {
+    let accesses = templateContext.computeAccesses('');
 
     for (const c in _.omit(config, 'depends')) {
-      const fields = computeTemplateAccesses(config[c], possibleFields);
+      const fields = templateContext.computeAccesses(config[c]);
       accesses = mergeTemplateAccesses(accesses, fields);
     }
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -95,7 +95,7 @@ export async function build({
 
   if (dryRun && rpcUrl) {
     log(
-      yellowBright(bold('⚠️ This is a simulation. No changes will be made to the chain. No package data will be saved.\n'))
+      yellowBright(bold('⚠️ This is a simulation. No changes will be made to the chain. No package data will be saved.\n')),
     );
   }
 
@@ -104,7 +104,7 @@ export async function build({
   const packageReference = PackageReference.from(
     packageDefinition.name,
     packageDefinition.version,
-    packageDefinition.preset
+    packageDefinition.preset,
   );
 
   const { fullPackageRef, packageRef } = packageReference;
@@ -160,7 +160,7 @@ export async function build({
         runtime.provider,
         packageReference,
         runtime.chainId,
-        def.getDeployers()
+        def.getDeployers(),
       );
       if (oldDeployHash) {
         log(green(bold(`Found deployment state via on-chain store: ${oldDeployHash}`)));
@@ -182,7 +182,11 @@ export async function build({
 
   const resolvedSettings = _.pickBy(_.assign((!wipe && oldDeployData?.options) || {}, packageDefinition.settings));
 
-  def = def || (oldDeployData ? new ChainDefinition(oldDeployData!.def) : undefined);
+  def =
+    def ||
+    (oldDeployData
+      ? new ChainDefinition(oldDeployData!.def, false, { chainId, timestamp: Date.now(), package: { version: '0.0.0' } })
+      : undefined);
 
   if (!def) {
     throw new Error('no deployment definition to build');
@@ -252,8 +256,8 @@ export async function build({
       yellowBright(
         `${'  '.repeat(d)}  \u26A0\uFE0F  Skipping [${n}] (${
           typeof err === 'object' && err.toString === Object.prototype.toString ? JSON.stringify(err) : err.toString()
-        })`
-      )
+        })`,
+      ),
     );
   });
   runtime.on(Events.Notice, (n, msg) => {
@@ -266,7 +270,7 @@ export async function build({
         log(
           `${'  '.repeat(d)}  ${green('\u2714')} Successfully called ${c.func}(${c?.args
             ?.map((arg: any) => (typeof arg === 'object' && arg !== null ? JSON.stringify(arg) : arg))
-            .join(', ')})`
+            .join(', ')})`,
         );
       } else {
         log(`${'  '.repeat(d)}  ${green('\u2714')} Successfully performed operation`);
@@ -286,9 +290,9 @@ export async function build({
       log(
         gray(
           `${'  '.repeat(d)}  Transaction Cost: ${viem.formatEther(
-            cost
-          )} ${nativeCurrencySymbol} (${txn.gasUsed.toLocaleString()} gas)`
-        )
+            cost,
+          )} ${nativeCurrencySymbol} (${txn.gasUsed.toLocaleString()} gas)`,
+        ),
       );
     }
     for (const contractKey in o.contracts) {
@@ -297,7 +301,7 @@ export async function build({
         log(
           `${'  '.repeat(d)}  ${green('\u2714')} Successfully deployed ${contract.contractName}${
             c.create2 ? ' using CREATE2' : ''
-          }`
+          }`,
         );
         log(gray(`${'  '.repeat(d)}  Contract Address: ${contract.address}`));
         log(gray(`${'  '.repeat(d)}  Transaction Hash: ${contract.deployTxnHash}`));
@@ -306,9 +310,9 @@ export async function build({
         log(
           gray(
             `${'  '.repeat(d)}  Transaction Cost: ${viem.formatEther(
-              cost
-            )} ${nativeCurrencySymbol} (${contract.gasUsed.toLocaleString()} gas)`
-          )
+              cost,
+            )} ${nativeCurrencySymbol} (${contract.gasUsed.toLocaleString()} gas)`,
+          ),
         );
       }
     }
@@ -325,10 +329,10 @@ export async function build({
   });
 
   runtime.on(Events.ResolveDeploy, (packageName, preset, chainId, registry, d) =>
-    log(magenta(`${'  '.repeat(d)}  Resolving ${packageName} (Chain ID: ${chainId}) via ${registry}...`))
+    log(magenta(`${'  '.repeat(d)}  Resolving ${packageName} (Chain ID: ${chainId}) via ${registry}...`)),
   );
   runtime.on(Events.DownloadDeploy, (hash, gateway, d) =>
-    log(gray(`${'  '.repeat(d)}    Downloading ${hash} via ${gateway}`))
+    log(gray(`${'  '.repeat(d)}    Downloading ${hash} via ${gateway}`)),
   );
 
   // attach control-c handler
@@ -374,7 +378,7 @@ export async function build({
     });
 
     const cliError = new Error(
-      `An error occured during build. A file with comprehensive information pertaining to this error has been written to ${dumpFilePath}. Please include this file when reporting an issue.`
+      `An error occured during build. A file with comprehensive information pertaining to this error has been written to ${dumpFilePath}. Please include this file when reporting an issue.`,
     );
 
     throw mergeErrors(cliError, buildErr);
@@ -437,9 +441,9 @@ export async function build({
             error(
               red(
                 bold(
-                  `Failed to write state on-chain. The next time you upgrade your package, you should include the option --upgrade-from ${deployUrl}.`
-                )
-              )
+                  `Failed to write state on-chain. The next time you upgrade your package, you should include the option --upgrade-from ${deployUrl}.`,
+                ),
+              ),
             );
           }
         }
@@ -457,14 +461,14 @@ export async function build({
       log(
         yellowBright(
           bold(
-            '\n\u26A0\uFE0F  Your deployment was not fully completed. Please inspect the issues listed above and resolve as necessary.'
-          )
-        )
+            '\n\u26A0\uFE0F  Your deployment was not fully completed. Please inspect the issues listed above and resolve as necessary.',
+          ),
+        ),
       );
       log(gray(`Total Cost: ${viem.formatEther(totalCost)} ${nativeCurrencySymbol}`));
       log('');
       log(
-        '- Rerunning the build command will attempt to execute skipped operations. It will not rerun executed operations. (To rerun executed operations, delete the partial build package generated by this run by adding the --wipe flag to the build command on the next run.)'
+        '- Rerunning the build command will attempt to execute skipped operations. It will not rerun executed operations. (To rerun executed operations, delete the partial build package generated by this run by adding the --wipe flag to the build command on the next run.)',
       );
       if (upgradeFrom) {
         log(bold('  Remove the --upgrade-from option to continue from the partial build.'));
@@ -473,7 +477,7 @@ export async function build({
       log(
         '- Run ' +
           bold(`cannon pin ${deployUrl}`) +
-          ' to pin the partial deployment package on IPFS. Then use https://usecannon.com/deploy to collect signatures from a Safe for the skipped operations in the partial deployment package.'
+          ' to pin the partial deployment package on IPFS. Then use https://usecannon.com/deploy to collect signatures from a Safe for the skipped operations in the partial deployment package.',
       );
     } else {
       if (dryRun) {
@@ -485,8 +489,8 @@ export async function build({
           bold(
             `Package data would be stored locally${
               filteredSettings.writeIpfsUrl && ' and pinned to ' + filteredSettings.writeIpfsUrl
-            }`
-          )
+            }`,
+          ),
         );
         log();
 
@@ -505,8 +509,8 @@ export async function build({
           bold(
             `Package data has been stored locally${
               filteredSettings.writeIpfsUrl && ' and pinned to ' + filteredSettings.writeIpfsUrl
-            }`
-          )
+            }`,
+          ),
         );
       }
       log(
@@ -514,7 +518,7 @@ export async function build({
           ['Deployment Data', deployUrl],
           ['Package Code', miscUrl],
           ['Metadata', metaUrl],
-        ])
+        ]),
       );
 
       const isMainPreset = preset === PackageReference.DEFAULT_PRESET;
@@ -523,15 +527,15 @@ export async function build({
         if (isMainPreset) {
           log(
             bold(
-              `Publish ${bold(`${packageRef}`)} to the registry and pin the IPFS data to ${filteredSettings.publishIpfsUrl}`
-            )
+              `Publish ${bold(`${packageRef}`)} to the registry and pin the IPFS data to ${filteredSettings.publishIpfsUrl}`,
+            ),
           );
           log(`> cannon publish ${packageRef} --chain-id ${chainId}`);
         } else {
           log(
             bold(
-              `Publish ${bold(fullPackageRef)} to the registry and pin the IPFS data to ${filteredSettings.publishIpfsUrl}`
-            )
+              `Publish ${bold(fullPackageRef)} to the registry and pin the IPFS data to ${filteredSettings.publishIpfsUrl}`,
+            ),
           );
           log(`> cannon publish ${fullPackageRef} --chain-id ${chainId}`);
         }
@@ -554,9 +558,9 @@ export async function build({
         yellow(
           `Chain state could not be saved via ${runtime.loaders[
             runtime.defaultLoaderScheme
-          ].getLabel()}. Try a writable endpoint by setting ipfsUrl through \`cannon setup\`.`
-        )
-      )
+          ].getLabel()}. Try a writable endpoint by setting ipfsUrl through \`cannon setup\`.`,
+        ),
+      ),
     );
   }
 

--- a/packages/cli/src/custom-steps/run.ts
+++ b/packages/cli/src/custom-steps/run.ts
@@ -4,11 +4,11 @@ import {
   ChainArtifacts,
   ChainBuilderContext,
   ChainBuilderRuntimeInfo,
-  computeTemplateAccesses,
   mergeTemplateAccesses,
   PackageState,
   registerAction,
   template,
+  TemplateContext,
 } from '@usecannon/builder';
 import crypto from 'crypto';
 import Debug from 'debug';
@@ -137,12 +137,12 @@ const runAction = {
     return config;
   },
 
-  getInputs(config: Config) {
-    let accesses = computeTemplateAccesses(config.exec);
+  getInputs(config: Config, templateContext: TemplateContext) {
+    let accesses = templateContext.computeAccesses(config.exec);
 
-    _.forEach(config.modified, (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(a))));
-    _.forEach(config.args, (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(a))));
-    _.forEach(config.env, (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(a))));
+    _.forEach(config.modified, (a) => (accesses = mergeTemplateAccesses(accesses, templateContext.computeAccesses(a))));
+    _.forEach(config.args, (a) => (accesses = mergeTemplateAccesses(accesses, templateContext.computeAccesses(a))));
+    _.forEach(config.env, (a) => (accesses = mergeTemplateAccesses(accesses, templateContext.computeAccesses(a))));
 
     return accesses;
   },

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -230,8 +230,12 @@ export async function loadCannonfile(filepath: string) {
   }
 
   // second argument ensures "sensitive" dependency verification--which ensures users are always specifying dependencies when they cant be reliably determined
-  const def = new ChainDefinition(rawDef, true);
   const pkg = loadPackageJson(path.join(path.dirname(path.resolve(filepath)), 'package.json'));
+  const def = new ChainDefinition(rawDef, true, {
+    chainId: CANNON_CHAIN_ID,
+    timestamp: Date.now(),
+    package: { version: pkg.version || '0.0.0' },
+  });
 
   // TODO: there should be a helper in the builder to create the initial ctx
   const ctx: ChainBuilderContext = {
@@ -264,7 +268,7 @@ export async function loadCannonfile(filepath: string) {
 async function loadChainDefinitionToml(filepath: string, trace: string[]): Promise<[Partial<RawChainDefinition>, Buffer]> {
   if (!fs.existsSync(filepath)) {
     throw new Error(
-      `Chain definition TOML '${filepath}' not found. Include trace:\n${trace.map((p) => ' => ' + p).join('\n')}`
+      `Chain definition TOML '${filepath}' not found. Include trace:\n${trace.map((p) => ' => ' + p).join('\n')}`,
     );
   }
 
@@ -335,11 +339,11 @@ export async function ensureChainIdConsistency(rpcUrl?: string, chainId?: number
         log(
           red(
             `Error: The chainId (${providerChainId}) obtained from the ${bold('--rpc-url')} does not match with ${bold(
-              '--chain-id'
+              '--chain-id',
             )} value (${chainId}). Please ensure that the ${bold(
-              '--chain-id'
-            )} value matches the network your RPC is connected to.`
-          )
+              '--chain-id',
+            )} value matches the network your RPC is connected to.`,
+          ),
         );
 
         process.exit(1);
@@ -453,7 +457,7 @@ export function checkAndNormalizePrivateKey(privateKey: string | viem.Hex | unde
   normalizedPrivateKeys.forEach((key: viem.Hex) => {
     if (!isPrivateKey(key)) {
       throw new Error(
-        'Invalid private key found. Please verify the CANNON_PRIVATE_KEY environment variable, review your settings file, or check the value supplied to the --private-key flag'
+        'Invalid private key found. Please verify the CANNON_PRIVATE_KEY environment variable, review your settings file, or check the value supplied to the --private-key flag',
       );
     }
   });
@@ -483,7 +487,7 @@ export async function getPackageReference(packageRef: string, givenChainId: any,
 export async function getPackageInfo(
   packageRef: string,
   givenChainId: any,
-  givenRpcUrl: string
+  givenRpcUrl: string,
 ): Promise<{ fullPackageRef: string; chainId: number }> {
   const ipfsUrl = getIpfsUrl(packageRef);
   const parsedChainId = Number(givenChainId) || undefined;

--- a/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
+++ b/packages/website/src/features/Deploy/TransactionDetailsPage.tsx
@@ -222,9 +222,11 @@ function TransactionDetailsPage() {
     const getChainDef = async () => {
       if (!cannonDefInfo.def) return;
 
-      chainDefinitionRef.current = await getChainDefinitionFromWorker(
-        cannonDefInfo.def
-      );
+      chainDefinitionRef.current = await getChainDefinitionFromWorker({
+        def: cannonDefInfo.def,
+        chainId,
+        timestamp: Date.now(),
+      });
     };
 
     void getChainDef();

--- a/packages/website/src/features/Packages/CannonfileExplorer.tsx
+++ b/packages/website/src/features/Packages/CannonfileExplorer.tsx
@@ -123,7 +123,7 @@ export const CannonfileExplorer: FC<{ pkg: ApiPackage }> = ({ pkg }) => {
                 className={`${displayMode === 1 ? 'block h-full' : 'hidden'} `}
               >
                 <div className="h-full">
-                  <CannonfileGraph deploymentDefinition={deploymentInfo.def} />
+                  <CannonfileGraph deployInfo={deploymentInfo} />
                 </div>
               </div>
 

--- a/packages/website/src/features/Packages/CannonfileGraph.tsx
+++ b/packages/website/src/features/Packages/CannonfileGraph.tsx
@@ -4,7 +4,7 @@ import * as d3 from 'd3';
 import { createGlobalStyle } from 'styled-components';
 import { useStepModalContext } from '@/providers/stepModalProvider';
 import { getChainDefinitionFromWorker } from '@/helpers/chain-definition';
-import { RawChainDefinition } from '@usecannon/builder';
+import { DeploymentInfo } from '@usecannon/builder';
 
 // Define global styles
 const GlobalStyles = createGlobalStyle`
@@ -47,8 +47,9 @@ interface ExtendedSimulationNodeDatum extends d3.SimulationNodeDatum {
 }
 
 export const CannonfileGraph: FC<{
-  deploymentDefinition: RawChainDefinition;
-}> = ({ deploymentDefinition }) => {
+  deployInfo: DeploymentInfo;
+}> = ({ deployInfo }) => {
+  const deploymentDefinition = deployInfo.def;
   const nodes: ExtendedSimulationNodeDatum[] = [];
   const links: d3.SimulationLinkDatum<ExtendedSimulationNodeDatum>[] = [];
 
@@ -59,7 +60,7 @@ export const CannonfileGraph: FC<{
     async function initializeGraph() {
       try {
         const { allActionNames, resolvedDependencies } =
-          await getChainDefinitionFromWorker(deploymentDefinition);
+          await getChainDefinitionFromWorker(deployInfo);
 
         // Clear existing nodes and links
         nodes.length = 0;

--- a/packages/website/src/features/Packages/PackageAccordionHelper/index.tsx
+++ b/packages/website/src/features/Packages/PackageAccordionHelper/index.tsx
@@ -63,9 +63,11 @@ export default function PackageAccordionHelper({
         const { ['run']: _, ...filteredDefinition } = deploymentData.data
           .def as any;
 
-        const chainDefinition = await getChainDefinitionFromWorker(
-          filteredDefinition
-        );
+        const chainDefinition = await getChainDefinitionFromWorker({
+          def: filteredDefinition,
+          chainId,
+          timestamp: Date.now(),
+        });
 
         setChainDefinition(chainDefinition);
       }

--- a/packages/website/src/helpers/chain-definition.ts
+++ b/packages/website/src/helpers/chain-definition.ts
@@ -1,6 +1,6 @@
-import { ChainDefinition, RawChainDefinition } from '@usecannon/builder';
+import { ChainDefinition, DeploymentInfo } from '@usecannon/builder';
 
-export const getChainDefinitionFromWorker = (deployInfo: RawChainDefinition) => {
+export const getChainDefinitionFromWorker = (deployInfo: Pick<DeploymentInfo, 'def' | 'chainId' | 'timestamp'>) => {
   return new Promise<ChainDefinition>((resolve, reject) => {
     const worker = new Worker(new URL('@/workers/chain-definition.worker.ts', import.meta.url));
 
@@ -8,7 +8,11 @@ export const getChainDefinitionFromWorker = (deployInfo: RawChainDefinition) => 
       if ('error' in event.data) {
         worker.terminate();
         // in case of error, fallback to non-worker execution
-        const def = new ChainDefinition(deployInfo);
+        const def = new ChainDefinition(deployInfo.def, false, {
+          chainId: deployInfo.chainId || 0,
+          timestamp: deployInfo.timestamp,
+          package: { version: '0.0.0' },
+        });
         def.initializeComputedDependencies();
         resolve(def);
       } else {

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -28,7 +28,6 @@ import {
   publishPackage,
   findUpgradeFromPackage,
   ChainBuilderContext,
-  RawChainDefinition,
   CannonRegistry,
   getIpfsUrl,
 } from '@usecannon/builder';
@@ -597,9 +596,9 @@ export function useMergedCannonDefInfo(gitInfo: CannonfileGitInfo, partialDeploy
         return null;
       }
 
-      const deployInfo = partialDeployInfo?.ipfsQuery.data?.deployInfo?.def || originalCannonDefInfo.def;
+      const deployInfo = partialDeployInfo?.ipfsQuery.data?.deployInfo || originalCannonDefInfo;
 
-      return await getChainDefinitionFromWorker(deployInfo as RawChainDefinition);
+      return await getChainDefinitionFromWorker(deployInfo as DeploymentInfo);
     },
     enabled: Boolean(partialDeployInfo?.ipfsQuery.data?.deployInfo || originalCannonDefInfo.def),
   });
@@ -644,7 +643,7 @@ export function useCannonPackageContracts(packageRef?: string, chainId?: number)
           { ipfs: loader }
         );
 
-        const chainDefinition = await getChainDefinitionFromWorker(info.def);
+        const chainDefinition = await getChainDefinitionFromWorker(info);
 
         const outputs = await getOutputs(readRuntime, chainDefinition, info.state);
 

--- a/packages/website/src/workers/chain-definition.worker.ts
+++ b/packages/website/src/workers/chain-definition.worker.ts
@@ -6,7 +6,11 @@ self.onmessage = (event) => {
       throw new Error('No chain definition data provided');
     }
 
-    const def = new ChainDefinition(event.data);
+    const def = new ChainDefinition(event.data.def, false, {
+      chainId: event.data.chainId,
+      timestamp: event.data.timestamp,
+      package: { version: '0.0.0.0' },
+    });
     if (!def) {
       throw new Error('Failed to create chain definition');
     }


### PR DESCRIPTION
or other globals

this basically turned into a refactor because we have to kind of rethink how we are supplying values to the ChainDefinition. But I think its a move in the right direction.

Unfortunately refactors like this usually lead to breakage, so probably best to save this for next release.