### PR TITLE
fix(builder): infinite loop possible on cycle in chain definition

### DIFF
--- a/packages/builder/src/definition.test.ts
+++ b/packages/builder/src/definition.test.ts
@@ -16,7 +16,9 @@ function makeFakeChainDefinition(nodes: { [n: string]: any }) {
 
   try {
     def.initializeComputedDependencies();
-  } catch {}
+  } catch {
+    // no contents
+  }
 
   return def;
 }

--- a/packages/builder/src/definition.test.ts
+++ b/packages/builder/src/definition.test.ts
@@ -12,7 +12,13 @@ function makeFakeChainDefinition(nodes: { [n: string]: any }) {
     _.set(rawDef, n, nodes[n]);
   }
 
-  return new ChainDefinition(rawDef);
+  const def = new ChainDefinition(rawDef);
+
+  try {
+    def.initializeComputedDependencies();
+  } catch {}
+
+  return def;
 }
 
 describe('ChainDefinition', () => {

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -343,6 +343,11 @@ export class ChainDefinition {
 
     computeDepsDebug('finished compute dependencies');
 
+    const cycles = this.checkCycles()
+    if (cycles?.length) {
+      throw new Error(`cannot generate dependency tree: dependency cycle found: ${cycles.join(' => ')}`);
+    }
+
     this._roots = new Set(this.allActionNames.filter((n) => !this.getDependencies(n).length));
 
     if (computeDepsDebug.enabled) {
@@ -482,8 +487,6 @@ export class ChainDefinition {
     currentPath = new Set<string>()
   ): string[] | null {
     // resolved dependencies gets set during dependency computation
-    this.initializeComputedDependencies();
-
     for (const n of actions) {
       if (seenNodes.has(n)) {
         return null;

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -343,7 +343,7 @@ export class ChainDefinition {
 
     computeDepsDebug('finished compute dependencies');
 
-    const cycles = this.checkCycles()
+    const cycles = this.checkCycles();
     if (cycles?.length) {
       throw new Error(`cannot generate dependency tree: dependency cycle found: ${cycles.join(' => ')}`);
     }


### PR DESCRIPTION
due to the way that the call patterns work, it was very possible to have a cycle if dependencies were defined incorrectly.

fixes https://linear.app/usecannon/issue/CAN-763/builder-fails-to-detect-cycle-in-cannonfile