### PR TITLE
fix(website): adjust icon size and space

### DIFF
--- a/packages/website/src/components/AbiParameterPreview/index.tsx
+++ b/packages/website/src/components/AbiParameterPreview/index.tsx
@@ -97,7 +97,7 @@ export function AbiParameterPreview({
             <EncodedValueInput value={parsedValue} />
           )}
 
-          <div className="absolute right-2 top-1">
+          <div className="absolute right-2 top-1 space-x-1">
             {explorerUrl && <ExternalLinkButton href={explorerUrl} />}
             <ClipboardButton text={rawValue as string} />
           </div>

--- a/packages/website/src/features/Deploy/SafeSignExecuteButtons.tsx
+++ b/packages/website/src/features/Deploy/SafeSignExecuteButtons.tsx
@@ -197,7 +197,7 @@ export function SafeSignExecuteButtons({
         )}
 
         {!isTransactionExecuted && !executionTxnHash && (
-          <div className="flex gap-4">
+          <div className="flex gap-4 mt-3">
             {accountConnected && walletChainId === safe.chainId ? (
               <>
                 <Tooltip>

--- a/packages/website/src/features/Deploy/SafeSignExecuteButtons.tsx
+++ b/packages/website/src/features/Deploy/SafeSignExecuteButtons.tsx
@@ -171,11 +171,11 @@ export function SafeSignExecuteButtons({
           <>
             <div className="flex flex-col gap-3">
               {signers?.map((s) => (
-                <div key={s}>
+                <div key={s} className="flex items-center">
                   <div className="inline-flex items-center justify-center w-5 h-5 mr-2.5 bg-teal-500 rounded-full">
                     <Check className="w-2.5 h-2.5 text-white" />
                   </div>
-                  <span className="inline font-mono font-light text-gray-200">
+                  <span className="inline-flex font-mono font-light text-gray-200">
                     {`${s.substring(0, 8)}...${s.slice(-6)}`}
                     <a
                       target="_blank"
@@ -183,7 +183,7 @@ export function SafeSignExecuteButtons({
                       className="ml-1.5 hover:text-gray-300"
                       href={getExplorerUrl(safeChain?.id, s)}
                     >
-                      <ExternalLink className="inline" />
+                      <ExternalLink className="h-5 w-5" />
                     </a>
                   </span>
                 </div>

--- a/packages/website/src/features/Deploy/TransactionDisplay.tsx
+++ b/packages/website/src/features/Deploy/TransactionDisplay.tsx
@@ -193,7 +193,11 @@ export function TransactionDisplay(props: {
                     onClick={() => setExpandDiff(!expandDiff)}
                     className="absolute top-4 right-5 hover:text-gray-300"
                   >
-                    {expandDiff ? <Shrink /> : <Expand />}
+                    {expandDiff ? (
+                      <Shrink className="h-5 w-5" />
+                    ) : (
+                      <Expand className="h-5 w-5" />
+                    )}
                   </button>
                 </TooltipTrigger>
                 <TooltipContent>


### PR DESCRIPTION
Adjust icon size and space based on the [CAN-750](https://linear.app/usecannon/issue/CAN-750/adjust-icon-size-and-space)

![Screenshot 2025-06-25 at 10 52 04](https://github.com/user-attachments/assets/7cc15aba-13ef-474c-9f62-1a4399e36261)

<img width="412" alt="Screenshot 2025-06-25 at 13 17 53" src="https://github.com/user-attachments/assets/2aaf8bb4-a069-4293-8dcc-7e35b62b404c" />

<img width="361" alt="Screenshot 2025-06-25 at 13 24 46" src="https://github.com/user-attachments/assets/30b5e5c7-9427-45bc-b357-c4248b84732b" />
