### PR TITLE
prevent browser from pushing path to history when

### DIFF
--- a/packages/website/src/features/Deploy/SafeAddressInput.tsx
+++ b/packages/website/src/features/Deploy/SafeAddressInput.tsx
@@ -73,7 +73,7 @@ export function SafeAddressInput() {
     if (safeString == '') {
       setIsClearing(true);
       setCurrentSafe(null);
-      await router.push({
+      await router.replace({
         pathname: router.pathname,
         query: omit(router.query, ['chainId', 'address']),
       });
@@ -90,7 +90,7 @@ export function SafeAddressInput() {
       return;
     }
 
-    await router.push({
+    await router.replace({
       pathname: router.pathname,
       query: {
         ...router.query,
@@ -115,7 +115,7 @@ export function SafeAddressInput() {
     ) {
       setIsClearing(true);
       void router
-        .push({
+        .replace({
           pathname: '/deploy',
           query: {},
         })


### PR DESCRIPTION
use `replace` instaed.

not using this makes it difficult/impossible to use the back button to go back.

https://linear.app/usecannon/issue/CAN-679/infinex-requests