### PR TITLE
hotfix(builder): add preset length validation

### DIFF
--- a/packages/builder/jest.config.ts
+++ b/packages/builder/jest.config.ts
@@ -93,7 +93,7 @@ export default {
   // moduleNameMapper: {},
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-  // modulePathIgnorePatterns: [],
+  modulePathIgnorePatterns: ['/dist/'],
 
   // Activates notifications for test results
   // notify: false,

--- a/packages/builder/src/package-reference.ts
+++ b/packages/builder/src/package-reference.ts
@@ -10,8 +10,8 @@ interface PartialRefValues {
 export class PackageReference {
   static DEFAULT_TAG = 'latest';
   static DEFAULT_PRESET = 'main';
-  static PACKAGE_REGEX = /^(?<name>[a-z0-9][A-Za-z0-9-]{1,}[a-z0-9])(?::(?<version>[^@]+))?(@(?<preset>[^\s]+))?$/;
-
+  static PACKAGE_REGEX = /^(?<name>[a-z0-9][A-Za-z0-9-]{1,}[a-z0-9])(?::(?<version>[^@]+))?(@(?<preset>[^\s]{1,24}))?$/;
+  static VARIANT_REGEX = /^(?<chainId>\d+)-(?<preset>[^\s]{1,24})$/;
   /**
    * Anything before the colon or an @ (if no version is present) is the package name.
    */
@@ -67,7 +67,13 @@ export class PackageReference {
       throw new Error(`Package reference "${ref}" is too long. Package version exceeds 32 bytes`);
     }
 
-    if (match.groups.preset) res.preset = match.groups.preset;
+    if (match.groups.preset) {
+      res.preset = match.groups.preset;
+
+      if (res.preset.length > 22) {
+        throw new Error(`Package reference "${ref}" is too long. Package preset exceeds 22 bytes`);
+      }
+    }
 
     return res;
   }
@@ -93,8 +99,13 @@ export class PackageReference {
    * @returns chainId and preset
    */
   static parseVariant(variant: string): [number, string] {
-    const [chainId, preset] = variant.split(/-(.*)/s);
-    return [Number(chainId), preset];
+    const match = variant.match(PackageReference.VARIANT_REGEX);
+
+    if (!match || !match.groups?.chainId || !match.groups?.preset) {
+      throw new Error(`Invalid variant "${variant}". Should be of the format <chainId>-<preset>`);
+    }
+
+    return [Number(match.groups.chainId), match.groups.preset];
   }
 
   constructor(ref: string) {

--- a/packages/builder/src/package-reference.ts
+++ b/packages/builder/src/package-reference.ts
@@ -10,8 +10,8 @@ interface PartialRefValues {
 export class PackageReference {
   static DEFAULT_TAG = 'latest';
   static DEFAULT_PRESET = 'main';
-  static PACKAGE_REGEX = /^(?<name>[a-z0-9][A-Za-z0-9-]{1,}[a-z0-9])(?::(?<version>[^@]+))?(@(?<preset>[^\s]{1,24}))?$/;
-  static VARIANT_REGEX = /^(?<chainId>\d+)-(?<preset>[^\s]{1,24})$/;
+  static PACKAGE_REGEX = /^(?<name>[a-z0-9][A-Za-z0-9-]{1,}[a-z0-9])(?::(?<version>[^@]+))?(@(?<preset>[^\s]+))?$/;
+  static VARIANT_REGEX = /^(?<chainId>\d+)-(?<preset>[^\s]+)$/;
   /**
    * Anything before the colon or an @ (if no version is present) is the package name.
    */
@@ -55,23 +55,21 @@ export class PackageReference {
 
     const res: PartialRefValues = { name: match.groups.name };
 
-    const nameSize = res.name.length;
-    if (nameSize > 32) {
-      throw new Error(`Package reference "${ref}" is too long. Package name exceeds 32 bytes`);
+    if (res.name.length > 32) {
+      throw new Error(`Package name for "${ref}" is too long. Package name exceeds 32 characters`);
     }
 
-    if (match.groups.version) res.version = match.groups.version;
-
-    const versionSize = res.version?.length || 0;
-    if (versionSize > 32) {
-      throw new Error(`Package reference "${ref}" is too long. Package version exceeds 32 bytes`);
+    if (match.groups.version) {
+      res.version = match.groups.version;
+      if (res.version.length > 32) {
+        throw new Error(`Package version for "${ref}" is too long. Package version exceeds 32 characters`);
+      }
     }
 
     if (match.groups.preset) {
       res.preset = match.groups.preset;
-
-      if (res.preset.length > 22) {
-        throw new Error(`Package reference "${ref}" is too long. Package preset exceeds 22 bytes`);
+      if (res.preset.length > 24) {
+        throw new Error(`Package preset for "${ref}" is too long. Package preset exceeds 24 characters`);
       }
     }
 

--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -869,6 +869,12 @@ export const chainDefinitionSchema = z
       .refine((val) => !!val.match(RegExp(/[\w.]+/, 'gm')), {
         message: 'Preset cannot contain any special characters',
       })
+      .refine(
+        (val) => {
+          return new Blob([val]).size <= 22;
+        },
+        (val) => ({ message: `Package preset "${val}" is too long. Package preset exceeds 22 bytes` })
+      )
       .describe(
         'Preset of the package (Presets are useful for distinguishing multiple deployments of the same protocol on the same chain.) Defaults to "main".'
       )

--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -871,9 +871,9 @@ export const chainDefinitionSchema = z
       })
       .refine(
         (val) => {
-          return new Blob([val]).size <= 22;
+          return new Blob([val]).size <= 24;
         },
-        (val) => ({ message: `Package preset "${val}" is too long. Package preset exceeds 22 bytes` })
+        (val) => ({ message: `Package preset "${val}" is too long. Package preset exceeds 24 bytes` })
       )
       .describe(
         'Preset of the package (Presets are useful for distinguishing multiple deployments of the same protocol on the same chain.) Defaults to "main".'

--- a/packages/builder/src/steps/clone.test.ts
+++ b/packages/builder/src/steps/clone.test.ts
@@ -108,7 +108,7 @@ describe('steps/clone.ts', () => {
           { source: 'undefined-deployment:1.0.0' },
           { ref: new PackageReference('package:1.0.0'), currentLabel: 'clone.whatever' }
         )
-      ).rejects.toThrowError('deployment not found');
+      ).rejects.toThrow('deployment not found');
     });
 
     it('throws if source name is longer than 32 bytes', async () => {
@@ -119,7 +119,9 @@ describe('steps/clone.ts', () => {
           { source: 'package-name-longer-than-32bytes1337:1.0.0' },
           { ref: new PackageReference('package:1.0.0'), currentLabel: 'clone.whatever' }
         )
-      ).rejects.toThrowError('Package name exceeds 32 bytes');
+      ).rejects.toThrow(
+        'Package name for "package-name-longer-than-32bytes1337:1.0.0" is too long. Package name exceeds 32 characters'
+      );
     });
 
     it('throws if source version is longer than 32 bytes', async () => {
@@ -172,7 +174,9 @@ describe('steps/clone.ts', () => {
           { source: 'package:package-version-longer-than-32bytes1337' },
           { ref: new PackageReference('package:1.0.0'), currentLabel: 'clone.whatever' }
         )
-      ).rejects.toThrowError('Package version exceeds 32 bytes');
+      ).rejects.toThrow(
+        'Package version for "package:package-version-longer-than-32bytes1337" is too long. Package version exceeds 32 characters'
+      );
     });
 
     it('throws if target name is longer than 32 bytes', async () => {
@@ -183,7 +187,9 @@ describe('steps/clone.ts', () => {
           { source: 'package:1.0.0', target: 'package-name-longer-than-32bytes1337:1.0.0' },
           { ref: new PackageReference('package:1.0.0'), currentLabel: 'clone.whatever' }
         )
-      ).rejects.toThrowError('Package name exceeds 32 bytes');
+      ).rejects.toThrow(
+        'Package name for "package-name-longer-than-32bytes1337:1.0.0" is too long. Package name exceeds 32 characters'
+      );
     });
 
     it('throws if target version is longer than 32 bytes', async () => {
@@ -236,7 +242,9 @@ describe('steps/clone.ts', () => {
           { source: 'package:1.0.0', target: 'package:package-version-longer-than-32bytes1337' },
           { ref: new PackageReference('package:1.0.0'), currentLabel: 'clone.whatever' }
         )
-      ).rejects.toThrowError('Package version exceeds 32 bytes');
+      ).rejects.toThrow(
+        'Package version for "package:package-version-longer-than-32bytes1337" is too long. Package version exceeds 32 characters'
+      );
     });
 
     it('returns partial deployment if runtime becomes cancelled', async () => {

--- a/packages/builder/src/steps/pull.test.ts
+++ b/packages/builder/src/steps/pull.test.ts
@@ -123,7 +123,9 @@ describe('steps/pull.ts', () => {
           { source: 'package-name-longer-than-32bytes1337:1.0.0' },
           { ref: new PackageReference('package:1.0.0'), currentLabel: 'clone.whatever' }
         )
-      ).rejects.toThrowError('Package name exceeds 32 bytes');
+      ).rejects.toThrow(
+        'Package name for "package-name-longer-than-32bytes1337:1.0.0" is too long. Package name exceeds 32 characters'
+      );
     });
 
     it('throws if target version is longer than 32 bytes', async () => {
@@ -175,7 +177,9 @@ describe('steps/pull.ts', () => {
           { source: 'package:package-version-longer-than-32bytes1337' },
           { ref: new PackageReference('package:1.0.0'), currentLabel: 'pull.whatever' }
         )
-      ).rejects.toThrowError('Package version exceeds 32 bytes');
+      ).rejects.toThrow(
+        'Package version for "package:package-version-longer-than-32bytes1337" is too long. Package version exceeds 32 characters'
+      );
     });
 
     it('works properly', async () => {


### PR DESCRIPTION
Preset length was not being validated, this causes that when generating the variant for publishing to the registry it can end up being more than 32bytes. Luckily, this fix is not going to break any already published package as the current preset max length published is `24bytes`.

This is the original error that was being thrown when trying to pin/publish:
```
cannon pin ipfs://Qm...
Uploading package data for pinning...
Error: SizeOverflowError: Size cannot exceed 32 bytes. Given size: 36 bytes.

Version: viem@2.23.2
    at FallbackRegistry.getUrl (/Users/**/.nvm/versions/node/v20.10.0/lib/node_modules/@usecannon/cli/node_modules/@usecannon/builder/dist/src/registry.js:147:23)
    at async pinIpfs 
```

And now, with the fix it doesn't even allow you to build the package:
<img width="1293" alt="Screenshot 2025-02-19 at 22 50 51" src="https://github.com/user-attachments/assets/066288ac-4bc7-4cd9-9df9-ba1bbedc5262" />
