### PR TITLE
require `--impersonate` or `--impersonate-all` on dry run builds

### DIFF
--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -56,7 +56,8 @@ export const commandsConfig: CommandsConfig = {
       },
       {
         flags: '--impersonate <address>',
-        description: 'Impersonate all calls from the given signer instead of a real wallet. Only works with --fork',
+        description:
+          'Impersonate all calls from the given signer instead of a real wallet.',
         defaultValue: ANVIL_FIRST_ADDRESS,
       },
       {
@@ -113,7 +114,11 @@ export const commandsConfig: CommandsConfig = {
       },
       {
         flags: '--impersonate [addresses]',
-        description: 'Specify a comma separated list of signers to impersonate. Only works with --dry-run',
+        description: 'Specify a comma separated list of signers to impersonate. Useful to ensure only specified signers are required to complete a deployment. Only works with --dry-run Only works with --dry-run',
+      },
+      {
+        flags: '--impersonate-all',
+        description: 'Impersonate all calls from all required wallets. Only works with --dry-run',
       },
       {
         flags: '--keep-alive',

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -56,8 +56,7 @@ export const commandsConfig: CommandsConfig = {
       },
       {
         flags: '--impersonate <address>',
-        description:
-          'Impersonate all calls from the given signer instead of a real wallet.',
+        description: 'Impersonate all calls from the given signer instead of a real wallet.',
         defaultValue: ANVIL_FIRST_ADDRESS,
       },
       {
@@ -114,7 +113,8 @@ export const commandsConfig: CommandsConfig = {
       },
       {
         flags: '--impersonate [addresses]',
-        description: 'Specify a comma separated list of signers to impersonate. Useful to ensure only specified signers are required to complete a deployment. Only works with --dry-run Only works with --dry-run',
+        description:
+          'Specify a comma separated list of signers to impersonate. Useful to ensure only specified signers are required to complete a deployment. Only works with --dry-run Only works with --dry-run',
       },
       {
         flags: '--impersonate-all',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -101,7 +101,7 @@ function configureRun(program: Command) {
   return applyCommandsConfig(program, commandsConfig.run).action(async function (
     packages: PackageSpecification[],
     options,
-    program,
+    program
   ) {
     log(bold('Starting local node...\n'));
 
@@ -267,67 +267,74 @@ applyCommandsConfig(program.command('verify'), commandsConfig.verify).action(asy
   await verify(fullPackageRef, cliSettings, chainId);
 });
 
-applyCommandsConfig(program.command('diff'), commandsConfig.diff).action(
-  async function (packageRef, projectDirectory, options) {
-    const { diff } = await import('./commands/diff');
+applyCommandsConfig(program.command('diff'), commandsConfig.diff).action(async function (
+  packageRef,
+  projectDirectory,
+  options
+) {
+  const { diff } = await import('./commands/diff');
 
-    const cliSettings = resolveCliSettings(options);
-    const { fullPackageRef, chainId } = await getPackageInfo(packageRef, options.chainId, cliSettings.rpcUrl);
+  const cliSettings = resolveCliSettings(options);
+  const { fullPackageRef, chainId } = await getPackageInfo(packageRef, options.chainId, cliSettings.rpcUrl);
 
-    const foundDiffs = await diff(
-      fullPackageRef,
-      cliSettings,
-      chainId,
-      projectDirectory,
-      options.matchContract,
-      options.matchSource,
-    );
+  const foundDiffs = await diff(
+    fullPackageRef,
+    cliSettings,
+    chainId,
+    projectDirectory,
+    options.matchContract,
+    options.matchSource
+  );
 
-    // exit code is the number of differences found--useful for CI checks
-    process.exit(foundDiffs);
-  },
-);
+  // exit code is the number of differences found--useful for CI checks
+  process.exit(foundDiffs);
+});
 
-applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(
-  async function (packageName, command, options, flags) {
-    const { alter } = await import('./commands/alter');
+applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(async function (
+  packageName,
+  command,
+  options,
+  flags
+) {
+  const { alter } = await import('./commands/alter');
 
-    const cliSettings = resolveCliSettings(flags);
+  const cliSettings = resolveCliSettings(flags);
 
-    // throw an error if the chainId is not consistent with the provider's chainId
-    await ensureChainIdConsistency(cliSettings.rpcUrl, flags.chainId);
+  // throw an error if the chainId is not consistent with the provider's chainId
+  await ensureChainIdConsistency(cliSettings.rpcUrl, flags.chainId);
 
-    // note: for command below, pkgInfo is empty because forge currently supplies no package.json or anything similar
-    const newUrl = await alter(
-      packageName,
-      flags.subpkg ? flags.subpkg.split(',') : [],
-      parseInt(flags.chainId),
-      cliSettings,
-      {},
-      command,
-      options,
-      {},
-    );
+  // note: for command below, pkgInfo is empty because forge currently supplies no package.json or anything similar
+  const newUrl = await alter(
+    packageName,
+    flags.subpkg ? flags.subpkg.split(',') : [],
+    parseInt(flags.chainId),
+    cliSettings,
+    {},
+    command,
+    options,
+    {}
+  );
 
-    log(newUrl);
-  },
-);
+  log(newUrl);
+});
 
-applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(
-  async function (packageRef, givenIpfsUrl, options) {
-    const { fetch } = await import('./commands/fetch');
+applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(async function (
+  packageRef,
+  givenIpfsUrl,
+  options
+) {
+  const { fetch } = await import('./commands/fetch');
 
-    const { fullPackageRef, chainId } = await getPackageReference(packageRef, options.chainId);
-    const ipfsUrl = getIpfsUrl(givenIpfsUrl);
-    const metaIpfsUrl = getIpfsUrl(options.metaHash) || undefined;
+  const { fullPackageRef, chainId } = await getPackageReference(packageRef, options.chainId);
+  const ipfsUrl = getIpfsUrl(givenIpfsUrl);
+  const metaIpfsUrl = getIpfsUrl(options.metaHash) || undefined;
 
-    if (!ipfsUrl) {
-      throw new Error('IPFS URL is required.');
-    }
+  if (!ipfsUrl) {
+    throw new Error('IPFS URL is required.');
+  }
 
-    await fetch(fullPackageRef, chainId, ipfsUrl, metaIpfsUrl);
-  },
-);
+  await fetch(fullPackageRef, chainId, ipfsUrl, metaIpfsUrl);
+});
 
 applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async function (packageRef, options) {
   const cliSettings = resolveCliSettings(options);
@@ -353,7 +360,7 @@ applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async fun
 
 applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(async function (
   packageRef,
-  options: { [opt: string]: string },
+  options: { [opt: string]: string }
 ) {
   const { publish } = await import('./commands/publish');
 
@@ -430,8 +437,8 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
     log();
     log(
       gray(
-        `Package "${pkgRef.name}" not yet registered, please use "cannon register" to register your package first.\nYou need enough gas on Ethereum Mainnet to register the package on Cannon Registry`,
-      ),
+        `Package "${pkgRef.name}" not yet registered, please use "cannon register" to register your package first.\nYou need enough gas on Ethereum Mainnet to register the package on Cannon Registry`
+      )
     );
     log();
 
@@ -484,7 +491,7 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
     }\n - Max Priority Fee Per Gas: ${
       overrides.maxPriorityFeePerGas ? overrides.maxPriorityFeePerGas.toString() : 'default'
     }\n - Gas Limit: ${overrides.gasLimit ? overrides.gasLimit : 'default'}\n` +
-      " - To alter these settings use the parameters '--max-fee-per-gas', '--max-priority-fee-per-gas', '--gas-limit'.\n",
+      " - To alter these settings use the parameters '--max-fee-per-gas', '--max-priority-fee-per-gas', '--gas-limit'.\n"
   );
 
   await publish({
@@ -531,7 +538,7 @@ applyCommandsConfig(program.command('inspect'), commandsConfig.inspect).action(a
   const { fullPackageRef, chainId, ipfsUrl, deployInfo } = await getPackageInfo(
     packageRef,
     options.chainId,
-    cliSettings.rpcUrl,
+    cliSettings.rpcUrl
   );
 
   await inspect(
@@ -542,7 +549,7 @@ applyCommandsConfig(program.command('inspect'), commandsConfig.inspect).action(a
     cliSettings,
     options.json ? 'deploy-json' : options.out,
     options.writeDeployments,
-    options.sources,
+    options.sources
   );
 });
 
@@ -563,7 +570,7 @@ applyCommandsConfig(program.command('prune'), commandsConfig.prune).action(async
     storage,
     options.filterPackage?.split(',') || '',
     options.filterVariant?.split(',') || '',
-    options.keepAge,
+    options.keepAge
   );
 
   if (pruneUrls.length) {
@@ -650,9 +657,9 @@ applyCommandsConfig(program.command('test'), commandsConfig.test).action(async f
     warn(
       yellowBright(
         bold(
-          '⚠️  The `--` syntax for passing options to forge or anvil is deprecated. Please use `--forge.*` or `--anvil.*` instead.',
-        ),
-      ),
+          '⚠️  The `--` syntax for passing options to forge or anvil is deprecated. Please use `--forge.*` or `--anvil.*` instead.'
+        )
+      )
     );
     log();
   }
@@ -717,14 +724,14 @@ applyCommandsConfig(program.command('interact'), commandsConfig.interact).action
       priorityGasFee: options.maxPriorityFee,
     },
     resolver,
-    getMainLoader(cliSettings),
+    getMainLoader(cliSettings)
   );
 
   const deployData = await runtime.readDeploy(fullPackageRef, runtime.chainId);
 
   if (!deployData) {
     throw new Error(
-      `deployment not found for package: ${fullPackageRef} with chaindId ${chainId}. please make sure it exists for the given preset and current network.`,
+      `deployment not found for package: ${fullPackageRef} with chaindId ${chainId}. please make sure it exists for the given preset and current network.`
     );
   }
 
@@ -732,7 +739,7 @@ applyCommandsConfig(program.command('interact'), commandsConfig.interact).action
 
   if (!outputs) {
     throw new Error(
-      `no cannon build found for ${fullPackageRef} with chaindId ${chainId}. Did you mean to run the package instead?`,
+      `no cannon build found for ${fullPackageRef} with chaindId ${chainId}. Did you mean to run the package instead?`
     );
   }
 


### PR DESCRIPTION
its an extremely common error that unexpected signers are needed to complete a deployment, so this will ensure that a user has to be explicit about which signers should be required.

this is a breaking change, of course. Roll it in with all the others coming out in the next release.

TODO: do we need to check if `--private-key` is provided also? if it is then it could be treated as an implicit `--impersonate`