### PR TITLE
fix(website): safe tx progress

### DIFF
--- a/packages/website/src/features/Deploy/TransactionStepper.tsx
+++ b/packages/website/src/features/Deploy/TransactionStepper.tsx
@@ -105,9 +105,6 @@ export function TransactionStepper(props: {
       }`
     : undefined;
 
-  // if (transactionHash || packagePublished) {
-  //   debugger;
-  // }
   let activeStep = 1;
   if (packagePublished && transactionHash) {
     activeStep = 5;


### PR DESCRIPTION
Fix the condition that derives the safe-tx state. 

If the new tx tries to deploy a package version that already exists it now also checks for both, `packagePublished` & `transactionHash` to determine if the tx is completed.