### PR TITLE
fix(builder): deploy `importExisting` was not properly handling create2 contracts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@ packages/hardhat-cannon/dist
 packages/website/out
 typechain-types
 typechain
+artifacts

--- a/packages/builder/src/steps/deploy.test.ts
+++ b/packages/builder/src/steps/deploy.test.ts
@@ -424,4 +424,99 @@ describe('steps/deploy.ts', () => {
       });
     });
   });
+
+  describe('importExisting', () => {
+    it('throws if more than one existing key supplied', async () => {
+      await expect(() =>
+        action.importExisting(fakeRuntime, fakeCtx, {} as any, { currentLabel: 'foo' } as any, ['one', 'two'])
+      ).rejects.toThrow('can only be deployed on one transaction');
+    });
+
+    it('works for normal contract creation', async () => {
+      const rx = fixtureTransactionReceipt();
+      const tx = {
+        hash: rx.transactionHash,
+        blockNumber: 1234,
+      };
+
+      jest.mocked(fakeRuntime.provider.getTransaction).mockResolvedValue(tx as any);
+      jest.mocked(fakeRuntime.provider.getTransactionReceipt).mockResolvedValue(rx);
+      jest.mocked(fakeRuntime.provider.getBlock).mockResolvedValue({ timestamp: 1234123412 } as any);
+
+      const result = await action.importExisting(
+        fakeRuntime,
+        fakeCtx,
+        { artifact: 'hello' } as any,
+        { currentLabel: 'contract.Woot' } as any,
+        [rx.transactionHash]
+      );
+
+      expect(result).toMatchObject({
+        contracts: {
+          Woot: {
+            address: rx.contractAddress,
+            deployTxnHash: rx.transactionHash,
+          },
+        },
+      });
+    });
+
+    it('works for create2 contract creation', async () => {
+      const rx = fixtureTransactionReceipt({ contractAddress: null });
+      const tx = {
+        hash: rx.transactionHash,
+        blockNumber: 1234,
+        to: '0x1234567890123456789012345678901234567890',
+        input: viem.concat([viem.zeroHash, '0x1234']),
+      };
+
+      jest.mocked(fakeRuntime.provider.getTransaction).mockResolvedValue(tx as any);
+      jest.mocked(fakeRuntime.provider.getTransactionReceipt).mockResolvedValue(rx);
+      jest.mocked(fakeRuntime.provider.getBlock).mockResolvedValue({ timestamp: 1234123412 } as any);
+
+      // calculate expected address
+      const expectedAddress = viem.getContractAddress({
+        opcode: 'CREATE2',
+        from: tx.to as any,
+        salt: viem.zeroHash,
+        bytecode: '0x1234',
+      });
+
+      const result = await action.importExisting(
+        fakeRuntime,
+        fakeCtx,
+        { artifact: 'hello' } as any,
+        { currentLabel: 'contract.Woot' } as any,
+        [rx.transactionHash]
+      );
+
+      expect(result).toMatchObject({
+        contracts: {
+          Woot: {
+            address: expectedAddress,
+            deployTxnHash: rx.transactionHash,
+          },
+        },
+      });
+    });
+
+    it('throws if transaction not a contract creation', async () => {
+      const rx = fixtureTransactionReceipt({ contractAddress: null });
+      const tx = {
+        hash: rx.transactionHash,
+        blockNumber: 1234,
+        to: '0x1234567890123456789012345678901234567890',
+        input: '0x',
+      };
+
+      jest.mocked(fakeRuntime.provider.getTransaction).mockResolvedValue(tx as any);
+      jest.mocked(fakeRuntime.provider.getTransactionReceipt).mockResolvedValue(rx);
+
+      await expect(() =>
+        action.importExisting(fakeRuntime, fakeCtx, { artifact: 'hello' } as any, { currentLabel: 'contract.Woot' } as any, [
+          rx.transactionHash,
+        ])
+      ).rejects.toThrow('does not appear to deploy a contract');
+    });
+  });
 });

--- a/packages/builder/src/steps/deploy.ts
+++ b/packages/builder/src/steps/deploy.ts
@@ -432,12 +432,13 @@ const deploySpec = {
     const receipt = await runtime.provider.getTransactionReceipt({ hash: existingKeys[0] as viem.Hash });
 
     // We need to compute from the import data
-    console.log('the input txn data', txn, receipt);
     let contractAddress;
+    // In the case that the contract address is given in the transaction receipt: It was a create (1) transaction
     if (receipt.contractAddress) {
       contractAddress = receipt.contractAddress;
+      // in the case that the contract address is *NOT* given, its CREATE2 through arachnid (or, not a contract creation transaction at all).
     } else if (txn.to && txn.input && txn.input.length > 66) {
-      // Note: the `from` address is actually the `to` address because the contract we call is what is actually imported
+      // Note: the `from` address is actually the `to` address here because this function wants the address of the contract executing the deployment of the contract
       contractAddress = viem.getContractAddress({
         opcode: 'CREATE2',
         from: txn.to,

--- a/packages/builder/src/steps/deploy.ts
+++ b/packages/builder/src/steps/deploy.ts
@@ -121,7 +121,7 @@ function generateOutputs(
         deployedOn: currentLabel!,
         highlight: config.highlight,
         gasUsed: Number(deployTxn?.gasUsed) || 0,
-        gasCost: deployTxn?.effectiveGasPrice.toString() || '0',
+        gasCost: deployTxn?.effectiveGasPrice?.toString() || '0',
       },
     },
   };
@@ -428,19 +428,29 @@ const deploySpec = {
 
     const artifactData = await runtime.getArtifact!(config.artifact);
 
-    const txn = await runtime.provider.getTransactionReceipt({ hash: existingKeys[0] as viem.Hash });
+    const txn = await runtime.provider.getTransaction({ hash: existingKeys[0] as viem.Hash });
+    const receipt = await runtime.provider.getTransactionReceipt({ hash: existingKeys[0] as viem.Hash });
 
-    // When a CREATE2 contract is deployed, it doesnt output the contractAddress property.
-    // However the txn will emit events from the deployed contract address which can be found in the txn logs
-    const contractAddress = config.create2 ? txn.logs[0].address : txn.contractAddress;
-
-    if (!viem.isAddress(contractAddress as string)) {
-      throw new Error('imported txn does not appear to deploy a contract');
+    // We need to compute from the import data
+    console.log('the input txn data', txn, receipt);
+    let contractAddress;
+    if (receipt.contractAddress) {
+      contractAddress = receipt.contractAddress;
+    } else if (txn.to && txn.input && txn.input.length > 66) {
+      // Note: the `from` address is actually the `to` address because the contract we call is what is actually imported
+      contractAddress = viem.getContractAddress({
+        opcode: 'CREATE2',
+        from: txn.to,
+        salt: viem.sliceHex(txn.input, 0, 32),
+        bytecode: viem.sliceHex(txn.input, 32),
+      });
+    } else {
+      throw new Error('The transaction hash you provided does not appear to deploy a contract');
     }
 
     const block = await runtime.provider.getBlock({ blockNumber: txn?.blockNumber });
 
-    return generateOutputs(config, ctx, artifactData, txn, block, contractAddress!, packageState.currentLabel);
+    return generateOutputs(config, ctx, artifactData, receipt, block, contractAddress!, packageState.currentLabel);
   },
 } satisfies CannonAction<Config>;
 


### PR DESCRIPTION


This prevents using `cannon alter import` command with create2 contracts