### PR TITLE
fix(website): clear display when buttons are grayed out due to outsid…

### DIFF
--- a/packages/builder/src/trace.ts
+++ b/packages/builder/src/trace.ts
@@ -69,7 +69,9 @@ export function renderTraceEntry(ctx: ChainArtifacts, trace: TraceEntry): string
         (contractName || callTraceAction.to) +
         '.' +
         (parsedInput || callTraceAction.input) +
-        (BigInt(callTraceAction.value || '0') != BigInt(0) ? red(`{value:${viem.formatEther(BigInt(callTraceAction.value))}}`) : '') +
+        (BigInt(callTraceAction.value || '0') != BigInt(0)
+          ? red(`{value:${viem.formatEther(BigInt(callTraceAction.value))}}`)
+          : '') +
         (parsedOutput ? ' => ' + parsedOutput : '');
 
       str = actionStr + (contractName ? green(txStr) : txStr) + gasStr;

--- a/packages/website/src/features/Deploy/SafeTransactionsAndExecution.tsx
+++ b/packages/website/src/features/Deploy/SafeTransactionsAndExecution.tsx
@@ -42,7 +42,7 @@ interface Props {
 function calculateTotalGas(safeSteps: CannonTxRecord[] | undefined): bigint {
   return (safeSteps || []).reduce(
     (total, step) => total + BigInt(step.gas.toString()),
-    BigInt(0)
+    BigInt(0),
   );
 }
 
@@ -62,7 +62,7 @@ export function SafeTransactionsAndExecution({
   const gitHash = getGitHash(refsInfo.refs, gitInfo.gitRef);
   const prevInfoQuery = useGetPreviousGitInfoQuery(
     currentSafe,
-    gitInfo.gitUrl + ':' + gitInfo.gitFile
+    gitInfo.gitUrl + ':' + gitInfo.gitFile,
   );
   const [pickedNonce, setPickedNonce] = useState<number | null>(null);
   const multicallTxn = useMultisendTxsParams({
@@ -77,7 +77,8 @@ export function SafeTransactionsAndExecution({
   });
 
   const isOutsideSafeTxnsRequired =
-    (buildState.result?.deployerSteps.length || 0) > 0 && !deployer.isComplete;
+    (buildState.result?.deployerSteps.length || 0) > 0 &&
+    deployer.executionProgress.length < deployer.queuedTransactions.length;
 
   const stager = useTxnStager(
     multicallTxn?.data
@@ -98,7 +99,7 @@ export function SafeTransactionsAndExecution({
           duration: 5000,
         });
       },
-    }
+    },
   );
 
   const showPackage = cannonDefInfo && cannonDefInfo.def && multicallTxn?.data;
@@ -164,6 +165,14 @@ export function SafeTransactionsAndExecution({
           </AlertDescription>
         </Alert>
       )}
+      {isOutsideSafeTxnsRequired && (
+        <Alert variant="warning" className="mt-0 border-none">
+          <AlertDescription>
+            You must execute the Outside Safe Transactions before continuing
+            with the Safe deployment.
+          </AlertDescription>
+        </Alert>
+      )}
       {canExecute && (
         <div>
           <NoncePicker safe={currentSafe} handleChange={setPickedNonce} />
@@ -205,7 +214,7 @@ export function SafeTransactionsAndExecution({
                           'You successfully executed the transaction.',
                           {
                             duration: 5000,
-                          }
+                          },
                         );
                       },
                     });

--- a/packages/website/src/hooks/deployer.ts
+++ b/packages/website/src/hooks/deployer.ts
@@ -24,7 +24,13 @@ export function useDeployerWallet(chainId?: number) {
 
       (async () => {
         // is this the first transaction, or have we finished executing a transaction?
-        if ((isIdle && !executionProgress.length && queuedTransactions.length) || isConfirmed) {
+        if (
+          (isIdle &&
+            !executionProgress.length &&
+            queuedTransactions.length &&
+            queuedTransactions.length > executionProgress.length) ||
+          isConfirmed
+        ) {
           // ensure we are on the correct network
           await switchChainAsync({ chainId });
           // execute the next transaction
@@ -43,7 +49,7 @@ export function useDeployerWallet(chainId?: number) {
               onSuccess(hash: viem.Hash) {
                 setExecutionProgress([...executionProgress, hash]);
               },
-            }
+            },
           );
         }
       })()
@@ -55,7 +61,7 @@ export function useDeployerWallet(chainId?: number) {
           setError(err);
         });
     },
-    [isConfirmed, isIdle, executionProgress.length, queuedTransactions, chainId, executionProgress]
+    [isConfirmed, isIdle, executionProgress.length, queuedTransactions, chainId, executionProgress],
   );
 
   return {

--- a/packages/website/src/hooks/deployer.ts
+++ b/packages/website/src/hooks/deployer.ts
@@ -24,13 +24,7 @@ export function useDeployerWallet(chainId?: number) {
 
       (async () => {
         // is this the first transaction, or have we finished executing a transaction?
-        if (
-          (isIdle &&
-            !executionProgress.length &&
-            queuedTransactions.length &&
-            queuedTransactions.length > executionProgress.length) ||
-          isConfirmed
-        ) {
+        if ((isIdle && !executionProgress.length && executionProgress.length < queuedTransactions.length) || isConfirmed) {
           // ensure we are on the correct network
           await switchChainAsync({ chainId });
           // execute the next transaction

--- a/packages/website/src/hooks/deployer.ts
+++ b/packages/website/src/hooks/deployer.ts
@@ -49,7 +49,7 @@ export function useDeployerWallet(chainId?: number) {
               onSuccess(hash: viem.Hash) {
                 setExecutionProgress([...executionProgress, hash]);
               },
-            },
+            }
           );
         }
       })()
@@ -61,7 +61,7 @@ export function useDeployerWallet(chainId?: number) {
           setError(err);
         });
     },
-    [isConfirmed, isIdle, executionProgress.length, queuedTransactions, chainId, executionProgress],
+    [isConfirmed, isIdle, executionProgress.length, queuedTransactions, chainId, executionProgress]
   );
 
   return {

--- a/packages/website/src/hooks/deployer.ts
+++ b/packages/website/src/hooks/deployer.ts
@@ -24,7 +24,7 @@ export function useDeployerWallet(chainId?: number) {
 
       (async () => {
         // is this the first transaction, or have we finished executing a transaction?
-        if ((isIdle && !executionProgress.length && executionProgress.length < queuedTransactions.length) || isConfirmed) {
+        if ((isIdle && executionProgress.length < queuedTransactions.length) || isConfirmed) {
           // ensure we are on the correct network
           await switchChainAsync({ chainId });
           // execute the next transaction


### PR DESCRIPTION
its very confusing when outside safe transactions are grayed out and its unexplained why. This adds a needed error message that may indicate a failure to execute "Outside Safe Transactions" so that its clear the reason why its grayed out.

additionally, there is a logic change/simplification in the button change logic hwere we only unblock the button when there are "incomplete" trnasactions remaining (ie . `deployer.executionProgress.length < deployer.queuedTransactions.length`). This is intended, and is the more correct approach.