### PR TITLE
fix(website): add custom rpc alert

### DIFF
--- a/packages/website/src/features/Deploy/QueueTransaction.tsx
+++ b/packages/website/src/features/Deploy/QueueTransaction.tsx
@@ -25,6 +25,7 @@ import { useEffect, useState } from 'react';
 import * as viem from 'viem';
 import { ContractMethodInputs } from '../Packages/AbiMethod/AbiContractMethodInputs';
 import 'react-diff-view/style/index.css';
+import Link from 'next/link';
 
 function decodeError(err: viem.Hex, abi: viem.Abi) {
   try {
@@ -95,6 +96,11 @@ export function QueueTransaction({
   > | null>(tx || null);
   const [paramsEncodeError, setParamsEncodeError] = useState<string | null>();
 
+  const [hasCustomProviderAlert, setHasCustomProviderAlert] =
+    useState<boolean>(false);
+  const customProviders = useStore((s) => s.settings.customProviders);
+  const hasNoCustomProviderSetting = customProviders.length === 0;
+
   useEffect(() => {
     if (!selectedContractName) {
       setSelectedFunction(null);
@@ -153,6 +159,7 @@ export function QueueTransaction({
     }
 
     setParamsEncodeError(error);
+    setHasCustomProviderAlert(hasNoCustomProviderSetting);
     setTxn(_txn);
     onChange(
       _txn,
@@ -429,6 +436,20 @@ export function QueueTransaction({
               <AlertTitle>Params Encode Error</AlertTitle>
               <AlertDescription className="text-sm">
                 {paramsEncodeError}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {paramsEncodeError && hasCustomProviderAlert && (
+            <Alert variant="warning" className="mt-2">
+              <AlertDescription>
+                No custom provider specified. Please configure one on the{' '}
+                <Link
+                  href="/settings"
+                  className="border-b border-dotted border-gray-300"
+                >
+                  settings page.
+                </Link>
               </AlertDescription>
             </Alert>
           )}

--- a/packages/website/src/features/Packages/interact/AbiContractMethodInteraction.tsx
+++ b/packages/website/src/features/Packages/interact/AbiContractMethodInteraction.tsx
@@ -67,7 +67,7 @@ const SimulateButton: React.FC<{
       disabled={isCallingMethod || hasParamsError}
       variant="outline"
       onClick={onSimulate}
-      className="rounded-r-none border-r-0 w-1/2 w-full"
+      className="rounded-r-none border-r-0 w-full"
       data-testid="simulate-txs-button"
     >
       <PlayIcon className="w-4 h-4" />
@@ -257,6 +257,32 @@ const MethodCallAlertError: React.FC<{
   );
 };
 
+const CustomProviderAlert: React.FC<{ onClose: () => void }> = ({
+  onClose,
+}) => {
+  return (
+    <Alert variant="warning" className="mt-4">
+      <div className="flex justify-between items-start">
+        <AlertDescription>
+          No custom provider specified. Please configure one on the{' '}
+          <Link
+            href="/settings"
+            className="border-b border-dotted border-gray-300"
+          >
+            settings page.
+          </Link>
+        </AlertDescription>
+        <button
+          onClick={onClose}
+          className="ml-2 hover:opacity-70 flex-shrink-0"
+        >
+          <XIcon className="h-4 w-4" />
+        </button>
+      </div>
+    </Alert>
+  );
+};
+
 const InputErrorAlert: React.FC<{
   error: string;
 }> = ({ error }) => (
@@ -306,9 +332,11 @@ export const AbiContractMethodInteraction: FC<{
     isSimulation,
     callMethodResult,
     simulationSender,
+    hasCustomProviderAlert,
     setSimulationSender,
     submit,
     clearResult,
+    cleanCustomProviderAlert,
   } = useContractInteraction({
     f,
     abi,
@@ -561,6 +589,10 @@ export const AbiContractMethodInteraction: FC<{
                 error={callMethodResult.error}
                 onClose={clearResult}
               />
+            )}
+
+            {hasCustomProviderAlert && (
+              <CustomProviderAlert onClose={() => cleanCustomProviderAlert()} />
             )}
 
             {stageToSafeError && <InputErrorAlert error={stageToSafeError} />}

--- a/packages/website/src/features/Packages/interact/useContractInteraction.ts
+++ b/packages/website/src/features/Packages/interact/useContractInteraction.ts
@@ -75,7 +75,7 @@ export const useContractInteraction = ({
   const [isSimulation, setIsSimulation] = useState(false);
   const [callMethodResult, setCallMethodResult] = useState<ContractCallResult | null>(null);
   const [hasCustomProviderAlert, setHasCustomProviderAlert] = useState<boolean>(false);
-  const customProviders = useStore((s) => s.settings.customProviders)
+  const customProviders = useStore((s) => s.settings.customProviders);
   const hasNoCustomProviderSetting = customProviders.length === 0;
 
   // Simulation state
@@ -166,7 +166,7 @@ export const useContractInteraction = ({
     setIsCallingMethod(true);
     setCallMethodResult(null);
     setIsSimulation(simulate);
-    setHasCustomProviderAlert(false)
+    setHasCustomProviderAlert(false);
 
     try {
       if (isFunctionReadOnly || simulate) {
@@ -185,7 +185,7 @@ export const useContractInteraction = ({
 
   const cleanCustomProviderAlert = () => {
     setHasCustomProviderAlert(false);
-  }
+  };
 
   return {
     isCallingMethod,

--- a/packages/website/src/features/Packages/interact/useContractInteraction.ts
+++ b/packages/website/src/features/Packages/interact/useContractInteraction.ts
@@ -5,6 +5,7 @@ import { Abi, AbiFunction } from 'abitype';
 import { Address, createPublicClient, zeroAddress } from 'viem';
 import { useState, useEffect } from 'react';
 import { useCannonChains } from '@/providers/CannonProvidersProvider';
+import { useStore } from '@/helpers/store';
 
 interface ContractCallResult {
   value: unknown;
@@ -73,6 +74,9 @@ export const useContractInteraction = ({
   const [isCallingMethod, setIsCallingMethod] = useState(false);
   const [isSimulation, setIsSimulation] = useState(false);
   const [callMethodResult, setCallMethodResult] = useState<ContractCallResult | null>(null);
+  const [hasCustomProviderAlert, setHasCustomProviderAlert] = useState<boolean>(false);
+  const customProviders = useStore((s) => s.settings.customProviders)
+  const hasNoCustomProviderSetting = customProviders.length === 0;
 
   // Simulation state
   const { simulationSender, setSimulationSender } = useSimulation();
@@ -98,8 +102,10 @@ export const useContractInteraction = ({
         value: null,
         error: extractError(result.error),
       });
+      setHasCustomProviderAlert(hasNoCustomProviderSetting);
     } else {
       setCallMethodResult({ value: result.value, error: null });
+      setHasCustomProviderAlert(false);
     }
   };
 
@@ -126,6 +132,7 @@ export const useContractInteraction = ({
           value: null,
           error: extractError(result.error),
         });
+        setHasCustomProviderAlert(hasNoCustomProviderSetting);
         return;
       }
 
@@ -136,11 +143,13 @@ export const useContractInteraction = ({
         .then((r) => {
           if (r.status === 'success') {
             setCallMethodResult({ value: result.value, error: null });
+            setHasCustomProviderAlert(false);
           } else {
             setCallMethodResult({
               value: null,
               error: 'Transaction failed',
             });
+            setHasCustomProviderAlert(hasNoCustomProviderSetting);
           }
         });
     } catch (error) {
@@ -148,6 +157,7 @@ export const useContractInteraction = ({
         value: null,
         error: extractError(error),
       });
+      setHasCustomProviderAlert(hasNoCustomProviderSetting);
     }
   };
 
@@ -156,6 +166,7 @@ export const useContractInteraction = ({
     setIsCallingMethod(true);
     setCallMethodResult(null);
     setIsSimulation(simulate);
+    setHasCustomProviderAlert(false)
 
     try {
       if (isFunctionReadOnly || simulate) {
@@ -172,13 +183,19 @@ export const useContractInteraction = ({
     setCallMethodResult(null);
   };
 
+  const cleanCustomProviderAlert = () => {
+    setHasCustomProviderAlert(false);
+  }
+
   return {
     isCallingMethod,
     isSimulation,
     callMethodResult,
     simulationSender,
+    hasCustomProviderAlert,
     setSimulationSender,
     submit,
     clearResult,
+    cleanCustomProviderAlert,
   };
 };


### PR DESCRIPTION
Fixed [CAN-666](https://linear.app/usecannon/issue/CAN-666/suggest-the-user-to-configure-a-custom-rpc-on-the-settings-when-it-is)

Leave yellow color because it looks good.

<img width="799" height="356" alt="Screenshot 2025-07-16 at 15 54 04" src="https://github.com/user-attachments/assets/a1d39e43-fed4-47bb-af5f-cb52cc862334" />

<img width="530" height="599" alt="Screenshot 2025-07-16 at 15 52 54" src="https://github.com/user-attachments/assets/951c6023-bf76-4bcf-89ce-ac2be6b7d7af" />
