### PR TITLE
fix(website): fix clipboard button position

### DIFF
--- a/packages/website/src/components/AbiParameterPreview/index.tsx
+++ b/packages/website/src/components/AbiParameterPreview/index.tsx
@@ -93,7 +93,7 @@ export function AbiParameterPreview({
             <EncodedValueInput value={parsedValue} />
           )}
 
-          <div className="absolute right-0 top-1">
+          <div className="absolute right-2 top-1">
             {explorerUrl && <ExternalLinkButton href={explorerUrl} />}
             <ClipboardButton text={rawValue as string} />
           </div>

--- a/packages/website/src/features/Search/PackageCard/DataTable.tsx
+++ b/packages/website/src/features/Search/PackageCard/DataTable.tsx
@@ -27,6 +27,7 @@ import Chain from './Chain';
 import { format, formatDistanceToNow } from 'date-fns';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import ClipboardButton from '@/components/ClipboardButton';
 
 export type DataTableProps<Data extends object> = {
   data: Data[];
@@ -70,6 +71,10 @@ const getCellContent = ({ cell }: { cell: any }) => {
       return (
         <code className="text-xs translate-y-[1px]">
           {formatIPFS(cell.row.original.deployUrl, 10)}
+          <ClipboardButton
+            text={cell.row.original.deployUrl}
+            className="ml-3 z-10 relative"
+          />
         </code>
       );
     }


### PR DESCRIPTION
Fixed [CAN-737](https://linear.app/usecannon/issue/CAN-737/add-some-marginpadding-to-the-right-of-the-copy-button-here-to-match) and [CAN-489](https://linear.app/usecannon/issue/CAN-489/add-a-copy-button-to-the-ipfs-hash-in-the-packages-table)
- Adjust its position in interact page.
- Add the clipboard button on the package page.

[CAN-737](https://linear.app/usecannon/issue/CAN-737/add-some-marginpadding-to-the-right-of-the-copy-button-here-to-match)
![Screenshot 2025-04-21 at 15 51 57](https://github.com/user-attachments/assets/1c01422c-e211-4749-9273-32c9e6a62b28)

[CAN-489](https://linear.app/usecannon/issue/CAN-489/add-a-copy-button-to-the-ipfs-hash-in-the-packages-table)
![Screenshot 2025-04-21 at 15 52 18](https://github.com/user-attachments/assets/4940bb8e-a1cc-4743-bb41-1c5d6255c818)
