### PR TITLE
feat(builder): chain specific build steps

### DIFF
--- a/examples/sample-foundry-project/cannonfile.consumer.toml
+++ b/examples/sample-foundry-project/cannonfile.consumer.toml
@@ -18,6 +18,8 @@ target = "greeter-foundry2:secondary"
 var.salt = "second"
 var.msg = "a message from second greeter set"
 
+chains = [13370]
+
 [invoke.do_change_greeting2]
 target = ["greeters.greeter"]
 func = "setGreeting"
@@ -27,6 +29,8 @@ args = ["<%= settings.change_greeting2 %>", false]
 target = ["more_greeters.greeter"]
 func = "setGreeting"
 args = ["<%= settings.change_greeting2 %>", true]
+
+chains = [13370]
 
 # test for factory functionality
 [invoke.clone]
@@ -64,6 +68,8 @@ target = ["<%= AddressZero %>"]
 abi = '[{"type":"function","name":"test","inputs":[{"type": "string"},{"type":"string"}]}]'
 func = "test"
 args = ["true", "FALSE"]
+
+chains = [1]
 
 # Clone 2 greeters iteratively (used to test multiple emissions of the same event)
 # Testing this using extras object instead of factory 

--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -190,6 +190,13 @@ export const deploySchema = z
           .describe('Override transaction settings'),
 
         /**
+         * Allows for a specific step to only be executed on the given chain IDs.
+         */
+        chains: z
+          .array(z.number().int())
+          .optional()
+          .describe('If specified, this action is only executed on the specified chain IDs.'),
+        /**
          *  List of operations that this operation depends on, which Cannon will execute first. If unspecified, Cannon automatically detects dependencies.
          */
         depends: z
@@ -268,6 +275,13 @@ export const pullSchema = z
          *  Preset label of the package being imported
          */
         preset: z.string().describe('Preset label of the package being imported'),
+        /**
+         * Allows for a specific step to only be executed on the given chain IDs.
+         */
+        chains: z
+          .array(z.number().int())
+          .optional()
+          .describe('If specified, this action is only executed on the specified chain IDs.'),
         /**
          *  Previous operations this operation is dependent on
          *  ```toml
@@ -527,6 +541,14 @@ export const invokeSchema = z
           .describe(
             'Object defined to hold deployment transaction result data. For now its limited to getting deployment event data so it can be reused in other operations'
           ),
+
+        /**
+         * Allows for a specific step to only be executed on the given chain IDs.
+         */
+        chains: z
+          .array(z.number().int())
+          .optional()
+          .describe('If specified, this action is only executed on the specified chain IDs.'),
         /**
          *  Previous operations this operation is dependent on
          */
@@ -682,6 +704,15 @@ export const cloneSchema = z
         tags: z
           .array(z.string())
           .describe('Additional tags to set on the registry for when this provisioned package is published.'),
+
+        /**
+         * Allows for a specific step to only be executed on the given chain IDs.
+         */
+        chains: z
+          .array(z.number().int())
+          .optional()
+          .describe('If specified, this action is only executed on the specified chain IDs.'),
+
         /**
          *  Previous operations this operation is dependent on
          */
@@ -738,6 +769,14 @@ export const routerSchema = z
       })
       .optional()
       .describe('Override transaction settings'),
+
+    /**
+     * Allows for a specific step to only be executed on the given chain IDs.
+     */
+    chains: z
+      .array(z.number().int())
+      .optional()
+      .describe('If specified, this action is only executed on the specified chain IDs.'),
     /**
      *  List of operations that this operation depends on, which Cannon will execute first. If unspecified, Cannon automatically detects dependencies.
      */

--- a/packages/builder/src/steps/pull.ts
+++ b/packages/builder/src/steps/pull.ts
@@ -92,7 +92,7 @@ const pullSpec = {
 
     if (!deployInfo) {
       throw new Error(
-        `deployment not found: ${source}. please make sure it exists for the cannon network and ${preset} preset.`
+        `deployment not found: ${source}. please make sure it exists for the ${chainId} network and ${preset} preset.`
       );
     }
 

--- a/packages/cli/bin/cannon.js
+++ b/packages/cli/bin/cannon.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --enable-source-maps
 
 const { red } = require('chalk');
 const cli = require('../dist/src');


### PR DESCRIPTION
prevent steps from executing unless the specified network is currently being built

this is often useful if you are working with bridge contracts or anything multi-network, as it allows for steps to be quickly excluded without having to create any new files.