### PR TITLE
fix(cli): use etherscan api v2

### DIFF
--- a/packages/cli/src/util/verify.ts
+++ b/packages/cli/src/util/verify.ts
@@ -37,9 +37,10 @@ export type EtherscanGetSourceCodeResponse = EtherscanGetSourceCodeNotOkResponse
  * @returns True if the contract is verified, false otherwise.
  */
 
-export async function isVerified(address: string, apiUrl: string, apiKey: string): Promise<boolean> {
+export async function isVerified(address: string, apiUrl: string, apiKey: string, chainId: number): Promise<boolean> {
   const parameters = new URLSearchParams({
     apikey: apiKey,
+    chainid: chainId.toString(),
     module: 'contract',
     action: 'getsourcecode',
     address,


### PR DESCRIPTION
does the migration to etherscan api v2. Docs on how this works here: https://docs.etherscan.io/etherscan-v2/v2-quickstart#if-youre-coming-from-another-explorer-basescan-arbiscan-polygonscan-etc

also, to prevent from the verification process being insanely long, add a very simple deduplication check that auto-skips contract addresses which have already been seen.