### PR TITLE
fix crash on is highlighted

### DIFF
--- a/packages/cli/src/commands/interact.ts
+++ b/packages/cli/src/commands/interact.ts
@@ -190,7 +190,7 @@ async function pickContract({
   contractNames: string[];
   contractArtifacts?: ContractMap;
 }) {
-  const isHighlighted = (n: string) => !!contractArtifacts?.[n].highlight;
+  const isHighlighted = (n: string) => !!contractArtifacts?.[n]?.highlight;
 
   const choices: Choice[] = _.sortBy(contractNames, [
     (contractName) => !isHighlighted(contractName),


### PR DESCRIPTION
the `highlighted` property is no longer guarenteed to be seen on a contract artifact, so adding a question mark ensures that case is properly handled