### PR TITLE
fix: CAN-747

### DIFF
--- a/packages/website/src/features/Packages/interact/useActiveContract.ts
+++ b/packages/website/src/features/Packages/interact/useActiveContract.ts
@@ -5,10 +5,15 @@ import { useRouter } from 'next/router';
  */
 export function useActiveContract() {
   const pathName = useRouter().asPath;
-  const activeContractPath = pathName.split('#')[0].split('interact/')[1];
+  const withoutMethodSelector = pathName.split('#')[0];
+  const selectedContractInfo = withoutMethodSelector.split('interact/')[1];
 
-  if (activeContractPath) {
-    const [moduleName, contractName, contractAddress] = activeContractPath.split('/');
+  if (selectedContractInfo) {
+    const [moduleName, contractName, contractAddress] = selectedContractInfo.split('/');
+
+    if (!moduleName || !contractName || !contractAddress) {
+      return undefined;
+    }
 
     return {
       moduleName,


### PR DESCRIPTION
Some packages were not loading the interact tab due to a wrong return type in the useActiveContracts hook.

This hook is supposed to return the active contract to render if the conditions are met, or undefined otherwise. However, it was returning a partially filled object with only the moduleName set but with the contract name and address as undefiend