### PR TITLE
fix(builder): add additional input hash step

### DIFF
--- a/packages/builder/src/steps/router.ts
+++ b/packages/builder/src/steps/router.ts
@@ -65,6 +65,17 @@ const routerStep = {
           newConfig.create2,
         ],
       ],
+      [
+        contractAbis,
+        contractAddresses,
+        [
+          newConfig.salt,
+          newConfig.overrides,
+          newConfig.includeReceive,
+          newConfig.includeDiamondCompatibility,
+          newConfig.highlight,
+        ],
+      ],
       {
         contractAbis,
         contractAddresses,


### PR DESCRIPTION
a customer reported that excessive `router` steps were being executed due to `create2` option affecting the step upgrade match check for. To resolve this issue, we need to preserve the existing step match by preserving the original array item, rather than replacing it.