### PR TITLE
fix(builder): early return from `computeTemplateAccesses`

### DIFF
--- a/examples/sample-foundry-project/cannonfile.toml
+++ b/examples/sample-foundry-project/cannonfile.toml
@@ -1,6 +1,5 @@
-#:schema https://raw.githubusercontent.com/usecannon/cannon/refs/heads/dev/packages/lsp/src/schema.json
 name = "greeter-foundry"
-version = "1.2.3"
+version = "<%= package.version %>"
 description = "Simple project to verify the functionality of cannon"
 keywords = ["sample", "greeter"]
 
@@ -13,7 +12,6 @@ msg = "my library was deployed in txn <%= contracts.library.deployTxnHash %>"
 [deploy.library]
 artifact = "Library"
 value = "2929372"
-
 
 [deploy.greeter]
 artifact = "Greeter"

--- a/examples/sample-foundry-project/cannonfile.toml
+++ b/examples/sample-foundry-project/cannonfile.toml
@@ -1,5 +1,6 @@
+#:schema https://raw.githubusercontent.com/usecannon/cannon/refs/heads/dev/packages/lsp/src/schema.json
 name = "greeter-foundry"
-version = "<%= package.version %>"
+version = "1.2.3"
 description = "Simple project to verify the functionality of cannon"
 keywords = ["sample", "greeter"]
 
@@ -12,6 +13,7 @@ msg = "my library was deployed in txn <%= contracts.library.deployTxnHash %>"
 [deploy.library]
 artifact = "Library"
 value = "2929372"
+
 
 [deploy.greeter]
 artifact = "Greeter"

--- a/packages/builder/src/access-recorder.test.ts
+++ b/packages/builder/src/access-recorder.test.ts
@@ -1,51 +1,52 @@
-import { computeTemplateAccesses } from './access-recorder';
+import { AccessRecorderEngine } from './access-recorder';
 
 describe('access-recorder.ts', () => {
+  const engine = new AccessRecorderEngine([]);
   describe('computeTemplateAccesses()', () => {
     it('computes dependency with addition operation', () => {
-      expect(computeTemplateAccesses('<%= settings.value1 + settings.value2 %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= settings.value1 + settings.value2 %>')).toEqual({
         accesses: ['settings.value1', 'settings.value2'],
         unableToCompute: false,
       });
     });
 
     it('computes dependency with addition operation using extras', () => {
-      expect(computeTemplateAccesses('<%= extras.value1 + extras.value2 %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= extras.value1 + extras.value2 %>')).toEqual({
         accesses: ['extras.value1', 'extras.value2'],
         unableToCompute: false,
       });
     });
 
     it('computes dependency with usage of allowed global variables', () => {
-      expect(computeTemplateAccesses('<%= parseEther(String(0.3)) %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= parseEther(String(0.3)) %>')).toEqual({
         accesses: [],
         unableToCompute: false,
       });
     });
 
     it('computes simple addition', () => {
-      expect(computeTemplateAccesses('<%= 1 + 1 %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= 1 + 1 %>')).toEqual({
         accesses: [],
         unableToCompute: false,
       });
     });
 
     it('computes dependency with subtraction operation', () => {
-      expect(computeTemplateAccesses('<%= settings.value1 - settings.value2 %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= settings.value1 - settings.value2 %>')).toEqual({
         accesses: ['settings.value1', 'settings.value2'],
         unableToCompute: false,
       });
     });
 
     it('computes dependency with multiplication operation', () => {
-      expect(computeTemplateAccesses('<%= settings.value1 * settings.value2 %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= settings.value1 * settings.value2 %>')).toEqual({
         accesses: ['settings.value1', 'settings.value2'],
         unableToCompute: false,
       });
     });
 
     it('computes dependency with division operation', () => {
-      expect(computeTemplateAccesses('<%= settings.value1 / settings.value2 %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= settings.value1 / settings.value2 %>')).toEqual({
         accesses: ['settings.value1', 'settings.value2'],
         unableToCompute: false,
       });
@@ -53,7 +54,7 @@ describe('access-recorder.ts', () => {
 
     it('computes dependency with complex math operation', () => {
       expect(
-        computeTemplateAccesses('<%= (settings.value1 + settings.value2) * settings.value3 / settings.value4 %>')
+        engine.computeTemplateAccesses('<%= (settings.value1 + settings.value2) * settings.value3 / settings.value4 %>')
       ).toEqual({
         accesses: ['settings.value1', 'settings.value2', 'settings.value3', 'settings.value4'],
         unableToCompute: false,
@@ -61,14 +62,14 @@ describe('access-recorder.ts', () => {
     });
 
     it('computes multiple dependencies on different template tags', () => {
-      expect(computeTemplateAccesses('<%= settings.woot %>-<%= settings.woot2 %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= settings.woot %>-<%= settings.woot2 %>')).toEqual({
         accesses: ['settings.woot', 'settings.woot2'],
         unableToCompute: false,
       });
     });
 
     it('computes simple dependency', () => {
-      expect(computeTemplateAccesses('<%= settings.woot %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= settings.woot %>')).toEqual({
         accesses: ['settings.woot'],
         unableToCompute: false,
       });
@@ -76,7 +77,7 @@ describe('access-recorder.ts', () => {
 
     it('computes array dependency', () => {
       expect(
-        computeTemplateAccesses(
+        engine.computeTemplateAccesses(
           '["<%= settings.camelotSwapPublisherAdmin1 %>","<%= settings.camelotSwapPublisherAdmin2 %>"]'
         )
       ).toEqual({
@@ -86,7 +87,7 @@ describe('access-recorder.ts', () => {
     });
 
     it('computes dependency using simple CannonHelperContext', () => {
-      expect(computeTemplateAccesses('<%= parseEther(settings.woot) %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= parseEther(settings.woot) %>')).toEqual({
         accesses: ['settings.woot'],
         unableToCompute: false,
       });
@@ -94,7 +95,7 @@ describe('access-recorder.ts', () => {
 
     it('computes dependency using complex CannonHelperContext', () => {
       expect(
-        computeTemplateAccesses(
+        engine.computeTemplateAccesses(
           '<%= defaultAbiCoder.encode(parseEther(settings.woot)) %> + <%= defaultAbiCoder.decode(contracts.compound) %>'
         )
       ).toEqual({
@@ -106,28 +107,28 @@ describe('access-recorder.ts', () => {
 
   describe('computeTemplateAccesses() syntax validation', () => {
     it('handles invalid template syntax - unmatched brackets', () => {
-      expect(computeTemplateAccesses('<%= settings.value) %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= settings.value) %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('handles empty template tags', () => {
-      expect(computeTemplateAccesses('<%=%>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%=%>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('handles multiple template tags with mixed validity', () => {
-      expect(computeTemplateAccesses('<%= settings.valid %> and <% invalid.syntax')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= settings.valid %> and <% invalid.syntax')).toEqual({
         accesses: ['settings.valid'],
         unableToCompute: false,
       });
     });
 
     it('handles template with only whitespace', () => {
-      expect(computeTemplateAccesses('<%=   %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%=   %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
@@ -136,42 +137,42 @@ describe('access-recorder.ts', () => {
 
   describe('computeTemplateAccesses() security', () => {
     it('prevents direct code execution', () => {
-      expect(computeTemplateAccesses('<%= process.exit(1) %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= process.exit(1) %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('prevents access to global objects', () => {
-      expect(computeTemplateAccesses('<%= global.process %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= global.process %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('prevents require/import statements', () => {
-      expect(computeTemplateAccesses('<%= require("fs") %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= require("fs") %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('prevents eval usage', () => {
-      expect(computeTemplateAccesses('<%= eval("console.log(\'REKT\')") %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= eval("console.log(\'REKT\')") %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('prevents Function constructor usage', () => {
-      expect(computeTemplateAccesses('<%= new Function("return process")() %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= new Function("return process")() %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
     });
 
     it('prevents setTimeout/setInterval usage', () => {
-      expect(computeTemplateAccesses('<%= setTimeout(() => {}, 1000) %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= setTimeout(() => {}, 1000) %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });
@@ -179,7 +180,7 @@ describe('access-recorder.ts', () => {
 
     it('prevents overriding console.log', () => {
       expect(
-        computeTemplateAccesses('<%= console.log=function(n){require("fs").writeFileSync("./exploit.log",n)} %>')
+        engine.computeTemplateAccesses('<%= console.log=function(n){require("fs").writeFileSync("./exploit.log",n)} %>')
       ).toEqual({
         accesses: [],
         unableToCompute: true,
@@ -187,7 +188,7 @@ describe('access-recorder.ts', () => {
     });
 
     it('prevents assignment of values', () => {
-      expect(computeTemplateAccesses('<%= const value = 1 + 2 %>')).toEqual({
+      expect(engine.computeTemplateAccesses('<%= const value = 1 + 2 %>')).toEqual({
         accesses: [],
         unableToCompute: true,
       });

--- a/packages/builder/src/access-recorder.ts
+++ b/packages/builder/src/access-recorder.ts
@@ -12,7 +12,7 @@ class ExtendableProxy {
   constructor(defaultValue?: any) {
     return new Proxy(this, {
       get: (obj: any, prop: string) => {
-        if (prop === 'accessed' || prop === 'getAccesses') {
+        if (prop === 'accessed' || prop === 'getAccesses' || prop === 'clearAccesses') {
           return obj[prop];
         }
         if (!this.accessed.has(prop)) {
@@ -52,13 +52,17 @@ export class AccessRecorder extends ExtendableProxy {
 
     return acc;
   }
+
+  clearAccesses() {
+    this.accessed.clear();
+  }
 }
 
 export type AccessComputationResult = { accesses: string[]; unableToCompute: boolean };
 
 type AccessRecorderMap = { [k: string]: AccessRecorder };
 
-type TemplateContext = {
+export type TemplateContext = {
   [k: string]: AccessRecorder | AccessRecorderMap | unknown;
 };
 
@@ -67,7 +71,7 @@ type TemplateContext = {
  * @param possibleNames - The possible names to setup the context for
  * @returns The template context
  */
-function setupTemplateContext(possibleNames: string[] = []): TemplateContext {
+export function setupTemplateContext(possibleNames: string[] = []): TemplateContext {
   // Create a fake helper context, so the render works but no real functions are called
   const fakeHelperContext = _createDeepNoopObject(CannonHelperContext);
 
@@ -85,7 +89,7 @@ function setupTemplateContext(possibleNames: string[] = []): TemplateContext {
     imports: new AccessRecorder(),
     extras: new AccessRecorder(),
     txns: new AccessRecorder(),
-    // For settings, we give it a zeroAddress as a best case scenarion that is going
+    // For settings, we give it a zeroAddress as a best case scenario that is going
     // to be working for most cases.
     // e.g., when calculating a setting value for 'settings.owners.split(',')' or 'settings.someNumber' will work.
     settings: new AccessRecorder(viem.zeroAddress),
@@ -137,30 +141,44 @@ function collectAccesses(recorders: TemplateContext, possibleNames: string[]): s
   return accesses;
 }
 
-/**
- * Compute the accesses from the template.
- * @param str - The template to compute accesses from
- * @param possibleNames - The possible names to compute accesses from
- * @returns The accesses
- */
-export function computeTemplateAccesses(str?: string, possibleNames: string[] = []): AccessComputationResult {
-  // here we have an early return if there are no templates in the string at all-this saves a huge amount of compute.
-  if (!str || !str.includes('<%=')) {
-    return { accesses: [], unableToCompute: false };
+export class AccessRecorderEngine {
+  readonly possibleNames: string[] = [];
+  readonly templateContext: TemplateContext;
+
+  constructor(possibleNames: string[]) {
+    this.possibleNames = possibleNames;
+    this.templateContext = setupTemplateContext(possibleNames);
   }
 
-  const recorders = setupTemplateContext(possibleNames);
+  /**
+   * Compute the accesses from the template.
+   * @param str - The template to compute accesses from
+   * @param possibleNames - The possible names to compute accesses from
+   * @returns The accesses
+   */
+  computeTemplateAccesses(str?: string): AccessComputationResult {
+    // here we have an early return if there are no templates in the string at all-this saves a huge amount of compute.
+    if (!str || !str.includes('<%=')) {
+      return { accesses: [], unableToCompute: false };
+    }
 
-  try {
-    // we give it "true" for safeContext to avoid cloning and freezing of the object
-    // this is because we want to keep the access recorder, and is not a security risk
-    // if the user can modify that object
-    template(str, recorders, true);
-    const accesses = collectAccesses(recorders, possibleNames);
-    return { accesses, unableToCompute: false };
-  } catch (err) {
-    debug('Template execution failed:', err);
-    return { accesses: [], unableToCompute: true };
+    for (const r in this.templateContext) {
+      if (this.templateContext[r] instanceof AccessRecorder) {
+        this.templateContext[r].clearAccesses();
+      }
+    }
+
+    try {
+      // we give it "true" for safeContext to avoid cloning and freezing of the object
+      // this is because we want to keep the access recorder, and is not a security risk
+      // if the user can modify that object
+      template(str, this.templateContext, true);
+      const accesses = collectAccesses(this.templateContext, this.possibleNames);
+      return { accesses, unableToCompute: false };
+    } catch (err) {
+      debug('Template execution failed:', err);
+      return { accesses: [], unableToCompute: true };
+    }
   }
 }
 

--- a/packages/builder/src/access-recorder.ts
+++ b/packages/builder/src/access-recorder.ts
@@ -144,7 +144,8 @@ function collectAccesses(recorders: TemplateContext, possibleNames: string[]): s
  * @returns The accesses
  */
 export function computeTemplateAccesses(str?: string, possibleNames: string[] = []): AccessComputationResult {
-  if (!str) {
+  // here we have an early return if there are no templates in the string at all-this saves a huge amount of compute.
+  if (!str || !str.includes('<%=')) {
     return { accesses: [], unableToCompute: false };
   }
 

--- a/packages/builder/src/actions.ts
+++ b/packages/builder/src/actions.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { AccessComputationResult } from './access-recorder';
+import { AccessComputationResult, AccessRecorderEngine } from './access-recorder';
 import { handleZodErrors } from './error/zod';
 import { ChainBuilderRuntime } from './runtime';
 import { chainDefinitionSchema } from './schemas';
@@ -33,7 +33,7 @@ export interface CannonAction<Config extends RawConfig = any> {
   /**
    * Returns a list of state keys that this operation consumes (used for dependency inference)
    */
-  getInputs?: (config: Config, possibleFields: string[], packageState: PackageState) => AccessComputationResult;
+  getInputs?: (config: Config, engine: AccessRecorderEngine, packageState: PackageState) => AccessComputationResult;
 
   /**
    * Returns a list of state keys this operation produces (used for dependency inference)

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -73,6 +73,8 @@ export class ChainDefinition {
   readonly dependencyFor = new Map<string, string>();
   readonly resolvedDependencies = new Map<string, string[]>();
 
+  readonly templatePossibleNames: string[] = [];
+
   readonly danglingDependencies = new Set<`${string}:${string}`>();
 
   constructor(def: RawChainDefinition, sensitiveDependencies = false) {
@@ -254,20 +256,7 @@ export class ChainDefinition {
     }
 
     if (ActionKinds[n].getInputs) {
-      const possibleFields: string[] = [];
-      for (const k of this.dependencyFor.keys()) {
-        const baseName = k.split('.')[0];
-        if (
-          baseName !== 'contracts' &&
-          baseName !== 'imports' &&
-          baseName !== 'settings' &&
-          baseName !== 'extras' &&
-          baseName !== 'txns'
-        ) {
-          possibleFields.push(baseName);
-        }
-      }
-      const accessComputationResults = ActionKinds[n].getInputs!(_.get(this.raw, node), possibleFields, {
+      const accessComputationResults = ActionKinds[n].getInputs!(_.get(this.raw, node), this.templatePossibleNames, {
         ref: null,
         currentLabel: node,
       });
@@ -449,10 +438,27 @@ export class ChainDefinition {
             outputClashes.push({ output, actions: [this.dependencyFor.get(output)!, fullActionName] });
           }
         }
+
+        this.computePossibleNames();
       }
     }
 
     return outputClashes;
+  }
+
+  computePossibleNames() {
+    for (const k of this.dependencyFor.keys()) {
+      const baseName = k.split('.')[0];
+      if (
+        baseName !== 'contracts' &&
+        baseName !== 'imports' &&
+        baseName !== 'settings' &&
+        baseName !== 'extras' &&
+        baseName !== 'txns'
+      ) {
+        this.templatePossibleNames.push(baseName);
+      }
+    }
   }
 
   /**

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -74,7 +74,7 @@ export class ChainDefinition {
   readonly dependencyFor = new Map<string, string>();
   readonly resolvedDependencies = new Map<string, string[]>();
 
-  accessRecorderEngine: AccessRecorderEngine|null = null;
+  accessRecorderEngine: AccessRecorderEngine | null = null;
 
   readonly danglingDependencies = new Set<`${string}:${string}`>();
 
@@ -233,6 +233,10 @@ export class ChainDefinition {
    * @returns direct dependencies for the specified node
    */
   computeDependencies(node: string) {
+    if (!this.accessRecorderEngine) {
+      this.computePossibleNames();
+    }
+
     if (!_.get(this.raw, node)) {
       const stepName = node.split('.')[0];
       const possibleSteps = _.get(this.raw, stepName);
@@ -448,6 +452,10 @@ export class ChainDefinition {
   }
 
   computePossibleNames() {
+    if (this.dependencyFor.size == 0) {
+      this.checkOutputClash();
+    }
+
     const possibleNames = [];
     for (const k of this.dependencyFor.keys()) {
       const baseName = k.split('.')[0];

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -452,7 +452,7 @@ export class ChainDefinition {
   }
 
   computePossibleNames() {
-    if (this.dependencyFor.size == 0) {
+    if (this.allActionNames.length > 0 && this.dependencyFor.size == 0) {
       this.checkOutputClash();
     }
 

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -10,7 +10,7 @@ import { template } from './utils/template';
 
 import { PackageReference } from './package-reference';
 import { ZodIssue } from 'zod';
-import { AccessRecorderEngine } from '.';
+import { AccessRecorderEngine } from './access-recorder';
 
 const debug = Debug('cannon:builder:definition');
 const debugVerbose = Debug('cannon:verbose:builder:definition');

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -10,6 +10,7 @@ import { template } from './utils/template';
 
 import { PackageReference } from './package-reference';
 import { ZodIssue } from 'zod';
+import { AccessRecorderEngine } from '.';
 
 const debug = Debug('cannon:builder:definition');
 const debugVerbose = Debug('cannon:verbose:builder:definition');
@@ -73,7 +74,7 @@ export class ChainDefinition {
   readonly dependencyFor = new Map<string, string>();
   readonly resolvedDependencies = new Map<string, string[]>();
 
-  readonly templatePossibleNames: string[] = [];
+  accessRecorderEngine: AccessRecorderEngine|null = null;
 
   readonly danglingDependencies = new Set<`${string}:${string}`>();
 
@@ -256,7 +257,7 @@ export class ChainDefinition {
     }
 
     if (ActionKinds[n].getInputs) {
-      const accessComputationResults = ActionKinds[n].getInputs!(_.get(this.raw, node), this.templatePossibleNames, {
+      const accessComputationResults = ActionKinds[n].getInputs!(_.get(this.raw, node), this.accessRecorderEngine!, {
         ref: null,
         currentLabel: node,
       });
@@ -447,6 +448,7 @@ export class ChainDefinition {
   }
 
   computePossibleNames() {
+    const possibleNames = [];
     for (const k of this.dependencyFor.keys()) {
       const baseName = k.split('.')[0];
       if (
@@ -456,9 +458,11 @@ export class ChainDefinition {
         baseName !== 'extras' &&
         baseName !== 'txns'
       ) {
-        this.templatePossibleNames.push(baseName);
+        possibleNames.push(baseName);
       }
     }
+
+    this.accessRecorderEngine = new AccessRecorderEngine(possibleNames);
   }
 
   /**

--- a/packages/builder/src/definition.ts
+++ b/packages/builder/src/definition.ts
@@ -443,10 +443,10 @@ export class ChainDefinition {
             outputClashes.push({ output, actions: [this.dependencyFor.get(output)!, fullActionName] });
           }
         }
-
-        this.computePossibleNames();
       }
     }
+
+    this.computePossibleNames();
 
     return outputClashes;
   }

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -6,7 +6,7 @@ if (!Object.prototype.hasOwnProperty.call(BigInt.prototype, 'toJSON')) {
 }
 
 export { createInitialContext, build, getArtifacts, addOutputsToContext, getOutputs } from './builder';
-export { computeTemplateAccesses, mergeTemplateAccesses } from './access-recorder';
+export { mergeTemplateAccesses } from './access-recorder';
 export { registerAction, ActionKinds } from './actions';
 export type { CannonAction, RawChainDefinition } from './actions';
 export { ChainDefinition } from './definition';

--- a/packages/builder/src/steps/clone.test.ts
+++ b/packages/builder/src/steps/clone.test.ts
@@ -5,6 +5,7 @@ import action from './clone';
 import deployAction from './deploy';
 import { fakeCtx, fakeRuntime } from './utils.test.helper';
 import { PackageReference } from '../package-reference';
+import { AccessRecorderEngine } from '..';
 
 jest.mock('../loader');
 jest.mock('./deploy');
@@ -60,7 +61,7 @@ describe('steps/clone.ts', () => {
             var: { woot: '<%= settings.b %>', wah: '<%= settings.c %>' },
             options: { woot: '<%= settings.d %>', wah: '<%= settings.e %>', tags: '<%= settings.f %>' },
           },
-          []
+          new AccessRecorderEngine([])
         )
       ).toEqual({
         accesses: ['settings.a', 'settings.b', 'settings.c', 'settings.d', 'settings.e', 'settings.f'],

--- a/packages/builder/src/steps/clone.ts
+++ b/packages/builder/src/steps/clone.ts
@@ -88,17 +88,11 @@ const cloneSpec = {
     }
 
     if (config.options) {
-      _.forEach(
-        config.options,
-        (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(a)))
-      );
+      _.forEach(config.options, (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(a))));
     }
 
     if (config.tags) {
-      _.forEach(
-        config.tags,
-        (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(a)))
-      );
+      _.forEach(config.tags, (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(a))));
     }
 
     return accesses;

--- a/packages/builder/src/steps/clone.ts
+++ b/packages/builder/src/steps/clone.ts
@@ -3,7 +3,7 @@ import Debug from 'debug';
 import _ from 'lodash';
 import { z } from 'zod';
 import pkg from '../../package.json';
-import { computeTemplateAccesses, mergeTemplateAccesses } from '../access-recorder';
+import { mergeTemplateAccesses } from '../access-recorder';
 import { build, createInitialContext, getOutputs } from '../builder';
 import { CANNON_CHAIN_ID } from '../constants';
 import { ChainDefinition } from '../definition';
@@ -77,27 +77,27 @@ const cloneSpec = {
     return config;
   },
 
-  getInputs(config, possibleFields) {
-    let accesses = computeTemplateAccesses(config.source);
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.target, possibleFields));
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.sourcePreset, possibleFields));
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.targetPreset, possibleFields));
+  getInputs(config, engine) {
+    let accesses = engine.computeTemplateAccesses(config.source);
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.target));
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.sourcePreset));
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.targetPreset));
 
     if (config.var) {
-      _.forEach(config.var, (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(a, possibleFields))));
+      _.forEach(config.var, (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(a))));
     }
 
     if (config.options) {
       _.forEach(
         config.options,
-        (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(a, possibleFields)))
+        (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(a)))
       );
     }
 
     if (config.tags) {
       _.forEach(
         config.tags,
-        (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(a, possibleFields)))
+        (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(a)))
       );
     }
 

--- a/packages/builder/src/steps/deploy.test.ts
+++ b/packages/builder/src/steps/deploy.test.ts
@@ -5,6 +5,7 @@ import { ContractArtifact } from '../types';
 import action from './deploy';
 import { fakeCtx, fakeRuntime, makeFakeSigner } from './utils.test.helper';
 import { PackageReference } from '../package-reference';
+import { AccessRecorderEngine } from '..';
 
 const DEFAULT_ARACHNID_ADDRESS = '0x4e59b44847b379578588920cA78FbF26c0B4956C';
 
@@ -159,7 +160,7 @@ describe('steps/deploy.ts', () => {
               args: ['<%= contracts.h %>', '<%= contracts.i %>'],
               salt: '<%= contracts.j %>',
             },
-            []
+            new AccessRecorderEngine([])
           )
           .accesses.sort()
       ).toEqual([

--- a/packages/builder/src/steps/deploy.ts
+++ b/packages/builder/src/steps/deploy.ts
@@ -204,10 +204,7 @@ const deploySpec = {
     accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.salt));
 
     if (config.abiOf) {
-      _.forEach(
-        config.abiOf,
-        (v) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(v)))
-      );
+      _.forEach(config.abiOf, (v) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(v))));
     }
 
     if (config.args) {
@@ -218,10 +215,7 @@ const deploySpec = {
     }
 
     if (config.libraries) {
-      _.forEach(
-        config.libraries,
-        (v) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(v)))
-      );
+      _.forEach(config.libraries, (v) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(v))));
     }
 
     if (config?.overrides?.gasLimit) {

--- a/packages/builder/src/steps/deploy.ts
+++ b/packages/builder/src/steps/deploy.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import _ from 'lodash';
 import * as viem from 'viem';
 import { z } from 'zod';
-import { computeTemplateAccesses, mergeTemplateAccesses } from '../access-recorder';
+import { mergeTemplateAccesses } from '../access-recorder';
 import { ARACHNID_DEFAULT_DEPLOY_ADDR, ensureArachnidCreate2Exists, makeArachnidCreate2Txn } from '../create2';
 import { CannonError, handleTxnError } from '../error';
 import { deploySchema } from '../schemas';
@@ -195,37 +195,37 @@ const deploySpec = {
     return config;
   },
 
-  getInputs(config, possibleFields) {
-    let accesses = computeTemplateAccesses(config.from);
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.nonce, possibleFields));
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.artifact, possibleFields));
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.value, possibleFields));
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.abi, possibleFields));
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.salt, possibleFields));
+  getInputs(config, engine) {
+    let accesses = engine.computeTemplateAccesses(config.from);
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.nonce));
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.artifact));
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.value));
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.abi));
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.salt));
 
     if (config.abiOf) {
       _.forEach(
         config.abiOf,
-        (v) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(v, possibleFields)))
+        (v) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(v)))
       );
     }
 
     if (config.args) {
       _.forEach(
         config.args,
-        (v) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(JSON.stringify(v), possibleFields)))
+        (v) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(JSON.stringify(v))))
       );
     }
 
     if (config.libraries) {
       _.forEach(
         config.libraries,
-        (v) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(v, possibleFields)))
+        (v) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(v)))
       );
     }
 
     if (config?.overrides?.gasLimit) {
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.overrides.gasLimit, possibleFields));
+      accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.overrides.gasLimit));
     }
 
     return accesses;

--- a/packages/builder/src/steps/diamond.ts
+++ b/packages/builder/src/steps/diamond.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import * as viem from 'viem';
 import { z } from 'zod';
 import { ARACHNID_DEFAULT_DEPLOY_ADDR, ensureArachnidCreate2Exists, makeArachnidCreate2Txn } from '../create2';
-import { computeTemplateAccesses, mergeTemplateAccesses } from '../access-recorder';
+import { mergeTemplateAccesses } from '../access-recorder';
 import { ChainBuilderRuntime } from '../runtime';
 import { diamondSchema } from '../schemas';
 import { ContractArtifact, ContractMap, PackageState } from '../types';
@@ -94,23 +94,23 @@ const diamondStep = {
     return config;
   },
 
-  getInputs(config, possibleFields) {
-    let accesses = computeTemplateAccesses(config.diamondArgs.owner, possibleFields);
+  getInputs(config, engine) {
+    let accesses = engine.computeTemplateAccesses(config.diamondArgs.owner);
     if (config.diamondArgs.init) {
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.diamondArgs.init, possibleFields));
+      accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.diamondArgs.init));
     }
 
     if (config.diamondArgs.initCalldata) {
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.diamondArgs.initCalldata, possibleFields));
+      accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.diamondArgs.initCalldata));
     }
 
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.salt, possibleFields));
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.salt));
     accesses.accesses.push(
       ...config.contracts.map((c) => (c.includes('.') ? `imports.${c.split('.')[0]}` : `contracts.${c}`))
     );
 
     if (config?.overrides) {
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.overrides.gasLimit, possibleFields));
+      accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.overrides.gasLimit));
     }
 
     return accesses;

--- a/packages/builder/src/steps/invoke.test.ts
+++ b/packages/builder/src/steps/invoke.test.ts
@@ -3,6 +3,7 @@ import { validateConfig } from '../actions';
 import action from './invoke';
 import { fakeCtx, fakeRuntime } from './utils.test.helper';
 import { PackageReference } from '../package-reference';
+import { AccessRecorderEngine } from '..';
 
 describe('steps/invoke.ts', () => {
   const fakeContractInfo = {
@@ -174,7 +175,7 @@ describe('steps/invoke.ts', () => {
               args: ['<%= contracts.h %>', '<%= contracts.i %>'],
               overrides: { gasLimit: '<%= contracts.j %>' },
             },
-            []
+            new AccessRecorderEngine([])
           )
           .accesses.sort()
       ).toEqual([

--- a/packages/builder/src/steps/invoke.ts
+++ b/packages/builder/src/steps/invoke.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import _ from 'lodash';
 import * as viem from 'viem';
 import { z } from 'zod';
-import { computeTemplateAccesses, mergeTemplateAccesses } from '../access-recorder';
+import { mergeTemplateAccesses } from '../access-recorder';
 import { invokeSchema } from '../schemas';
 import {
   CannonSigner,
@@ -440,11 +440,11 @@ const invokeSpec = {
     return config;
   },
 
-  getInputs(config, possibleFields) {
-    let accesses = computeTemplateAccesses(config.abi, possibleFields);
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.func, possibleFields));
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.from, possibleFields));
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.value, possibleFields));
+  getInputs(config, engine) {
+    let accesses = engine.computeTemplateAccesses(config.abi);
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.func));
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.from));
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.value));
 
     if (typeof config.target === 'string') {
       config.target = [config.target as string];
@@ -460,7 +460,7 @@ const invokeSpec = {
         accesses.accesses.push(`imports.${(target as string).split('.')[0]}`);
       } else if (isTemplateString(target)) {
         for (const match of getTemplateMatches(target)) {
-          accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(match, possibleFields));
+          accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(match));
         }
       }
     }
@@ -468,37 +468,37 @@ const invokeSpec = {
     if (config.args) {
       _.forEach(
         config.args,
-        (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(JSON.stringify(a), possibleFields)))
+        (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(JSON.stringify(a))))
       );
     }
 
     if (config.fromCall) {
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.fromCall.func, possibleFields));
+      accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.fromCall.func));
 
       _.forEach(
         config.fromCall.args,
-        (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(JSON.stringify(a), possibleFields)))
+        (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(JSON.stringify(a))))
       );
     }
 
     if (config?.overrides) {
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.overrides.gasLimit, possibleFields));
+      accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.overrides.gasLimit));
     }
 
     for (const name in config.factory) {
       const f = config.factory[name];
 
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(f.event, possibleFields));
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(f.artifact, possibleFields));
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(f.abi, possibleFields));
+      accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(f.event));
+      accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(f.artifact));
+      accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(f.abi));
 
-      _.forEach(f.abiOf, (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(a, possibleFields))));
+      _.forEach(f.abiOf, (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(a))));
     }
 
     const varsConfig = config.var || config.extra;
     for (const name in varsConfig) {
       const f = varsConfig[name];
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(f.event, possibleFields));
+      accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(f.event));
     }
 
     return accesses;

--- a/packages/builder/src/steps/pull.ts
+++ b/packages/builder/src/steps/pull.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import _ from 'lodash';
 import { z } from 'zod';
 import { Events } from '../runtime';
-import { computeTemplateAccesses, mergeTemplateAccesses } from '../access-recorder';
+import { mergeTemplateAccesses } from '../access-recorder';
 import { getOutputs } from '../builder';
 import { ChainDefinition } from '../definition';
 import { PackageReference } from '../package-reference';
@@ -59,9 +59,9 @@ const pullSpec = {
     return config;
   },
 
-  getInputs(config, possibleFields) {
-    let accesses = computeTemplateAccesses(config.source, possibleFields);
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.preset, possibleFields));
+  getInputs(config, engine) {
+    let accesses = engine.computeTemplateAccesses(config.source);
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.preset));
 
     return accesses;
   },

--- a/packages/builder/src/steps/router.ts
+++ b/packages/builder/src/steps/router.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { generateRouter } from '@usecannon/router';
 import { ARACHNID_DEFAULT_DEPLOY_ADDR, ensureArachnidCreate2Exists, makeArachnidCreate2Txn } from '../create2';
 import { CannonError } from '../error';
-import { computeTemplateAccesses, mergeTemplateAccesses } from '../access-recorder';
+import { mergeTemplateAccesses } from '../access-recorder';
 import { routerSchema } from '../schemas';
 import { ContractMap } from '../types';
 import {
@@ -125,19 +125,19 @@ const routerStep = {
     return config;
   },
 
-  getInputs(config, possibleFields) {
-    let accesses = computeTemplateAccesses(config.from);
-    accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.salt, possibleFields));
+  getInputs(config, engine) {
+    let accesses = engine.computeTemplateAccesses(config.from);
+    accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.salt));
     accesses = mergeTemplateAccesses(
       accesses,
-      computeTemplateAccesses(typeof config.create2 === 'string' ? config.create2 : '', possibleFields)
+      engine.computeTemplateAccesses(typeof config.create2 === 'string' ? config.create2 : '')
     );
     accesses.accesses.push(
       ...config.contracts.map((c) => (c.includes('.') ? `imports.${c.split('.')[0]}` : `contracts.${c}`))
     );
 
     if (config?.overrides) {
-      accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(config.overrides.gasLimit, possibleFields));
+      accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(config.overrides.gasLimit));
     }
 
     return accesses;

--- a/packages/builder/src/steps/var.ts
+++ b/packages/builder/src/steps/var.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug';
 import _ from 'lodash';
 import { z } from 'zod';
-import { computeTemplateAccesses, mergeTemplateAccesses } from '../access-recorder';
+import { mergeTemplateAccesses } from '../access-recorder';
 import { varSchema } from '../schemas';
 import { template } from '../utils/template';
 import { CannonAction } from '../actions';
@@ -42,11 +42,11 @@ const varSpec = {
     return config;
   },
 
-  getInputs(config, possibleFields) {
-    let accesses = computeTemplateAccesses('', possibleFields);
+  getInputs(config, engine) {
+    let accesses = engine.computeTemplateAccesses('');
 
     for (const c in _.omit(config, 'depends')) {
-      const fields = computeTemplateAccesses(config[c], possibleFields);
+      const fields = engine.computeTemplateAccesses(config[c]);
       accesses = mergeTemplateAccesses(accesses, fields);
     }
 

--- a/packages/cli/src/custom-steps/run.ts
+++ b/packages/cli/src/custom-steps/run.ts
@@ -1,10 +1,10 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import {
+    AccessRecorderEngine,
   ChainArtifacts,
   ChainBuilderContext,
   ChainBuilderRuntimeInfo,
-  computeTemplateAccesses,
   mergeTemplateAccesses,
   PackageState,
   registerAction,
@@ -137,12 +137,12 @@ const runAction = {
     return config;
   },
 
-  getInputs(config: Config) {
-    let accesses = computeTemplateAccesses(config.exec);
+  getInputs(config: Config, engine: AccessRecorderEngine) {
+    let accesses = engine.computeTemplateAccesses(config.exec);
 
-    _.forEach(config.modified, (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(a))));
-    _.forEach(config.args, (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(a))));
-    _.forEach(config.env, (a) => (accesses = mergeTemplateAccesses(accesses, computeTemplateAccesses(a))));
+    _.forEach(config.modified, (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(a))));
+    _.forEach(config.args, (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(a))));
+    _.forEach(config.env, (a) => (accesses = mergeTemplateAccesses(accesses, engine.computeTemplateAccesses(a))));
 
     return accesses;
   },

--- a/packages/cli/src/custom-steps/run.ts
+++ b/packages/cli/src/custom-steps/run.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import {
-    AccessRecorderEngine,
+  AccessRecorderEngine,
   ChainArtifacts,
   ChainBuilderContext,
   ChainBuilderRuntimeInfo,


### PR DESCRIPTION
one of our users indicated that the website deployer was processing the cannonfile extremely slowly.

it turns out that `computeTemplateAccesses`  will use a huge amount of compute to process template accesses, even for strings that have no template usage at all. so to prevent this from being expensive, in most cases we can early return by just doing a simple string check.