### PR TITLE
feat(cli): increase default memory

### DIFF
--- a/packages/cli/bin/cannon.js
+++ b/packages/cli/bin/cannon.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --max-old-space-size=8192
 
 const { red } = require('chalk');
 const cli = require('../dist/src');


### PR DESCRIPTION
some large projects can exceed the node.js default memory limit. So we increase the default limit to prevent this from happening.

fixes https://linear.app/usecannon/issue/CAN-762/increase-cannon-maximum-memory-by-default