### PR TITLE
fix(cli): viair does not work properly with `cannon verify`

### DIFF
--- a/packages/cli/src/foundry.ts
+++ b/packages/cli/src/foundry.ts
@@ -1,9 +1,9 @@
-import path from 'path';
+import { ContractArtifact } from '@usecannon/builder';
+import Debug from 'debug';
 import fs from 'fs-extra';
 import { glob } from 'glob';
-import { ContractArtifact } from '@usecannon/builder';
 import _ from 'lodash';
-import Debug from 'debug';
+import path from 'path';
 
 import { execPromise } from './helpers';
 import { warn } from './util/console';
@@ -121,6 +121,7 @@ export async function getFoundryArtifact(name: string, baseDir = '', includeSour
         language: 'Solidity',
         sources,
         settings: {
+          ...artifact.metadata.settings,
           optimizer: artifact.metadata.settings.optimizer,
           evmVersion: evmVersionInfo,
           remappings: artifact.metadata.settings.remappings,


### PR DESCRIPTION
needs to save the additional compilation option. For safety, save all options.

in order to make sure any potential future new compilation settings are covered, spread syntax is used in addition to the processing we do now.