### PR TITLE
fix(cli): stall on some forge `cli` builds

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,7 +46,7 @@ jobs:
             
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Use `gh pr comment --edit-last` with your Bash tool to leave your review as a comment on the PR.
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options

--- a/packages/builder/src/trace.test.ts
+++ b/packages/builder/src/trace.test.ts
@@ -184,7 +184,7 @@ describe('trace.ts', () => {
       );
 
       expect(traceEntryString).toContain(
-        `      CALL FunTest.testFunc("woot", "1234") => ("${viem.zeroHash}") (123,402 gas)`
+        `      CALL FunTest.testFunc("woot", "1234"){value:0.000000000000001234} => ("${viem.zeroHash}") (123,402 gas)`
       );
     });
   });

--- a/packages/builder/src/trace.ts
+++ b/packages/builder/src/trace.ts
@@ -69,7 +69,9 @@ export function renderTraceEntry(ctx: ChainArtifacts, trace: TraceEntry): string
         (contractName || callTraceAction.to) +
         '.' +
         (parsedInput || callTraceAction.input) +
-        (BigInt(callTraceAction.value || '0') != BigInt(0) ? red(`{value:${viem.formatEther(BigInt(callTraceAction.value))}}`) : '') +
+        (BigInt(callTraceAction.value || '0') != BigInt(0)
+          ? red(`{value:${viem.formatEther(BigInt(callTraceAction.value))}}`)
+          : '') +
         (parsedOutput ? ' => ' + parsedOutput : '');
 
       str = actionStr + (contractName ? green(txStr) : txStr) + gasStr;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -101,7 +101,7 @@ function configureRun(program: Command) {
   return applyCommandsConfig(program, commandsConfig.run).action(async function (
     packages: PackageSpecification[],
     options,
-    program,
+    program
   ) {
     try {
       logSpinner(bold('Starting local node...\n'));
@@ -304,87 +304,94 @@ applyCommandsConfig(program.command('verify'), commandsConfig.verify).action(asy
   }
 });
 
-applyCommandsConfig(program.command('diff'), commandsConfig.diff).action(
-  async function (packageRef, projectDirectory, options) {
-    try {
-      spinner?.update({ text: 'Diffing...' });
-      const { diff } = await import('./commands/diff');
+applyCommandsConfig(program.command('diff'), commandsConfig.diff).action(async function (
+  packageRef,
+  projectDirectory,
+  options
+) {
+  try {
+    spinner?.update({ text: 'Diffing...' });
+    const { diff } = await import('./commands/diff');
 
-      const cliSettings = resolveCliSettings(options);
-      const { fullPackageRef, chainId } = await getPackageInfo(packageRef, options.chainId, cliSettings.rpcUrl);
+    const cliSettings = resolveCliSettings(options);
+    const { fullPackageRef, chainId } = await getPackageInfo(packageRef, options.chainId, cliSettings.rpcUrl);
 
-      const foundDiffs = await diff(
-        fullPackageRef,
-        cliSettings,
-        chainId,
-        projectDirectory,
-        options.matchContract,
-        options.matchSource,
-      );
+    const foundDiffs = await diff(
+      fullPackageRef,
+      cliSettings,
+      chainId,
+      projectDirectory,
+      options.matchContract,
+      options.matchSource
+    );
 
-      logSpinnerEnd();
-      // exit code is the number of differences found--useful for CI checks
-      process.exit(foundDiffs);
-    } catch (err) {
-      logSpinnerEnd();
-      throw err;
+    logSpinnerEnd();
+    // exit code is the number of differences found--useful for CI checks
+    process.exit(foundDiffs);
+  } catch (err) {
+    logSpinnerEnd();
+    throw err;
+  }
+});
+
+applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(async function (
+  packageName,
+  command,
+  options,
+  flags
+) {
+  try {
+    spinner?.update({ text: 'Altering...' });
+    const { alter } = await import('./commands/alter');
+
+    const cliSettings = resolveCliSettings(flags);
+
+    // throw an error if the chainId is not consistent with the provider's chainId
+    await ensureChainIdConsistency(cliSettings.rpcUrl, flags.chainId);
+
+    // note: for command below, pkgInfo is empty because forge currently supplies no package.json or anything similar
+    const newUrl = await alter(
+      packageName,
+      flags.subpkg ? flags.subpkg.split(',') : [],
+      parseInt(flags.chainId),
+      cliSettings,
+      {},
+      command,
+      options,
+      {}
+    );
+
+    logSpinner(newUrl);
+    logSpinnerEnd();
+  } catch (err) {
+    logSpinnerEnd();
+    throw err;
+  }
+});
+
+applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(async function (
+  packageRef,
+  givenIpfsUrl,
+  options
+) {
+  try {
+    const { fetch } = await import('./commands/fetch');
+
+    const { fullPackageRef, chainId } = await getPackageReference(packageRef, options.chainId);
+    const ipfsUrl = getIpfsUrl(givenIpfsUrl);
+    const metaIpfsUrl = getIpfsUrl(options.metaHash) || undefined;
+
+    if (!ipfsUrl) {
+      throw new Error('IPFS URL is required.');
     }
-  },
-);
 
-applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(
-  async function (packageName, command, options, flags) {
-    try {
-      spinner?.update({ text: 'Altering...' });
-      const { alter } = await import('./commands/alter');
-
-      const cliSettings = resolveCliSettings(flags);
-
-      // throw an error if the chainId is not consistent with the provider's chainId
-      await ensureChainIdConsistency(cliSettings.rpcUrl, flags.chainId);
-
-      // note: for command below, pkgInfo is empty because forge currently supplies no package.json or anything similar
-      const newUrl = await alter(
-        packageName,
-        flags.subpkg ? flags.subpkg.split(',') : [],
-        parseInt(flags.chainId),
-        cliSettings,
-        {},
-        command,
-        options,
-        {},
-      );
-
-      logSpinner(newUrl);
-      logSpinnerEnd();
-    } catch (err) {
-      logSpinnerEnd();
-      throw err;
-    }
-  },
-);
-
-applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(
-  async function (packageRef, givenIpfsUrl, options) {
-    try {
-      const { fetch } = await import('./commands/fetch');
-
-      const { fullPackageRef, chainId } = await getPackageReference(packageRef, options.chainId);
-      const ipfsUrl = getIpfsUrl(givenIpfsUrl);
-      const metaIpfsUrl = getIpfsUrl(options.metaHash) || undefined;
-
-      if (!ipfsUrl) {
-        throw new Error('IPFS URL is required.');
-      }
-
-      await fetch(fullPackageRef, chainId, ipfsUrl, metaIpfsUrl);
-      logSpinnerEnd();
-    } catch (err) {
-      logSpinnerEnd();
-      throw err;
-    }
-  },
-);
+    await fetch(fullPackageRef, chainId, ipfsUrl, metaIpfsUrl);
+    logSpinnerEnd();
+  } catch (err) {
+    logSpinnerEnd();
+    throw err;
+  }
+});
 
 applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async function (packageRef, options) {
   try {
@@ -416,7 +423,7 @@ applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async fun
 
 applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(async function (
   packageRef,
-  options: { [opt: string]: string },
+  options: { [opt: string]: string }
 ) {
   try {
     spinner?.update({ text: 'Publishing...' });
@@ -495,8 +502,8 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
       logSpinner();
       logSpinner(
         gray(
-          `Package "${pkgRef.name}" not yet registered, please use "cannon register" to register your package first.\nYou need enough gas on Ethereum Mainnet to register the package on Cannon Registry`,
-        ),
+          `Package "${pkgRef.name}" not yet registered, please use "cannon register" to register your package first.\nYou need enough gas on Ethereum Mainnet to register the package on Cannon Registry`
+        )
       );
       logSpinner();
 
@@ -549,7 +556,7 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
       }\n - Max Priority Fee Per Gas: ${
         overrides.maxPriorityFeePerGas ? overrides.maxPriorityFeePerGas.toString() : 'default'
       }\n - Gas Limit: ${overrides.gasLimit ? overrides.gasLimit : 'default'}\n` +
-        " - To alter these settings use the parameters '--max-fee-per-gas', '--max-priority-fee-per-gas', '--gas-limit'.\n",
+        " - To alter these settings use the parameters '--max-fee-per-gas', '--max-priority-fee-per-gas', '--gas-limit'.\n"
     );
 
     await publish({
@@ -626,7 +633,7 @@ applyCommandsConfig(program.command('inspect'), commandsConfig.inspect).action(a
     const { fullPackageRef, chainId, ipfsUrl, deployInfo } = await getPackageInfo(
       packageRef,
       options.chainId,
-      cliSettings.rpcUrl,
+      cliSettings.rpcUrl
     );
 
     await inspect(
@@ -637,7 +644,7 @@ applyCommandsConfig(program.command('inspect'), commandsConfig.inspect).action(a
       cliSettings,
       options.json ? 'deploy-json' : options.out,
       options.writeDeployments,
-      options.sources,
+      options.sources
     );
 
     logSpinnerEnd();
@@ -665,7 +672,7 @@ applyCommandsConfig(program.command('prune'), commandsConfig.prune).action(async
       storage,
       options.filterPackage?.split(',') || '',
       options.filterVariant?.split(',') || '',
-      options.keepAge,
+      options.keepAge
     );
 
     if (pruneUrls.length) {
@@ -771,9 +778,9 @@ applyCommandsConfig(program.command('test'), commandsConfig.test).action(async f
       warnSpinner(
         yellowBright(
           bold(
-            '⚠️  The `--` syntax for passing options to forge or anvil is deprecated. Please use `--forge.*` or `--anvil.*` instead.',
-          ),
-        ),
+            '⚠️  The `--` syntax for passing options to forge or anvil is deprecated. Please use `--forge.*` or `--anvil.*` instead.'
+          )
+        )
       );
       logSpinner();
     }
@@ -843,14 +850,14 @@ applyCommandsConfig(program.command('interact'), commandsConfig.interact).action
         priorityGasFee: options.maxPriorityFee,
       },
       resolver,
-      getMainLoader(cliSettings),
+      getMainLoader(cliSettings)
     );
 
     const deployData = await runtime.readDeploy(fullPackageRef, runtime.chainId);
 
     if (!deployData) {
       throw new Error(
-        `deployment not found for package: ${fullPackageRef} with chaindId ${chainId}. please make sure it exists for the given preset and current network.`,
+        `deployment not found for package: ${fullPackageRef} with chaindId ${chainId}. please make sure it exists for the given preset and current network.`
       );
     }
 
@@ -858,7 +865,7 @@ applyCommandsConfig(program.command('interact'), commandsConfig.interact).action
 
     if (!outputs) {
       throw new Error(
-        `no cannon build found for ${fullPackageRef} with chaindId ${chainId}. Did you mean to run the package instead?`,
+        `no cannon build found for ${fullPackageRef} with chaindId ${chainId}. Did you mean to run the package instead?`
       );
     }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -101,7 +101,7 @@ function configureRun(program: Command) {
   return applyCommandsConfig(program, commandsConfig.run).action(async function (
     packages: PackageSpecification[],
     options,
-    program
+    program,
   ) {
     try {
       logSpinner(bold('Starting local node...\n'));
@@ -218,10 +218,16 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
 
         await new Promise((resolve, reject) => {
           forgeBuildProcess.stdout.on('data', (d) => {
-            forgeStdout.push(d.toString('utf8'));
+            forgeStdout.slice(-999).push(d.toString('utf8'));
           });
           forgeBuildProcess.stderr.on('data', (d) => {
-            forgeStderr.push(d.toString('utf8'));
+            forgeStderr.slice(-999).push(d.toString('utf8'));
+          });
+          forgeBuildProcess.stdout.on('error', (err) => {
+            warnSpinner('forge child process stdout error:', err);
+          });
+          forgeBuildProcess.stderr.on('error', (err) => {
+            warnSpinner('forge child process stderr error:', err);
           });
           forgeBuildProcess.on('exit', (code) => {
             if (code === 0) {
@@ -298,94 +304,87 @@ applyCommandsConfig(program.command('verify'), commandsConfig.verify).action(asy
   }
 });
 
-applyCommandsConfig(program.command('diff'), commandsConfig.diff).action(async function (
-  packageRef,
-  projectDirectory,
-  options
-) {
-  try {
-    spinner?.update({ text: 'Diffing...' });
-    const { diff } = await import('./commands/diff');
+applyCommandsConfig(program.command('diff'), commandsConfig.diff).action(
+  async function (packageRef, projectDirectory, options) {
+    try {
+      spinner?.update({ text: 'Diffing...' });
+      const { diff } = await import('./commands/diff');
 
-    const cliSettings = resolveCliSettings(options);
-    const { fullPackageRef, chainId } = await getPackageInfo(packageRef, options.chainId, cliSettings.rpcUrl);
+      const cliSettings = resolveCliSettings(options);
+      const { fullPackageRef, chainId } = await getPackageInfo(packageRef, options.chainId, cliSettings.rpcUrl);
 
-    const foundDiffs = await diff(
-      fullPackageRef,
-      cliSettings,
-      chainId,
-      projectDirectory,
-      options.matchContract,
-      options.matchSource
-    );
+      const foundDiffs = await diff(
+        fullPackageRef,
+        cliSettings,
+        chainId,
+        projectDirectory,
+        options.matchContract,
+        options.matchSource,
+      );
 
-    logSpinnerEnd();
-    // exit code is the number of differences found--useful for CI checks
-    process.exit(foundDiffs);
-  } catch (err) {
-    logSpinnerEnd();
-    throw err;
-  }
-});
-
-applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(async function (
-  packageName,
-  command,
-  options,
-  flags
-) {
-  try {
-    spinner?.update({ text: 'Altering...' });
-    const { alter } = await import('./commands/alter');
-
-    const cliSettings = resolveCliSettings(flags);
-
-    // throw an error if the chainId is not consistent with the provider's chainId
-    await ensureChainIdConsistency(cliSettings.rpcUrl, flags.chainId);
-
-    // note: for command below, pkgInfo is empty because forge currently supplies no package.json or anything similar
-    const newUrl = await alter(
-      packageName,
-      flags.subpkg ? flags.subpkg.split(',') : [],
-      parseInt(flags.chainId),
-      cliSettings,
-      {},
-      command,
-      options,
-      {}
-    );
-
-    logSpinner(newUrl);
-    logSpinnerEnd();
-  } catch (err) {
-    logSpinnerEnd();
-    throw err;
-  }
-});
-
-applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(async function (
-  packageRef,
-  givenIpfsUrl,
-  options
-) {
-  try {
-    const { fetch } = await import('./commands/fetch');
-
-    const { fullPackageRef, chainId } = await getPackageReference(packageRef, options.chainId);
-    const ipfsUrl = getIpfsUrl(givenIpfsUrl);
-    const metaIpfsUrl = getIpfsUrl(options.metaHash) || undefined;
-
-    if (!ipfsUrl) {
-      throw new Error('IPFS URL is required.');
+      logSpinnerEnd();
+      // exit code is the number of differences found--useful for CI checks
+      process.exit(foundDiffs);
+    } catch (err) {
+      logSpinnerEnd();
+      throw err;
     }
+  },
+);
 
-    await fetch(fullPackageRef, chainId, ipfsUrl, metaIpfsUrl);
-    logSpinnerEnd();
-  } catch (err) {
-    logSpinnerEnd();
-    throw err;
-  }
-});
+applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(
+  async function (packageName, command, options, flags) {
+    try {
+      spinner?.update({ text: 'Altering...' });
+      const { alter } = await import('./commands/alter');
+
+      const cliSettings = resolveCliSettings(flags);
+
+      // throw an error if the chainId is not consistent with the provider's chainId
+      await ensureChainIdConsistency(cliSettings.rpcUrl, flags.chainId);
+
+      // note: for command below, pkgInfo is empty because forge currently supplies no package.json or anything similar
+      const newUrl = await alter(
+        packageName,
+        flags.subpkg ? flags.subpkg.split(',') : [],
+        parseInt(flags.chainId),
+        cliSettings,
+        {},
+        command,
+        options,
+        {},
+      );
+
+      logSpinner(newUrl);
+      logSpinnerEnd();
+    } catch (err) {
+      logSpinnerEnd();
+      throw err;
+    }
+  },
+);
+
+applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(
+  async function (packageRef, givenIpfsUrl, options) {
+    try {
+      const { fetch } = await import('./commands/fetch');
+
+      const { fullPackageRef, chainId } = await getPackageReference(packageRef, options.chainId);
+      const ipfsUrl = getIpfsUrl(givenIpfsUrl);
+      const metaIpfsUrl = getIpfsUrl(options.metaHash) || undefined;
+
+      if (!ipfsUrl) {
+        throw new Error('IPFS URL is required.');
+      }
+
+      await fetch(fullPackageRef, chainId, ipfsUrl, metaIpfsUrl);
+      logSpinnerEnd();
+    } catch (err) {
+      logSpinnerEnd();
+      throw err;
+    }
+  },
+);
 
 applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async function (packageRef, options) {
   try {
@@ -417,7 +416,7 @@ applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async fun
 
 applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(async function (
   packageRef,
-  options: { [opt: string]: string }
+  options: { [opt: string]: string },
 ) {
   try {
     spinner?.update({ text: 'Publishing...' });
@@ -496,8 +495,8 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
       logSpinner();
       logSpinner(
         gray(
-          `Package "${pkgRef.name}" not yet registered, please use "cannon register" to register your package first.\nYou need enough gas on Ethereum Mainnet to register the package on Cannon Registry`
-        )
+          `Package "${pkgRef.name}" not yet registered, please use "cannon register" to register your package first.\nYou need enough gas on Ethereum Mainnet to register the package on Cannon Registry`,
+        ),
       );
       logSpinner();
 
@@ -550,7 +549,7 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
       }\n - Max Priority Fee Per Gas: ${
         overrides.maxPriorityFeePerGas ? overrides.maxPriorityFeePerGas.toString() : 'default'
       }\n - Gas Limit: ${overrides.gasLimit ? overrides.gasLimit : 'default'}\n` +
-        " - To alter these settings use the parameters '--max-fee-per-gas', '--max-priority-fee-per-gas', '--gas-limit'.\n"
+        " - To alter these settings use the parameters '--max-fee-per-gas', '--max-priority-fee-per-gas', '--gas-limit'.\n",
     );
 
     await publish({
@@ -627,7 +626,7 @@ applyCommandsConfig(program.command('inspect'), commandsConfig.inspect).action(a
     const { fullPackageRef, chainId, ipfsUrl, deployInfo } = await getPackageInfo(
       packageRef,
       options.chainId,
-      cliSettings.rpcUrl
+      cliSettings.rpcUrl,
     );
 
     await inspect(
@@ -638,7 +637,7 @@ applyCommandsConfig(program.command('inspect'), commandsConfig.inspect).action(a
       cliSettings,
       options.json ? 'deploy-json' : options.out,
       options.writeDeployments,
-      options.sources
+      options.sources,
     );
 
     logSpinnerEnd();
@@ -666,7 +665,7 @@ applyCommandsConfig(program.command('prune'), commandsConfig.prune).action(async
       storage,
       options.filterPackage?.split(',') || '',
       options.filterVariant?.split(',') || '',
-      options.keepAge
+      options.keepAge,
     );
 
     if (pruneUrls.length) {
@@ -772,9 +771,9 @@ applyCommandsConfig(program.command('test'), commandsConfig.test).action(async f
       warnSpinner(
         yellowBright(
           bold(
-            '⚠️  The `--` syntax for passing options to forge or anvil is deprecated. Please use `--forge.*` or `--anvil.*` instead.'
-          )
-        )
+            '⚠️  The `--` syntax for passing options to forge or anvil is deprecated. Please use `--forge.*` or `--anvil.*` instead.',
+          ),
+        ),
       );
       logSpinner();
     }
@@ -844,14 +843,14 @@ applyCommandsConfig(program.command('interact'), commandsConfig.interact).action
         priorityGasFee: options.maxPriorityFee,
       },
       resolver,
-      getMainLoader(cliSettings)
+      getMainLoader(cliSettings),
     );
 
     const deployData = await runtime.readDeploy(fullPackageRef, runtime.chainId);
 
     if (!deployData) {
       throw new Error(
-        `deployment not found for package: ${fullPackageRef} with chaindId ${chainId}. please make sure it exists for the given preset and current network.`
+        `deployment not found for package: ${fullPackageRef} with chaindId ${chainId}. please make sure it exists for the given preset and current network.`,
       );
     }
 
@@ -859,7 +858,7 @@ applyCommandsConfig(program.command('interact'), commandsConfig.interact).action
 
     if (!outputs) {
       throw new Error(
-        `no cannon build found for ${fullPackageRef} with chaindId ${chainId}. Did you mean to run the package instead?`
+        `no cannon build found for ${fullPackageRef} with chaindId ${chainId}. Did you mean to run the package instead?`,
       );
     }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -218,10 +218,10 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
 
         await new Promise((resolve, reject) => {
           forgeBuildProcess.stdout.on('data', (d) => {
-            forgeStdout.slice(-999).push(d.toString('utf8'));
+            forgeStdout.push(d.toString('utf8'));
           });
           forgeBuildProcess.stderr.on('data', (d) => {
-            forgeStderr.slice(-999).push(d.toString('utf8'));
+            forgeStderr.push(d.toString('utf8'));
           });
           forgeBuildProcess.stdout.on('error', (err) => {
             warnSpinner('forge child process stdout error:', err);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -213,15 +213,15 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
         ];
 
         const forgeBuildProcess = spawn('forge', forgeBuildArgs, { cwd: projectDirectory, shell: true });
-        let forgeStdout = '';
-        let forgeStderr = '';
+        const forgeStdout: string[] = [];
+        const forgeStderr: string[] = [];
 
         await new Promise((resolve, reject) => {
           forgeBuildProcess.stdout.on('data', (d) => {
-            forgeStdout += d;
+            forgeStdout.push(d.toString('utf8'));
           });
           forgeBuildProcess.stderr.on('data', (d) => {
-            forgeStderr += d;
+            forgeStderr.push(d.toString('utf8'));
           });
           forgeBuildProcess.on('exit', (code) => {
             if (code === 0) {
@@ -229,8 +229,8 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
             } else {
               logSpinner(red('forge build failed'));
               logSpinner(red('Make sure "forge build" runs successfully or use the --skip-compile flag.'));
-              log(`forge stdout:\n${forgeStdout}`);
-              error(`forge stderr:\n${forgeStderr}`);
+              log(`forge stdout:\n${forgeStdout.join('')}`);
+              error(`forge stderr:\n${forgeStderr.join('')}`);
               return reject(new Error(`forge build failed with exit code "${code}"`));
             }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,7 +38,7 @@ import { PackageSpecification } from './types';
 
 import { doBuild } from './util/build';
 import { setDebugLevel } from './util/debug-level';
-import { log, logSpinner, warnSpinner, errorSpinner, logSpinnerEnd, spinner } from './util/console';
+import { log, error, logSpinner, warnSpinner, errorSpinner, logSpinnerEnd, spinner } from './util/console';
 import { getContractsRecursive } from './util/contracts-recursive';
 import { applyCommandsConfig } from './util/commands-config';
 import {
@@ -101,7 +101,7 @@ function configureRun(program: Command) {
   return applyCommandsConfig(program, commandsConfig.run).action(async function (
     packages: PackageSpecification[],
     options,
-    program
+    program,
   ) {
     try {
       logSpinner(bold('Starting local node...\n'));
@@ -213,14 +213,24 @@ applyCommandsConfig(program.command('build'), commandsConfig.build)
         ];
 
         const forgeBuildProcess = spawn('forge', forgeBuildArgs, { cwd: projectDirectory, shell: true });
+        let forgeStdout = '';
+        let forgeStderr = '';
 
         await new Promise((resolve, reject) => {
+          forgeBuildProcess.stdout.on('data', (d) => {
+            forgeStdout += d;
+          });
+          forgeBuildProcess.stderr.on('data', (d) => {
+            forgeStderr += d;
+          });
           forgeBuildProcess.on('exit', (code) => {
             if (code === 0) {
               logSpinner(gray('forge build succeeded'));
             } else {
               logSpinner(red('forge build failed'));
               logSpinner(red('Make sure "forge build" runs successfully or use the --skip-compile flag.'));
+              log(`forge stdout:\n${forgeStdout}`);
+              error(`forge stderr:\n${forgeStderr}`);
               return reject(new Error(`forge build failed with exit code "${code}"`));
             }
 
@@ -288,94 +298,87 @@ applyCommandsConfig(program.command('verify'), commandsConfig.verify).action(asy
   }
 });
 
-applyCommandsConfig(program.command('diff'), commandsConfig.diff).action(async function (
-  packageRef,
-  projectDirectory,
-  options
-) {
-  try {
-    spinner?.update({ text: 'Diffing...' });
-    const { diff } = await import('./commands/diff');
+applyCommandsConfig(program.command('diff'), commandsConfig.diff).action(
+  async function (packageRef, projectDirectory, options) {
+    try {
+      spinner?.update({ text: 'Diffing...' });
+      const { diff } = await import('./commands/diff');
 
-    const cliSettings = resolveCliSettings(options);
-    const { fullPackageRef, chainId } = await getPackageInfo(packageRef, options.chainId, cliSettings.rpcUrl);
+      const cliSettings = resolveCliSettings(options);
+      const { fullPackageRef, chainId } = await getPackageInfo(packageRef, options.chainId, cliSettings.rpcUrl);
 
-    const foundDiffs = await diff(
-      fullPackageRef,
-      cliSettings,
-      chainId,
-      projectDirectory,
-      options.matchContract,
-      options.matchSource
-    );
+      const foundDiffs = await diff(
+        fullPackageRef,
+        cliSettings,
+        chainId,
+        projectDirectory,
+        options.matchContract,
+        options.matchSource,
+      );
 
-    logSpinnerEnd();
-    // exit code is the number of differences found--useful for CI checks
-    process.exit(foundDiffs);
-  } catch (err) {
-    logSpinnerEnd();
-    throw err;
-  }
-});
-
-applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(async function (
-  packageName,
-  command,
-  options,
-  flags
-) {
-  try {
-    spinner?.update({ text: 'Altering...' });
-    const { alter } = await import('./commands/alter');
-
-    const cliSettings = resolveCliSettings(flags);
-
-    // throw an error if the chainId is not consistent with the provider's chainId
-    await ensureChainIdConsistency(cliSettings.rpcUrl, flags.chainId);
-
-    // note: for command below, pkgInfo is empty because forge currently supplies no package.json or anything similar
-    const newUrl = await alter(
-      packageName,
-      flags.subpkg ? flags.subpkg.split(',') : [],
-      parseInt(flags.chainId),
-      cliSettings,
-      {},
-      command,
-      options,
-      {}
-    );
-
-    logSpinner(newUrl);
-    logSpinnerEnd();
-  } catch (err) {
-    logSpinnerEnd();
-    throw err;
-  }
-});
-
-applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(async function (
-  packageRef,
-  givenIpfsUrl,
-  options
-) {
-  try {
-    const { fetch } = await import('./commands/fetch');
-
-    const { fullPackageRef, chainId } = await getPackageReference(packageRef, options.chainId);
-    const ipfsUrl = getIpfsUrl(givenIpfsUrl);
-    const metaIpfsUrl = getIpfsUrl(options.metaHash) || undefined;
-
-    if (!ipfsUrl) {
-      throw new Error('IPFS URL is required.');
+      logSpinnerEnd();
+      // exit code is the number of differences found--useful for CI checks
+      process.exit(foundDiffs);
+    } catch (err) {
+      logSpinnerEnd();
+      throw err;
     }
+  },
+);
 
-    await fetch(fullPackageRef, chainId, ipfsUrl, metaIpfsUrl);
-    logSpinnerEnd();
-  } catch (err) {
-    logSpinnerEnd();
-    throw err;
-  }
-});
+applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(
+  async function (packageName, command, options, flags) {
+    try {
+      spinner?.update({ text: 'Altering...' });
+      const { alter } = await import('./commands/alter');
+
+      const cliSettings = resolveCliSettings(flags);
+
+      // throw an error if the chainId is not consistent with the provider's chainId
+      await ensureChainIdConsistency(cliSettings.rpcUrl, flags.chainId);
+
+      // note: for command below, pkgInfo is empty because forge currently supplies no package.json or anything similar
+      const newUrl = await alter(
+        packageName,
+        flags.subpkg ? flags.subpkg.split(',') : [],
+        parseInt(flags.chainId),
+        cliSettings,
+        {},
+        command,
+        options,
+        {},
+      );
+
+      logSpinner(newUrl);
+      logSpinnerEnd();
+    } catch (err) {
+      logSpinnerEnd();
+      throw err;
+    }
+  },
+);
+
+applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(
+  async function (packageRef, givenIpfsUrl, options) {
+    try {
+      const { fetch } = await import('./commands/fetch');
+
+      const { fullPackageRef, chainId } = await getPackageReference(packageRef, options.chainId);
+      const ipfsUrl = getIpfsUrl(givenIpfsUrl);
+      const metaIpfsUrl = getIpfsUrl(options.metaHash) || undefined;
+
+      if (!ipfsUrl) {
+        throw new Error('IPFS URL is required.');
+      }
+
+      await fetch(fullPackageRef, chainId, ipfsUrl, metaIpfsUrl);
+      logSpinnerEnd();
+    } catch (err) {
+      logSpinnerEnd();
+      throw err;
+    }
+  },
+);
 
 applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async function (packageRef, options) {
   try {
@@ -407,7 +410,7 @@ applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async fun
 
 applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(async function (
   packageRef,
-  options: { [opt: string]: string }
+  options: { [opt: string]: string },
 ) {
   try {
     spinner?.update({ text: 'Publishing...' });
@@ -486,8 +489,8 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
       logSpinner();
       logSpinner(
         gray(
-          `Package "${pkgRef.name}" not yet registered, please use "cannon register" to register your package first.\nYou need enough gas on Ethereum Mainnet to register the package on Cannon Registry`
-        )
+          `Package "${pkgRef.name}" not yet registered, please use "cannon register" to register your package first.\nYou need enough gas on Ethereum Mainnet to register the package on Cannon Registry`,
+        ),
       );
       logSpinner();
 
@@ -540,7 +543,7 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
       }\n - Max Priority Fee Per Gas: ${
         overrides.maxPriorityFeePerGas ? overrides.maxPriorityFeePerGas.toString() : 'default'
       }\n - Gas Limit: ${overrides.gasLimit ? overrides.gasLimit : 'default'}\n` +
-        " - To alter these settings use the parameters '--max-fee-per-gas', '--max-priority-fee-per-gas', '--gas-limit'.\n"
+        " - To alter these settings use the parameters '--max-fee-per-gas', '--max-priority-fee-per-gas', '--gas-limit'.\n",
     );
 
     await publish({
@@ -617,7 +620,7 @@ applyCommandsConfig(program.command('inspect'), commandsConfig.inspect).action(a
     const { fullPackageRef, chainId, ipfsUrl, deployInfo } = await getPackageInfo(
       packageRef,
       options.chainId,
-      cliSettings.rpcUrl
+      cliSettings.rpcUrl,
     );
 
     await inspect(
@@ -628,7 +631,7 @@ applyCommandsConfig(program.command('inspect'), commandsConfig.inspect).action(a
       cliSettings,
       options.json ? 'deploy-json' : options.out,
       options.writeDeployments,
-      options.sources
+      options.sources,
     );
 
     logSpinnerEnd();
@@ -656,7 +659,7 @@ applyCommandsConfig(program.command('prune'), commandsConfig.prune).action(async
       storage,
       options.filterPackage?.split(',') || '',
       options.filterVariant?.split(',') || '',
-      options.keepAge
+      options.keepAge,
     );
 
     if (pruneUrls.length) {
@@ -762,9 +765,9 @@ applyCommandsConfig(program.command('test'), commandsConfig.test).action(async f
       warnSpinner(
         yellowBright(
           bold(
-            '⚠️  The `--` syntax for passing options to forge or anvil is deprecated. Please use `--forge.*` or `--anvil.*` instead.'
-          )
-        )
+            '⚠️  The `--` syntax for passing options to forge or anvil is deprecated. Please use `--forge.*` or `--anvil.*` instead.',
+          ),
+        ),
       );
       logSpinner();
     }
@@ -834,14 +837,14 @@ applyCommandsConfig(program.command('interact'), commandsConfig.interact).action
         priorityGasFee: options.maxPriorityFee,
       },
       resolver,
-      getMainLoader(cliSettings)
+      getMainLoader(cliSettings),
     );
 
     const deployData = await runtime.readDeploy(fullPackageRef, runtime.chainId);
 
     if (!deployData) {
       throw new Error(
-        `deployment not found for package: ${fullPackageRef} with chaindId ${chainId}. please make sure it exists for the given preset and current network.`
+        `deployment not found for package: ${fullPackageRef} with chaindId ${chainId}. please make sure it exists for the given preset and current network.`,
       );
     }
 
@@ -849,7 +852,7 @@ applyCommandsConfig(program.command('interact'), commandsConfig.interact).action
 
     if (!outputs) {
       throw new Error(
-        `no cannon build found for ${fullPackageRef} with chaindId ${chainId}. Did you mean to run the package instead?`
+        `no cannon build found for ${fullPackageRef} with chaindId ${chainId}. Did you mean to run the package instead?`,
       );
     }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -101,7 +101,7 @@ function configureRun(program: Command) {
   return applyCommandsConfig(program, commandsConfig.run).action(async function (
     packages: PackageSpecification[],
     options,
-    program,
+    program
   ) {
     try {
       logSpinner(bold('Starting local node...\n'));
@@ -298,87 +298,94 @@ applyCommandsConfig(program.command('verify'), commandsConfig.verify).action(asy
   }
 });
 
-applyCommandsConfig(program.command('diff'), commandsConfig.diff).action(
-  async function (packageRef, projectDirectory, options) {
-    try {
-      spinner?.update({ text: 'Diffing...' });
-      const { diff } = await import('./commands/diff');
+applyCommandsConfig(program.command('diff'), commandsConfig.diff).action(async function (
+  packageRef,
+  projectDirectory,
+  options
+) {
+  try {
+    spinner?.update({ text: 'Diffing...' });
+    const { diff } = await import('./commands/diff');
 
-      const cliSettings = resolveCliSettings(options);
-      const { fullPackageRef, chainId } = await getPackageInfo(packageRef, options.chainId, cliSettings.rpcUrl);
+    const cliSettings = resolveCliSettings(options);
+    const { fullPackageRef, chainId } = await getPackageInfo(packageRef, options.chainId, cliSettings.rpcUrl);
 
-      const foundDiffs = await diff(
-        fullPackageRef,
-        cliSettings,
-        chainId,
-        projectDirectory,
-        options.matchContract,
-        options.matchSource,
-      );
+    const foundDiffs = await diff(
+      fullPackageRef,
+      cliSettings,
+      chainId,
+      projectDirectory,
+      options.matchContract,
+      options.matchSource
+    );
 
-      logSpinnerEnd();
-      // exit code is the number of differences found--useful for CI checks
-      process.exit(foundDiffs);
-    } catch (err) {
-      logSpinnerEnd();
-      throw err;
+    logSpinnerEnd();
+    // exit code is the number of differences found--useful for CI checks
+    process.exit(foundDiffs);
+  } catch (err) {
+    logSpinnerEnd();
+    throw err;
+  }
+});
+
+applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(async function (
+  packageName,
+  command,
+  options,
+  flags
+) {
+  try {
+    spinner?.update({ text: 'Altering...' });
+    const { alter } = await import('./commands/alter');
+
+    const cliSettings = resolveCliSettings(flags);
+
+    // throw an error if the chainId is not consistent with the provider's chainId
+    await ensureChainIdConsistency(cliSettings.rpcUrl, flags.chainId);
+
+    // note: for command below, pkgInfo is empty because forge currently supplies no package.json or anything similar
+    const newUrl = await alter(
+      packageName,
+      flags.subpkg ? flags.subpkg.split(',') : [],
+      parseInt(flags.chainId),
+      cliSettings,
+      {},
+      command,
+      options,
+      {}
+    );
+
+    logSpinner(newUrl);
+    logSpinnerEnd();
+  } catch (err) {
+    logSpinnerEnd();
+    throw err;
+  }
+});
+
+applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(async function (
+  packageRef,
+  givenIpfsUrl,
+  options
+) {
+  try {
+    const { fetch } = await import('./commands/fetch');
+
+    const { fullPackageRef, chainId } = await getPackageReference(packageRef, options.chainId);
+    const ipfsUrl = getIpfsUrl(givenIpfsUrl);
+    const metaIpfsUrl = getIpfsUrl(options.metaHash) || undefined;
+
+    if (!ipfsUrl) {
+      throw new Error('IPFS URL is required.');
     }
-  },
-);
 
-applyCommandsConfig(program.command('alter'), commandsConfig.alter).action(
-  async function (packageName, command, options, flags) {
-    try {
-      spinner?.update({ text: 'Altering...' });
-      const { alter } = await import('./commands/alter');
-
-      const cliSettings = resolveCliSettings(flags);
-
-      // throw an error if the chainId is not consistent with the provider's chainId
-      await ensureChainIdConsistency(cliSettings.rpcUrl, flags.chainId);
-
-      // note: for command below, pkgInfo is empty because forge currently supplies no package.json or anything similar
-      const newUrl = await alter(
-        packageName,
-        flags.subpkg ? flags.subpkg.split(',') : [],
-        parseInt(flags.chainId),
-        cliSettings,
-        {},
-        command,
-        options,
-        {},
-      );
-
-      logSpinner(newUrl);
-      logSpinnerEnd();
-    } catch (err) {
-      logSpinnerEnd();
-      throw err;
-    }
-  },
-);
-
-applyCommandsConfig(program.command('fetch'), commandsConfig.fetch).action(
-  async function (packageRef, givenIpfsUrl, options) {
-    try {
-      const { fetch } = await import('./commands/fetch');
-
-      const { fullPackageRef, chainId } = await getPackageReference(packageRef, options.chainId);
-      const ipfsUrl = getIpfsUrl(givenIpfsUrl);
-      const metaIpfsUrl = getIpfsUrl(options.metaHash) || undefined;
-
-      if (!ipfsUrl) {
-        throw new Error('IPFS URL is required.');
-      }
-
-      await fetch(fullPackageRef, chainId, ipfsUrl, metaIpfsUrl);
-      logSpinnerEnd();
-    } catch (err) {
-      logSpinnerEnd();
-      throw err;
-    }
-  },
-);
+    await fetch(fullPackageRef, chainId, ipfsUrl, metaIpfsUrl);
+    logSpinnerEnd();
+  } catch (err) {
+    logSpinnerEnd();
+    throw err;
+  }
+});
 
 applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async function (packageRef, options) {
   try {
@@ -410,7 +417,7 @@ applyCommandsConfig(program.command('pin'), commandsConfig.pin).action(async fun
 
 applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(async function (
   packageRef,
-  options: { [opt: string]: string },
+  options: { [opt: string]: string }
 ) {
   try {
     spinner?.update({ text: 'Publishing...' });
@@ -489,8 +496,8 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
       logSpinner();
       logSpinner(
         gray(
-          `Package "${pkgRef.name}" not yet registered, please use "cannon register" to register your package first.\nYou need enough gas on Ethereum Mainnet to register the package on Cannon Registry`,
-        ),
+          `Package "${pkgRef.name}" not yet registered, please use "cannon register" to register your package first.\nYou need enough gas on Ethereum Mainnet to register the package on Cannon Registry`
+        )
       );
       logSpinner();
 
@@ -543,7 +550,7 @@ applyCommandsConfig(program.command('publish'), commandsConfig.publish).action(a
       }\n - Max Priority Fee Per Gas: ${
         overrides.maxPriorityFeePerGas ? overrides.maxPriorityFeePerGas.toString() : 'default'
       }\n - Gas Limit: ${overrides.gasLimit ? overrides.gasLimit : 'default'}\n` +
-        " - To alter these settings use the parameters '--max-fee-per-gas', '--max-priority-fee-per-gas', '--gas-limit'.\n",
+        " - To alter these settings use the parameters '--max-fee-per-gas', '--max-priority-fee-per-gas', '--gas-limit'.\n"
     );
 
     await publish({
@@ -620,7 +627,7 @@ applyCommandsConfig(program.command('inspect'), commandsConfig.inspect).action(a
     const { fullPackageRef, chainId, ipfsUrl, deployInfo } = await getPackageInfo(
       packageRef,
       options.chainId,
-      cliSettings.rpcUrl,
+      cliSettings.rpcUrl
     );
 
     await inspect(
@@ -631,7 +638,7 @@ applyCommandsConfig(program.command('inspect'), commandsConfig.inspect).action(a
       cliSettings,
       options.json ? 'deploy-json' : options.out,
       options.writeDeployments,
-      options.sources,
+      options.sources
     );
 
     logSpinnerEnd();
@@ -659,7 +666,7 @@ applyCommandsConfig(program.command('prune'), commandsConfig.prune).action(async
       storage,
       options.filterPackage?.split(',') || '',
       options.filterVariant?.split(',') || '',
-      options.keepAge,
+      options.keepAge
     );
 
     if (pruneUrls.length) {
@@ -765,9 +772,9 @@ applyCommandsConfig(program.command('test'), commandsConfig.test).action(async f
       warnSpinner(
         yellowBright(
           bold(
-            '⚠️  The `--` syntax for passing options to forge or anvil is deprecated. Please use `--forge.*` or `--anvil.*` instead.',
-          ),
-        ),
+            '⚠️  The `--` syntax for passing options to forge or anvil is deprecated. Please use `--forge.*` or `--anvil.*` instead.'
+          )
+        )
       );
       logSpinner();
     }
@@ -837,14 +844,14 @@ applyCommandsConfig(program.command('interact'), commandsConfig.interact).action
         priorityGasFee: options.maxPriorityFee,
       },
       resolver,
-      getMainLoader(cliSettings),
+      getMainLoader(cliSettings)
     );
 
     const deployData = await runtime.readDeploy(fullPackageRef, runtime.chainId);
 
     if (!deployData) {
       throw new Error(
-        `deployment not found for package: ${fullPackageRef} with chaindId ${chainId}. please make sure it exists for the given preset and current network.`,
+        `deployment not found for package: ${fullPackageRef} with chaindId ${chainId}. please make sure it exists for the given preset and current network.`
       );
     }
 
@@ -852,7 +859,7 @@ applyCommandsConfig(program.command('interact'), commandsConfig.interact).action
 
     if (!outputs) {
       throw new Error(
-        `no cannon build found for ${fullPackageRef} with chaindId ${chainId}. Did you mean to run the package instead?`,
+        `no cannon build found for ${fullPackageRef} with chaindId ${chainId}. Did you mean to run the package instead?`
       );
     }
 

--- a/packages/cli/test/e2e/parallel.bats
+++ b/packages/cli/test/e2e/parallel.bats
@@ -150,3 +150,12 @@ teardown() {
   echo $output
   assert_success
 }
+
+@test "Build - Forge compile error displays stdout/stderr" {
+  run build-foundry-compile-error.sh
+  echo $output
+  assert_output --partial 'forge build failed'
+  assert_output --partial 'forge stdout:'
+  assert_output --partial 'forge stderr:'
+  assert_success
+}

--- a/packages/cli/test/e2e/scripts/non-interactive/build-foundry-compile-error.sh
+++ b/packages/cli/test/e2e/scripts/non-interactive/build-foundry-compile-error.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# This test verifies that when forge build fails, cannon prints stdout and stderr
+
+# Create a temporary directory for this test
+TEST_DIR=$(mktemp -d)
+cd "$TEST_DIR"
+
+# Initialize a basic foundry project
+forge init --no-git test-project
+cd test-project
+
+# Create a broken Solidity contract with a compilation error
+cat > src/Broken.sol << 'EOF'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Broken {
+    // This will cause a compilation error - undefined type
+    UndefinedType public myVar;
+
+    // Missing semicolon to cause another error
+    uint256 public anotherVar
+}
+EOF
+
+# Create a simple cannonfile.toml
+cat > cannonfile.toml << 'EOF'
+name = "broken-test"
+version = "1.0.0"
+
+[contract.Broken]
+artifact = "Broken"
+EOF
+
+# Try to build with cannon (this should fail)
+# Capture both stdout and stderr
+set +e
+BUILD_OUTPUT=$($CANNON build 2>&1)
+BUILD_EXIT_CODE=$?
+set -e
+
+# Clean up
+cd /
+rm -rf "$TEST_DIR"
+
+echo "Actual output:"
+echo "$BUILD_OUTPUT"
+
+# Verify the build failed
+if [ $BUILD_EXIT_CODE -eq 0 ]; then
+  echo "ERROR: Build should have failed but succeeded"
+  exit 1
+fi
+
+# Verify that the output contains forge build failure message
+if ! echo "$BUILD_OUTPUT" | grep -q "forge build failed"; then
+  echo "ERROR: Output should contain 'forge build failed' message"
+  exit 1
+fi
+
+# Verify that the output contains stdout from forge
+if ! echo "$BUILD_OUTPUT" | grep -q "forge stdout:"; then
+  echo "ERROR: Output should contain 'forge stdout:' message"
+  exit 1
+fi
+
+# Verify that the output contains stderr from forge (should have compilation error)
+if ! echo "$BUILD_OUTPUT" | grep -q "forge stderr:"; then
+  echo "ERROR: Output should contain 'forge stderr:' message"
+  exit 1
+fi
+
+# Verify that the actual error message is present in stderr
+# Look for common forge compilation error indicators
+if ! echo "$BUILD_OUTPUT" | grep -qE "(Error|error|Compiler run failed|Failed to compile)"; then
+  echo "ERROR: Output should contain compilation error details"
+  exit 1
+fi
+
+echo "SUCCESS: Forge build failure is properly captured and displayed"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
     devDependencies:
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^4.0.0
-        version: 4.0.0(diumfqelppi5madcjcfo5wyvqq)
+        version: 4.0.0(4ef034ff627b366ebcbbe411d94ead71)
       hardhat:
         specifier: ^2.19.2
         version: 2.22.9(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -696,10 +696,6 @@ importers:
       unzipper:
         specifier: ^0.12.3
         version: 0.12.3
-    optionalDependencies:
-      redis-memory-server:
-        specifier: ^0.11.0
-        version: 0.11.0
     devDependencies:
       '@types/busboy':
         specifier: ^1.5.4
@@ -776,6 +772,10 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.8(@types/node@22.14.0)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(sass@1.86.3)(terser@5.39.0)
+    optionalDependencies:
+      redis-memory-server:
+        specifier: ^0.11.0
+        version: 0.11.0
 
   packages/safe-app-backend:
     dependencies:
@@ -819,6 +819,36 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.14.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+
+  packages/vscode:
+    devDependencies:
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
+      '@types/node':
+        specifier: 20.x
+        version: 20.19.22
+      '@types/vscode':
+        specifier: ^1.102.0
+        version: 1.105.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.31.1
+        version: 8.46.1(@typescript-eslint/parser@8.46.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.31.1
+        version: 8.46.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      '@vscode/test-cli':
+        specifier: ^0.0.11
+        version: 0.0.11
+      '@vscode/test-electron':
+        specifier: ^2.5.2
+        version: 2.5.2
+      eslint:
+        specifier: ^9.25.1
+        version: 9.38.0(jiti@1.21.7)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -2915,6 +2945,12 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.11.0':
     resolution: {integrity: sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -2923,13 +2959,41 @@ packages:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  '@eslint/config-array@0.21.1':
+    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.1':
+    resolution: {integrity: sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.16.0':
+    resolution: {integrity: sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/js@8.43.0':
     resolution: {integrity: sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/js@9.38.0':
+    resolution: {integrity: sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.0':
+    resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ethereumjs/common@2.5.0':
     resolution: {integrity: sha512-DEHjW6e38o+JmB/NO3GZBpW4lpaiBpkFgXF6jLcJ6gETBYpEyaA5nTimsWBUJR3Vmtm/didUEbNjajskugZORg==}
@@ -3152,6 +3216,14 @@ packages:
     peerDependencies:
       react-hook-form: ^7.0.0
 
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -3164,6 +3236,10 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@hutson/parse-repository-url@3.0.2':
     resolution: {integrity: sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==}
@@ -6558,6 +6634,9 @@ packages:
   '@types/node@18.15.13':
     resolution: {integrity: sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==}
 
+  '@types/node@20.19.22':
+    resolution: {integrity: sha512-hRnu+5qggKDSyWHlnmThnUqg62l29Aj/6vcYgUaSFL9oc7DVjeWEQN3PRgdSc6F8d9QRMWkf36CLMch1Do/+RQ==}
+
   '@types/node@22.14.0':
     resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
@@ -6705,6 +6784,9 @@ packages:
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
+  '@types/vscode@1.105.0':
+    resolution: {integrity: sha512-Lotk3CTFlGZN8ray4VxJE7axIyLZZETQJVWi/lYoUVQuqfRxlQhVOfoejsD2V3dVXPSbS15ov5ZyowMAzgUqcw==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -6739,6 +6821,14 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/eslint-plugin@8.46.1':
+    resolution: {integrity: sha512-rUsLh8PXmBjdiPY+Emjz9NX2yHvhS11v0SR6xNJkm5GM1MO9ea/1GoDKlHHZGrOJclL/cZ2i/vRUYVtjRhrHVQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.46.1
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/parser@5.62.0':
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -6756,6 +6846,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/parser@8.46.1':
+    resolution: {integrity: sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.46.1':
+    resolution: {integrity: sha512-FOIaFVMHzRskXr5J4Jp8lFVV0gz5ngv3RHmn+E4HYxSJ3DgDzU7fVI1/M7Ijh1zf6S7HIoaIOtln1H5y8V+9Zg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/scope-manager@5.62.0':
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -6763,6 +6866,16 @@ packages:
   '@typescript-eslint/scope-manager@8.29.0':
     resolution: {integrity: sha512-aO1PVsq7Gm+tcghabUpzEnVSFMCU4/nYIgC2GOatJcllvWfnhrgW0ZEbnTxm36QsikmCN1K/6ZgM7fok2I7xNw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.46.1':
+    resolution: {integrity: sha512-weL9Gg3/5F0pVQKiF8eOXFZp8emqWzZsOJuWRUNtHT+UNV2xSJegmpCNQHy37aEQIbToTq7RHKhWvOsmbM680A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.46.1':
+    resolution: {integrity: sha512-X88+J/CwFvlJB+mK09VFqx5FE4H5cXD+H/Bdza2aEWkSb8hnWIQorNcscRl4IEo1Cz9VI/+/r/jnGWkbWPx54g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/type-utils@5.62.0':
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
@@ -6781,12 +6894,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/type-utils@8.46.1':
+    resolution: {integrity: sha512-+BlmiHIiqufBxkVnOtFwjah/vrkF4MtKKvpXrKSPLCkCtAp8H01/VV43sfqA98Od7nJpDcFnkwgyfQbOG0AMvw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/types@5.62.0':
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@typescript-eslint/types@8.29.0':
     resolution: {integrity: sha512-wcJL/+cOXV+RE3gjCyl/V2G877+2faqvlgtso/ZRbTCnZazh0gXhe+7gbAnfubzN2bNsBtZjDvlh7ero8uIbzg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.46.1':
+    resolution: {integrity: sha512-C+soprGBHwWBdkDpbaRC4paGBrkIXxVlNohadL5o0kfhsXqOC6GYH2S/Obmig+I0HTDl8wMaRySwrfrXVP8/pQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@5.62.0':
@@ -6804,6 +6928,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/typescript-estree@8.46.1':
+    resolution: {integrity: sha512-uIifjT4s8cQKFQ8ZBXXyoUODtRoAd7F7+G8MKmtzj17+1UbdzFl52AzRyZRyKqPHhgzvXunnSckVu36flGy8cg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/utils@5.62.0':
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -6817,12 +6947,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/utils@8.46.1':
+    resolution: {integrity: sha512-vkYUy6LdZS7q1v/Gxb2Zs7zziuXN0wxqsetJdeZdRe/f5dwJFglmuvZBfTUivCtjH725C1jWCDfpadadD95EDQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/visitor-keys@5.62.0':
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@typescript-eslint/visitor-keys@8.29.0':
     resolution: {integrity: sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.46.1':
+    resolution: {integrity: sha512-ptkmIf2iDkNUjdeu2bQqhFPV1m6qTnFFjg7PPDjxKWaMaP0Z6I9l30Jr3g5QqbZGdw8YdYvLp+XnqnWWZOg/NA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/promise-all-settled@1.1.2':
@@ -7031,6 +7172,15 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vscode/test-cli@0.0.11':
+    resolution: {integrity: sha512-qO332yvzFqGhBMJrp6TdwbIydiHgCtxXc2Nl6M58mbH/Z+0CyLR76Jzv4YWPEthhrARprzCRJUqzFvTHFhTj7Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@vscode/test-electron@2.5.2':
+    resolution: {integrity: sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==}
+    engines: {node: '>=16'}
 
   '@wagmi/connectors@5.7.12':
     resolution: {integrity: sha512-pLFuZ1PsLkNyY11mx0+IOrMM7xACWCBRxaulfX17osqixkDFeOAyqFGBjh/XxkvRyrDJUdO4F+QHEeSoOiPpgg==}
@@ -7928,6 +8078,11 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  c8@9.1.0:
+    resolution: {integrity: sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==}
+    engines: {node: '>=14.14.0'}
+    hasBin: true
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -9147,6 +9302,10 @@ packages:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
 
+  diff@7.0.0:
+    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+    engines: {node: '>=0.3.1'}
+
   diffie-hellman@5.0.3:
     resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
 
@@ -9659,6 +9818,10 @@ packages:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9667,15 +9830,33 @@ packages:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint@8.43.0:
     resolution: {integrity: sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
+  eslint@9.38.0:
+    resolution: {integrity: sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   esniff@2.0.1:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -10057,6 +10238,10 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
 
@@ -10117,6 +10302,10 @@ packages:
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
 
   flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
@@ -10489,6 +10678,10 @@ packages:
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -10895,6 +11088,9 @@ packages:
   imagescript@1.3.0:
     resolution: {integrity: sha512-lCYzQrWzdnA68K03oMj/BUlBJrVBnslzDOgGFymAp49NmdGEJxGeN7sHh5mCva0nQkq+kkKSuru2zLf1m04+3A==}
     engines: {node: '>=14.0.0'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   immutable@4.3.7:
     resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
@@ -11768,6 +11964,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   just-debounce-it@1.1.0:
     resolution: {integrity: sha512-87Nnc0qZKgBZuhFZjYVjSraic0x7zwjhaTMrCKlj0QYKH6lh0KbFzVnfu6LHan03NO7J8ygjeBeD0epejn5Zcg==}
 
@@ -11879,6 +12078,9 @@ packages:
   libnpmpublish@9.0.9:
     resolution: {integrity: sha512-26zzwoBNAvX9AWOPiqqF6FG4HrSCPsHFkQm7nT+xU1ggAujL/eae81RnCv4CJ2In9q9fh10B88sYSzKCUh/Ghg==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -12779,6 +12981,11 @@ packages:
   mocha@10.8.2:
     resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
     engines: {node: '>= 14.0.0'}
+    hasBin: true
+
+  mocha@11.7.4:
+    resolution: {integrity: sha512-1jYAaY8x0kAZ0XszLWu14pzsf4KV740Gld4HXkhNTXwcHx4AUEDkPzgEHg9CM5dVcW+zv036tjpsEbLraPJj4w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
   mock-fs@4.14.0:
@@ -15221,6 +15428,10 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-color@9.4.0:
+    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
+    engines: {node: '>=12'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -16428,6 +16639,9 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  web-solc@0.5.1:
+    resolution: {integrity: sha512-Z/hBplZq1+4i4bYeIeD9N3vP1BLUBXpSDa4h0Ipm2Z2cHv7x7DtZ2zFb0E1L1VZo4BF+OJGVtGlT+nTUXGgncQ==}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -16819,6 +17033,9 @@ packages:
 
   workerpool@6.5.1:
     resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
+
+  workerpool@9.3.4:
+    resolution: {integrity: sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -19704,7 +19921,7 @@ snapshots:
       '@cucumber/ci-environment': 10.0.1
       '@cucumber/cucumber-expressions': 17.1.0
       '@cucumber/gherkin': 28.0.0
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@25.0.1))(@cucumber/messages@24.1.0)
       '@cucumber/gherkin-utils': 9.0.0
       '@cucumber/html-formatter': 21.6.0(@cucumber/messages@24.1.0)
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -19744,7 +19961,7 @@ snapshots:
       yaml: 2.7.1
       yup: 1.2.0
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@25.0.1))(@cucumber/messages@24.1.0)':
     dependencies:
       '@cucumber/gherkin': 28.0.0
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -20179,9 +20396,30 @@ snapshots:
       eslint: 8.43.0
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0(jiti@1.21.7))':
+    dependencies:
+      eslint: 9.38.0(jiti@1.21.7)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.11.0': {}
 
   '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/config-array@0.21.1':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.0(supports-color@8.1.1)
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.1':
+    dependencies:
+      '@eslint/core': 0.16.0
+
+  '@eslint/core@0.16.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
@@ -20197,7 +20435,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.0(supports-color@8.1.1)
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@8.43.0': {}
+
+  '@eslint/js@9.38.0': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.0':
+    dependencies:
+      '@eslint/core': 0.16.0
+      levn: 0.4.1
 
   '@ethereumjs/common@2.5.0':
     dependencies:
@@ -20703,6 +20964,13 @@ snapshots:
     dependencies:
       react-hook-form: 7.55.0(react@18.3.1)
 
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -20714,6 +20982,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@hutson/parse-repository-url@3.0.2': {}
 
@@ -21643,7 +21913,7 @@ snapshots:
       ethereumjs-util: 7.1.5
       hardhat: 2.22.9(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
 
-  '@nomicfoundation/hardhat-toolbox@4.0.0(diumfqelppi5madcjcfo5wyvqq)':
+  '@nomicfoundation/hardhat-toolbox@4.0.0(4ef034ff627b366ebcbbe411d94ead71)':
     dependencies:
       '@nomicfoundation/hardhat-chai-matchers': 2.0.7(@nomicfoundation/hardhat-ethers@3.0.7(ethers@6.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.22.9(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)))(chai@5.2.0)(ethers@6.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.22.9(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
       '@nomicfoundation/hardhat-ethers': 3.0.7(ethers@6.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.22.9(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
@@ -24933,6 +25203,10 @@ snapshots:
 
   '@types/node@18.15.13': {}
 
+  '@types/node@20.19.22':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.14.0':
     dependencies:
       undici-types: 6.21.0
@@ -25084,6 +25358,8 @@ snapshots:
 
   '@types/uuid@9.0.8': {}
 
+  '@types/vscode@1.105.0': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.14.0
@@ -25139,6 +25415,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.46.1(@typescript-eslint/parser@8.46.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.46.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.46.1
+      '@typescript-eslint/type-utils': 8.46.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.46.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.46.1
+      eslint: 9.38.0(jiti@1.21.7)
+      graphemer: 1.4.0
+      ignore: 7.0.4
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@5.62.0(eslint@8.43.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
@@ -25163,6 +25456,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.46.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.46.1
+      '@typescript-eslint/types': 8.46.1
+      '@typescript-eslint/typescript-estree': 8.46.1(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.46.1
+      debug: 4.4.0(supports-color@8.1.1)
+      eslint: 9.38.0(jiti@1.21.7)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.46.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.46.1(typescript@5.8.3)
+      '@typescript-eslint/types': 8.46.1
+      debug: 4.4.0(supports-color@8.1.1)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -25172,6 +25486,15 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.29.0
       '@typescript-eslint/visitor-keys': 8.29.0
+
+  '@typescript-eslint/scope-manager@8.46.1':
+    dependencies:
+      '@typescript-eslint/types': 8.46.1
+      '@typescript-eslint/visitor-keys': 8.46.1
+
+  '@typescript-eslint/tsconfig-utils@8.46.1(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
 
   '@typescript-eslint/type-utils@5.62.0(eslint@8.43.0)(typescript@5.8.3)':
     dependencies:
@@ -25196,9 +25519,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.46.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.46.1
+      '@typescript-eslint/typescript-estree': 8.46.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.46.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      debug: 4.4.0(supports-color@8.1.1)
+      eslint: 9.38.0(jiti@1.21.7)
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@5.62.0': {}
 
   '@typescript-eslint/types@8.29.0': {}
+
+  '@typescript-eslint/types@8.46.1': {}
 
   '@typescript-eslint/typescript-estree@5.62.0(typescript@5.8.3)':
     dependencies:
@@ -25218,6 +25555,22 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.29.0
       '@typescript-eslint/visitor-keys': 8.29.0
+      debug: 4.4.0(supports-color@8.1.1)
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.46.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.46.1(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.46.1(typescript@5.8.3)
+      '@typescript-eslint/types': 8.46.1
+      '@typescript-eslint/visitor-keys': 8.46.1
       debug: 4.4.0(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -25254,6 +25607,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.46.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@1.21.7))
+      '@typescript-eslint/scope-manager': 8.46.1
+      '@typescript-eslint/types': 8.46.1
+      '@typescript-eslint/typescript-estree': 8.46.1(typescript@5.8.3)
+      eslint: 9.38.0(jiti@1.21.7)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -25263,6 +25627,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.29.0
       eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.46.1':
+    dependencies:
+      '@typescript-eslint/types': 8.46.1
+      eslint-visitor-keys: 4.2.1
 
   '@ungap/promise-all-settled@1.1.2': {}
 
@@ -25434,7 +25803,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@usecannon/web-solc@0.5.1': {}
+  '@usecannon/web-solc@0.5.1':
+    dependencies:
+      web-solc: 0.5.1
 
   '@vanilla-extract/css@1.15.5(babel-plugin-macros@3.1.0)':
     dependencies:
@@ -25558,6 +25929,28 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.1.3
       tinyrainbow: 1.2.0
+
+  '@vscode/test-cli@0.0.11':
+    dependencies:
+      '@types/mocha': 10.0.10
+      c8: 9.1.0
+      chokidar: 3.6.0
+      enhanced-resolve: 5.18.1
+      glob: 10.4.5
+      minimatch: 9.0.5
+      mocha: 11.7.4
+      supports-color: 9.4.0
+      yargs: 17.7.2
+
+  '@vscode/test-electron@2.5.2':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      jszip: 3.10.1
+      ora: 8.2.0
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@wagmi/connectors@5.7.12(@types/react@18.2.37)(@wagmi/core@2.16.7(@tanstack/query-core@5.71.10)(@types/react@18.2.37)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@18.3.1))(viem@2.30.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.2)))(bufferutil@4.0.9)(encoding@0.1.13)(ioredis@5.6.0)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.30.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.2))(zod@3.24.2)':
     dependencies:
@@ -26132,6 +26525,10 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
       acorn: 8.14.1
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
 
   acorn-walk@8.3.4:
     dependencies:
@@ -26961,6 +27358,20 @@ snapshots:
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
+
+  c8@9.1.0:
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@istanbuljs/schema': 0.1.3
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.1.7
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.3.0
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
 
   cac@6.7.14: {}
 
@@ -28283,6 +28694,8 @@ snapshots:
 
   diff@5.2.0: {}
 
+  diff@7.0.0: {}
+
   diffie-hellman@5.0.3:
     dependencies:
       bn.js: 4.12.1
@@ -28771,7 +29184,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.14.1
+      acorn: 8.15.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
 
@@ -29078,9 +29491,16 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.0: {}
+
+  eslint-visitor-keys@4.2.1: {}
 
   eslint@8.43.0:
     dependencies:
@@ -29126,12 +29546,59 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint@9.38.0(jiti@1.21.7):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@1.21.7))
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.21.1
+      '@eslint/config-helpers': 0.4.1
+      '@eslint/core': 0.16.0
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.38.0
+      '@eslint/plugin-kit': 0.4.0
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.7
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.0(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 1.21.7
+    transitivePeerDependencies:
+      - supports-color
+
   esniff@2.0.1:
     dependencies:
       d: 1.0.2
       es5-ext: 0.10.64
       event-emitter: 0.3.5
       type: 2.7.3
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
@@ -29802,6 +30269,10 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   filelist@1.0.4:
     dependencies:
       minimatch: 5.1.6
@@ -29888,6 +30359,11 @@ snapshots:
       flatted: 3.3.3
       keyv: 4.5.4
       rimraf: 3.0.2
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
 
   flat@5.0.2: {}
 
@@ -30309,6 +30785,8 @@ snapshots:
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
+
+  globals@14.0.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -30991,6 +31469,8 @@ snapshots:
   ignore@7.0.4: {}
 
   imagescript@1.3.0: {}
+
+  immediate@3.0.6: {}
 
   immutable@4.3.7: {}
 
@@ -32117,6 +32597,13 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   just-debounce-it@1.1.0: {}
 
   just-diff-apply@5.5.0: {}
@@ -32348,6 +32835,10 @@ snapshots:
       ssri: 10.0.6
     transitivePeerDependencies:
       - supports-color
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@3.1.3: {}
 
@@ -33823,6 +34314,30 @@ snapshots:
       workerpool: 6.5.1
       yargs: 16.2.0
       yargs-parser: 20.2.9
+      yargs-unparser: 2.0.0
+
+  mocha@11.7.4:
+    dependencies:
+      browser-stdout: 1.3.1
+      chokidar: 4.0.3
+      debug: 4.4.0(supports-color@8.1.1)
+      diff: 7.0.0
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 10.4.5
+      he: 1.2.0
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      log-symbols: 4.1.0
+      minimatch: 9.0.5
+      ms: 2.1.3
+      picocolors: 1.1.1
+      serialize-javascript: 6.0.2
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      workerpool: 9.3.4
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
   mock-fs@4.14.0: {}
@@ -36907,6 +37422,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@9.4.0: {}
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   swarm-js@0.1.42(bufferutil@4.0.9)(utf-8-validate@5.0.10):
@@ -38244,6 +38761,10 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  web-solc@0.5.1:
+    dependencies:
+      semver: 7.7.1
+
   web-streams-polyfill@3.3.3: {}
 
   web3-bzz@1.10.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
@@ -39063,6 +39584,8 @@ snapshots:
   workerpool@6.2.1: {}
 
   workerpool@6.5.1: {}
+
+  workerpool@9.3.4: {}
 
   wrap-ansi@6.2.0:
     dependencies:


### PR DESCRIPTION
When forge outputs large amounts of data (verbose builds, many warnings),
the child process buffers would fill causing the process to block.

This fix actively consumes stdout/stderr streams and displays them
on build failure to improve debuggability.