### PR TITLE
fix(cli): printing of RPC errors should be debug

### DIFF
--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -201,7 +201,7 @@ export function createProviderProxy(provider: viem.Client): Promise<string> {
           })
         );
       } catch (err) {
-        log('got rpc error', err);
+        debug('got rpc error', err);
         res.writeHead(400);
         res.end(
           JSON.stringify({


### PR DESCRIPTION
due to recent upstream changes RPC errors have become more vocal. likely not necessary to debug log RPC errors anymore as we do a good job of surfacing errors already if they are important