### PR TITLE
add field to get current deployer from inside cannon context

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "packages/cli/test/e2e/helpers/bats-file"]
 	path = packages/cli/test/e2e/helpers/bats-file
 	url = https://github.com/bats-core/bats-file.git
+[submodule "examples/test/lib/forge-std"]
+	path = examples/test/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/examples/sample-foundry-project/cannonfile.toml
+++ b/examples/sample-foundry-project/cannonfile.toml
@@ -15,6 +15,6 @@ value = "2929372"
 
 [deploy.greeter]
 artifact = "Greeter"
-args = ["<%= settings.msg %>! call from signer <%= deployer %>"]
+args = ["<%= settings.msg %>! call from signer <%= defaultSigner %>"]
 libraries.Library = "<%= contracts.library.address %>"
 salt = "<%= settings.salt %>"

--- a/examples/sample-foundry-project/cannonfile.toml
+++ b/examples/sample-foundry-project/cannonfile.toml
@@ -15,6 +15,6 @@ value = "2929372"
 
 [deploy.greeter]
 artifact = "Greeter"
-args = ["<%= settings.msg %>"]
+args = ["<%= settings.msg %>! call from signer <%= deployer %>"]
 libraries.Library = "<%= contracts.library.address %>"
 salt = "<%= settings.salt %>"

--- a/packages/builder/src/access-recorder.ts
+++ b/packages/builder/src/access-recorder.ts
@@ -75,6 +75,7 @@ function setupTemplateContext(possibleNames: string[] = []): TemplateContext {
     // Include base context variables, no access recording as they are always available
     chainId: 0,
     timestamp: 0,
+    deployer: viem.zeroAddress,
     package: { version: '0.0.0' },
     ...fakeHelperContext,
 

--- a/packages/builder/src/access-recorder.ts
+++ b/packages/builder/src/access-recorder.ts
@@ -75,7 +75,7 @@ function setupTemplateContext(possibleNames: string[] = []): TemplateContext {
     // Include base context variables, no access recording as they are always available
     chainId: 0,
     timestamp: 0,
-    deployer: viem.zeroAddress,
+    defaultSigner: viem.zeroAddress,
     package: { version: '0.0.0' },
     ...fakeHelperContext,
 

--- a/packages/builder/src/builder.test.ts
+++ b/packages/builder/src/builder.test.ts
@@ -314,7 +314,13 @@ describe('builder.ts', () => {
   describe('createInitialContext()', () => {
     it('assembles correctly', async () => {
       const pkg = { foo: 'bard' };
-      const ctx = await createInitialContext(new ChainDefinition(fakeDefinition), pkg, 5, { baz: 'boop' });
+      const ctx = await createInitialContext(
+        new ChainDefinition(fakeDefinition),
+        pkg,
+        5,
+        { baz: 'boop' },
+        '0x0987098709870987098709870987098709870987'
+      );
 
       expect(ctx.chainId).toBe(5);
       expect(ctx.package).toBe(pkg);
@@ -324,6 +330,7 @@ describe('builder.ts', () => {
       expect(ctx.txns).toStrictEqual({});
       expect(ctx.imports).toStrictEqual({});
       expect(ctx.settings).toStrictEqual({ baz: 'boop' });
+      expect(ctx.deployer).toEqual('0x0987098709870987098709870987098709870987');
     });
   });
 });

--- a/packages/builder/src/builder.test.ts
+++ b/packages/builder/src/builder.test.ts
@@ -330,7 +330,7 @@ describe('builder.ts', () => {
       expect(ctx.txns).toStrictEqual({});
       expect(ctx.imports).toStrictEqual({});
       expect(ctx.settings).toStrictEqual({ baz: 'boop' });
-      expect(ctx.deployer).toEqual('0x0987098709870987098709870987098709870987');
+      expect(ctx.defaultSigner).toEqual('0x0987098709870987098709870987098709870987');
     });
   });
 });

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -27,7 +27,7 @@ export async function createInitialContext(
     package: pkg,
     timestamp: Math.floor(Date.now() / 1000),
     chainId,
-    deployer: viem.zeroAddress,
+    deployer: defaultSigner,
     overrideSettings: opts,
   };
 

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -27,7 +27,7 @@ export async function createInitialContext(
     package: pkg,
     timestamp: Math.floor(Date.now() / 1000),
     chainId,
-    deployer: defaultSigner,
+    defaultSigner,
     overrideSettings: opts,
   };
 

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -20,12 +20,14 @@ export async function createInitialContext(
   def: ChainDefinition,
   pkg: any,
   chainId: number,
-  opts: BuildOptions
+  opts: BuildOptions,
+  defaultSigner: viem.Address = viem.zeroAddress
 ): Promise<ChainBuilderContext> {
   const preCtx: PreChainBuilderContext = {
     package: pkg,
     timestamp: Math.floor(Date.now() / 1000),
     chainId,
+    deployer: viem.zeroAddress,
     overrideSettings: opts,
   };
 

--- a/packages/builder/src/steps/clone.ts
+++ b/packages/builder/src/steps/clone.ts
@@ -185,7 +185,7 @@ const cloneSpec = {
     }
 
     // TODO: needs npm package from the manifest
-    const initialCtx = await createInitialContext(def, deployInfo.meta, runtime.chainId, importPkgOptions, ctx.deployer);
+    const initialCtx = await createInitialContext(def, deployInfo.meta, runtime.chainId, importPkgOptions, ctx.defaultSigner);
 
     // use separate runtime to ensure everything is clear
     // we override `getArtifact` to use a simple loader from the upstream misc data to ensure that any contract upgrades are captured as expected

--- a/packages/builder/src/steps/clone.ts
+++ b/packages/builder/src/steps/clone.ts
@@ -185,7 +185,13 @@ const cloneSpec = {
     }
 
     // TODO: needs npm package from the manifest
-    const initialCtx = await createInitialContext(def, deployInfo.meta, runtime.chainId, importPkgOptions, ctx.defaultSigner);
+    const initialCtx = await createInitialContext(
+      def,
+      deployInfo.meta,
+      runtime.chainId,
+      importPkgOptions,
+      ctx.defaultSigner
+    );
 
     // use separate runtime to ensure everything is clear
     // we override `getArtifact` to use a simple loader from the upstream misc data to ensure that any contract upgrades are captured as expected

--- a/packages/builder/src/steps/clone.ts
+++ b/packages/builder/src/steps/clone.ts
@@ -185,7 +185,7 @@ const cloneSpec = {
     }
 
     // TODO: needs npm package from the manifest
-    const initialCtx = await createInitialContext(def, deployInfo.meta, runtime.chainId, importPkgOptions);
+    const initialCtx = await createInitialContext(def, deployInfo.meta, runtime.chainId, importPkgOptions, ctx.deployer);
 
     // use separate runtime to ensure everything is clear
     // we override `getArtifact` to use a simple loader from the upstream misc data to ensure that any contract upgrades are captured as expected

--- a/packages/builder/src/types.test.ts
+++ b/packages/builder/src/types.test.ts
@@ -19,7 +19,7 @@ describe('types.ts', () => {
         {
           timestamp: 0,
           chainId: 0,
-          deployer: viem.zeroAddress,
+          defaultSigner: viem.zeroAddress,
           package: {},
           overrideSettings: {
             foo: 'bar',
@@ -66,7 +66,7 @@ describe('types.ts', () => {
         {
           timestamp: 0,
           chainId: 0,
-          deployer: viem.zeroAddress,
+          defaultSigner: viem.zeroAddress,
           package: {},
           overrideSettings: {},
           contracts: {},
@@ -79,7 +79,7 @@ describe('types.ts', () => {
         {
           timestamp: 0,
           chainId: 0,
-          deployer: viem.zeroAddress,
+          defaultSigner: viem.zeroAddress,
           package: {},
           overrideSettings: {},
           contracts: {

--- a/packages/builder/src/types.test.ts
+++ b/packages/builder/src/types.test.ts
@@ -19,6 +19,7 @@ describe('types.ts', () => {
         {
           timestamp: 0,
           chainId: 0,
+          deployer: viem.zeroAddress,
           package: {},
           overrideSettings: {
             foo: 'bar',
@@ -65,6 +66,7 @@ describe('types.ts', () => {
         {
           timestamp: 0,
           chainId: 0,
+          deployer: viem.zeroAddress,
           package: {},
           overrideSettings: {},
           contracts: {},
@@ -77,6 +79,7 @@ describe('types.ts', () => {
         {
           timestamp: 0,
           chainId: 0,
+          deployer: viem.zeroAddress,
           package: {},
           overrideSettings: {},
           contracts: {

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -78,6 +78,8 @@ export interface PreChainBuilderContext {
 
   timestamp: number;
 
+  deployer: viem.Address;
+
   overrideSettings: { [label: string]: string };
 }
 

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -78,7 +78,7 @@ export interface PreChainBuilderContext {
 
   timestamp: number;
 
-  deployer: viem.Address;
+  defaultSigner: viem.Address;
 
   overrideSettings: { [label: string]: string };
 }

--- a/packages/builder/src/util.test.ts
+++ b/packages/builder/src/util.test.ts
@@ -141,6 +141,7 @@ describe('util.ts', () => {
     txns: {},
     chainId: 0,
     timestamp: 0,
+    deployer: viem.zeroAddress,
     package: {},
   };
 

--- a/packages/builder/src/util.test.ts
+++ b/packages/builder/src/util.test.ts
@@ -141,7 +141,7 @@ describe('util.ts', () => {
     txns: {},
     chainId: 0,
     timestamp: 0,
-    deployer: viem.zeroAddress,
+    defaultSigner: viem.zeroAddress,
     package: {},
   };
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -189,7 +189,13 @@ export async function build({
     throw new Error('no deployment definition to build');
   }
 
-  const initialCtx = await createInitialContext(def, pkgInfo, chainId, resolvedSettings);
+  const initialCtx = await createInitialContext(
+    def,
+    pkgInfo,
+    chainId,
+    resolvedSettings,
+    getDefaultSigner ? (await getDefaultSigner()).address : viem.zeroAddress
+  );
 
   const pkgName = name || def.getName(initialCtx);
   const pkgVersion = version || def.getVersion(initialCtx);

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -239,7 +239,7 @@ export async function loadCannonfile(filepath: string) {
     chainId: CANNON_CHAIN_ID,
     settings: {},
     timestamp: 0,
-    deployer: viem.zeroAddress,
+    defaultSigner: viem.zeroAddress,
 
     contracts: {},
     txns: {},

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -239,6 +239,7 @@ export async function loadCannonfile(filepath: string) {
     chainId: CANNON_CHAIN_ID,
     settings: {},
     timestamp: 0,
+    deployer: viem.zeroAddress,
 
     contracts: {},
     txns: {},

--- a/packages/website/src/features/Deploy/hooks/useCannonPackage.ts
+++ b/packages/website/src/features/Deploy/hooks/useCannonPackage.ts
@@ -1,3 +1,4 @@
+import { zeroAddress } from 'viem';
 import {
   useCannonPackage as useFetchCannonPackage,
   useMergedCannonDefInfo,
@@ -9,6 +10,7 @@ import { ChainBuilderContext, getIpfsUrl, PackageReference } from '@usecannon/bu
 // TODO: is there any way to make a better context? maybe this means we should get rid of name using context?
 const ctx: ChainBuilderContext = {
   chainId: 0,
+  deployer: zeroAddress,
   package: {},
   timestamp: 0 as any, // TODO: fix this
   settings: {},

--- a/packages/website/src/features/Deploy/hooks/useCannonPackage.ts
+++ b/packages/website/src/features/Deploy/hooks/useCannonPackage.ts
@@ -25,7 +25,7 @@ function getCannonPackageError(
   cannonDefInfo: ReturnType<typeof useMergedCannonDefInfo>,
   partialDeployInfo: ReturnType<typeof useFetchCannonPackage>,
   prevCannonDeployInfo: ReturnType<typeof useFetchCannonPackage>,
-  hasDeployers: boolean,
+  hasDeployers: boolean
 ): {
   message: string;
   type: 'definition' | 'partialDeploy' | 'prevDeploy';
@@ -150,7 +150,7 @@ export function useCannonPackage({
     currentPackageReference,
     chainId,
     cannonDefInfo?.def?.getDeployers(),
-    prevPackageReference,
+    prevPackageReference
   );
 
   const prevDeployLocation = onChainPrevPkgQuery.data || '';
@@ -165,7 +165,7 @@ export function useCannonPackage({
   // Check if the cannonfile requires a previous package
   const requiresPrevPackage = Boolean(
     !hasDeployers &&
-      cannonDefInfo.def?.allActionNames.some((item) => item.startsWith('deploy.') || item.startsWith('contract.')),
+      cannonDefInfo.def?.allActionNames.some((item) => item.startsWith('deploy.') || item.startsWith('contract.'))
   );
 
   const isLoading =

--- a/packages/website/src/features/Deploy/hooks/useCannonPackage.ts
+++ b/packages/website/src/features/Deploy/hooks/useCannonPackage.ts
@@ -10,7 +10,7 @@ import { ChainBuilderContext, getIpfsUrl, PackageReference } from '@usecannon/bu
 // TODO: is there any way to make a better context? maybe this means we should get rid of name using context?
 const ctx: ChainBuilderContext = {
   chainId: 0,
-  deployer: zeroAddress,
+  defaultSigner: zeroAddress,
   package: {},
   timestamp: 0 as any, // TODO: fix this
   settings: {},
@@ -25,7 +25,7 @@ function getCannonPackageError(
   cannonDefInfo: ReturnType<typeof useMergedCannonDefInfo>,
   partialDeployInfo: ReturnType<typeof useFetchCannonPackage>,
   prevCannonDeployInfo: ReturnType<typeof useFetchCannonPackage>,
-  hasDeployers: boolean
+  hasDeployers: boolean,
 ): {
   message: string;
   type: 'definition' | 'partialDeploy' | 'prevDeploy';
@@ -150,7 +150,7 @@ export function useCannonPackage({
     currentPackageReference,
     chainId,
     cannonDefInfo?.def?.getDeployers(),
-    prevPackageReference
+    prevPackageReference,
   );
 
   const prevDeployLocation = onChainPrevPkgQuery.data || '';
@@ -165,7 +165,7 @@ export function useCannonPackage({
   // Check if the cannonfile requires a previous package
   const requiresPrevPackage = Boolean(
     !hasDeployers &&
-      cannonDefInfo.def?.allActionNames.some((item) => item.startsWith('deploy.') || item.startsWith('contract.'))
+      cannonDefInfo.def?.allActionNames.some((item) => item.startsWith('deploy.') || item.startsWith('contract.')),
   );
 
   const isLoading =

--- a/packages/website/src/hooks/cannon.ts
+++ b/packages/website/src/hooks/cannon.ts
@@ -273,7 +273,13 @@ export function useCannonBuild(safe: SafeDefinition | null) {
       await currentRuntime.restoreMisc(prevDeploy.miscUrl);
     }
 
-    const ctx = await createInitialContext(def, prevDeploy?.meta || {}, safe.chainId, prevDeploy?.options || {});
+    const ctx = await createInitialContext(
+      def,
+      prevDeploy?.meta || {},
+      safe.chainId,
+      prevDeploy?.options || {},
+      safe.address
+    );
 
     const newState = await cannonBuild(currentRuntime, def, _.cloneDeep(prevDeploy?.state) ?? {}, ctx);
 


### PR DESCRIPTION
should return the signer that will be used if `getDefaultSigner()` is called. Note that this default signer can implicitly be a different signer depending on the txn, so there is no 100% way to reconcile this, but many times, its the same signer no matter the txn (unless explicitly defined otherwise).

if a static deployer is available, it will be supplied as `<%= deployer %>`.

if a static deployer is not available, it is set to undefined.

a bit of research/testing has to be done to determine the consistency of using this field, because, similar to `timestamp`, it can cause cannon package build to be undeterministic/unstable