### PR TITLE
feat(cli): add --ipfs-superfluous flag to clean command

### DIFF
--- a/packages/cli/src/commands/clean.test.ts
+++ b/packages/cli/src/commands/clean.test.ts
@@ -1,4 +1,4 @@
-import { clean, cleanSuperfluousIpfs, CleanIpfsStats } from './clean';
+import { clean, cleanOrphanedIpfs, CleanIpfsStats } from './clean';
 import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import prompts from 'prompts';
@@ -62,7 +62,7 @@ describe('clean function', () => {
   });
 });
 
-describe('cleanSuperfluousIpfs function', () => {
+describe('cleanOrphanedIpfs function', () => {
   let consoleLogSpy: jest.SpyInstance;
 
   beforeEach(() => {
@@ -74,7 +74,7 @@ describe('cleanSuperfluousIpfs function', () => {
     jest.resetAllMocks();
   });
 
-  it('should return success with no deletions when no superfluous files exist', async () => {
+  it('should return success with no deletions when no orphaned files exist', async () => {
     // Mock tags directory with one tag
     (existsSync as jest.Mock).mockImplementation((path: string) => {
       if (path.includes('tags')) return true;
@@ -115,18 +115,13 @@ describe('cleanSuperfluousIpfs function', () => {
       return Promise.resolve('') as any;
     });
 
-    // Mock cache file stat
-    jest.spyOn(fs, 'stat').mockImplementation(() => 
-      Promise.resolve({ size: 1000 } as any)
-    );
-
-    const result = await cleanSuperfluousIpfs(false);
+    const result = await cleanOrphanedIpfs(false);
     
     expect(result.success).toBe(true);
-    expect(result.stats.superfluousFiles).toBe(0);
+    expect(result.stats.orphanedFiles).toBe(0);
   });
 
-  it('should identify and delete superfluous IPFS files', async () => {
+  it('should identify and delete orphaned IPFS files', async () => {
     (existsSync as jest.Mock).mockReturnValue(true);
 
     // @ts-ignore
@@ -136,7 +131,7 @@ describe('cleanSuperfluousIpfs function', () => {
       }
       if (dir.includes('ipfs_cache')) {
         // ipfs://QmXyz -> 58cd78e4d20301f9456940b3f1a735b5-qmxyz.json (referenced)
-        // ipfs://QmAbc -> d7195b608c408f59397fc013eba8fef4-qmabc.json (superfluous)
+        // ipfs://QmAbc -> d7195b608c408f59397fc013eba8fef4-qmabc.json (orphaned)
         return Promise.resolve([
           '58cd78e4d20301f9456940b3f1a735b5-qmxyz.json',
           'd7195b608c408f59397fc013eba8fef4-qmabc.json',
@@ -158,21 +153,15 @@ describe('cleanSuperfluousIpfs function', () => {
       return Promise.resolve('') as any;
     });
 
-    // Mock cache file stat
-    jest.spyOn(fs, 'stat').mockImplementation(() => 
-      Promise.resolve({ size: 1000 } as any)
-    );
-
     // Mock unlink
     jest.spyOn(fs, 'unlink').mockImplementation(() => Promise.resolve());
 
-    const result = await cleanSuperfluousIpfs(false);
+    const result = await cleanOrphanedIpfs(false);
     
     expect(result.success).toBe(true);
     expect(result.stats.totalFiles).toBe(2);
-    expect(result.stats.superfluousFiles).toBe(1);
+    expect(result.stats.orphanedFiles).toBe(1);
     expect(result.stats.deletedFiles).toBe(1);
-    expect(result.stats.freedBytes).toBe(1000);
   });
 
   it('should not delete files when user cancels confirmation', async () => {
@@ -185,7 +174,7 @@ describe('cleanSuperfluousIpfs function', () => {
         return Promise.resolve(['package_1.0.0_1-main.txt']);
       }
       if (dir.includes('ipfs_cache')) {
-        // Only superfluous file: ipfs://QmAbc
+        // Only orphaned file: ipfs://QmAbc
         return Promise.resolve(['d7195b608c408f59397fc013eba8fef4-qmabc.json']);
       }
       return Promise.resolve([]);
@@ -203,18 +192,13 @@ describe('cleanSuperfluousIpfs function', () => {
       return Promise.resolve('') as any;
     });
 
-    jest.spyOn(fs, 'stat').mockImplementation(() => 
-      Promise.resolve({ size: 1000 } as any)
-    );
-
     const unlinkSpy = jest.spyOn(fs, 'unlink').mockImplementation(() => Promise.resolve());
 
-    const result = await cleanSuperfluousIpfs(true);
+    const result = await cleanOrphanedIpfs(true);
     
     expect(result.success).toBe(false);
     expect(unlinkSpy).not.toHaveBeenCalled();
   });
-});
 
   it('should preserve second-order IPFS dependencies', async () => {
     (existsSync as jest.Mock).mockReturnValue(true);
@@ -279,20 +263,16 @@ describe('cleanSuperfluousIpfs function', () => {
       return Promise.resolve('') as any;
     });
 
-    jest.spyOn(fs, 'stat').mockImplementation(() => 
-      Promise.resolve({ size: 500 } as any)
-    );
-
     jest.spyOn(fs, 'unlink').mockImplementation(() => Promise.resolve());
 
-    const result = await cleanSuperfluousIpfs(false);
+    const result = await cleanOrphanedIpfs(false);
     
     expect(result.success).toBe(true);
     expect(result.stats.totalFiles).toBe(4);
     // QmRoot (direct), QmNested (second-order), QmDeep (third-order) = 3 referenced
     expect(result.stats.referencedFiles).toBe(3);
-    // Only QmOrphan should be superfluous
-    expect(result.stats.superfluousFiles).toBe(1);
+    // Only QmOrphan should be orphaned
+    expect(result.stats.orphanedFiles).toBe(1);
     expect(result.stats.deletedFiles).toBe(1);
   });
 });

--- a/packages/cli/src/commands/clean.test.ts
+++ b/packages/cli/src/commands/clean.test.ts
@@ -1,4 +1,4 @@
-import { clean } from './clean';
+import { clean, cleanSuperfluousIpfs, CleanIpfsStats } from './clean';
 import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import prompts from 'prompts';
@@ -59,5 +59,147 @@ describe('clean function', () => {
     expect(result).toBe(false);
     expect(fs.readdir).toHaveBeenCalled();
     expect(fs.rm).not.toHaveBeenCalled();
+  });
+});
+
+describe('cleanSuperfluousIpfs function', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log');
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    jest.resetAllMocks();
+  });
+
+  it('should return success with no deletions when no superfluous files exist', async () => {
+    // Mock tags directory with one tag
+    (existsSync as jest.Mock).mockImplementation((path: string) => {
+      if (path.includes('tags')) return true;
+      if (path.includes('ipfs_cache')) return true;
+      return false;
+    });
+
+    // @ts-ignore
+    jest.spyOn(fs, 'readdir').mockImplementation((dir: string) => {
+      if (dir.includes('tags')) {
+        return Promise.resolve(['package_1.0.0_1-main.txt', 'package_1.0.0_1-main.txt.meta']);
+      }
+      if (dir.includes('ipfs_cache')) {
+        // Return files that match the tag's IPFS URLs
+        // ipfs://QmXyz -> 58cd78e4d20301f9456940b3f1a735b5-qmxyz.json
+        // ipfs://QmMeta -> 1cdfa4521e3d781a0da1a3d3ff4eeece-qmmeta.json
+        return Promise.resolve([
+          '58cd78e4d20301f9456940b3f1a735b5-qmxyz.json',
+          '1cdfa4521e3d781a0da1a3d3ff4eeece-qmmeta.json',
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    // Mock tag file contents
+    jest.spyOn(fs, 'readFile').mockImplementation((path: any) => {
+      const pathStr = path.toString();
+      if (pathStr.includes('.txt') && !pathStr.includes('.meta')) {
+        return Promise.resolve('ipfs://QmXyz') as any;
+      }
+      if (pathStr.includes('.meta')) {
+        return Promise.resolve('ipfs://QmMeta') as any;
+      }
+      return Promise.resolve('') as any;
+    });
+
+    // Mock cache file stat
+    jest.spyOn(fs, 'stat').mockImplementation(() => 
+      Promise.resolve({ size: 1000 } as any)
+    );
+
+    const result = await cleanSuperfluousIpfs(false);
+    
+    expect(result.success).toBe(true);
+    expect(result.stats.superfluousFiles).toBe(0);
+  });
+
+  it('should identify and delete superfluous IPFS files', async () => {
+    (existsSync as jest.Mock).mockReturnValue(true);
+
+    // @ts-ignore
+    jest.spyOn(fs, 'readdir').mockImplementation((dir: string) => {
+      if (dir.includes('tags')) {
+        return Promise.resolve(['package_1.0.0_1-main.txt']);
+      }
+      if (dir.includes('ipfs_cache')) {
+        // ipfs://QmXyz -> 58cd78e4d20301f9456940b3f1a735b5-qmxyz.json (referenced)
+        // ipfs://QmAbc -> d7195b608c408f59397fc013eba8fef4-qmabc.json (superfluous)
+        return Promise.resolve([
+          '58cd78e4d20301f9456940b3f1a735b5-qmxyz.json',
+          'd7195b608c408f59397fc013eba8fef4-qmabc.json',
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    // Mock tag file contents
+    jest.spyOn(fs, 'readFile').mockImplementation((path: any) => {
+      const pathStr = path.toString();
+      if (pathStr.includes('.txt')) {
+        return Promise.resolve('ipfs://QmXyz') as any;
+      }
+      return Promise.resolve('') as any;
+    });
+
+    // Mock cache file stat
+    jest.spyOn(fs, 'stat').mockImplementation(() => 
+      Promise.resolve({ size: 1000 } as any)
+    );
+
+    // Mock unlink
+    jest.spyOn(fs, 'unlink').mockImplementation(() => Promise.resolve());
+
+    const result = await cleanSuperfluousIpfs(false);
+    
+    expect(result.success).toBe(true);
+    expect(result.stats.totalFiles).toBe(2);
+    expect(result.stats.superfluousFiles).toBe(1);
+    expect(result.stats.deletedFiles).toBe(1);
+    expect(result.stats.freedBytes).toBe(1000);
+  });
+
+  it('should not delete files when user cancels confirmation', async () => {
+    (existsSync as jest.Mock).mockReturnValue(true);
+    (prompts as unknown as jest.Mock).mockResolvedValue({ value: false });
+
+    // @ts-ignore
+    jest.spyOn(fs, 'readdir').mockImplementation((dir: string) => {
+      if (dir.includes('tags')) {
+        return Promise.resolve(['package_1.0.0_1-main.txt']);
+      }
+      if (dir.includes('ipfs_cache')) {
+        // Only superfluous file: ipfs://QmAbc
+        return Promise.resolve(['d7195b608c408f59397fc013eba8fef4-qmabc.json']);
+      }
+      return Promise.resolve([]);
+    });
+
+    jest.spyOn(fs, 'readFile').mockImplementation((path: any) => {
+      const pathStr = path.toString();
+      if (pathStr.includes('.txt')) {
+        return Promise.resolve('ipfs://QmXyz') as any;
+      }
+      return Promise.resolve('') as any;
+    });
+
+    jest.spyOn(fs, 'stat').mockImplementation(() => 
+      Promise.resolve({ size: 1000 } as any)
+    );
+
+    const unlinkSpy = jest.spyOn(fs, 'unlink').mockImplementation(() => Promise.resolve());
+
+    const result = await cleanSuperfluousIpfs(true);
+    
+    expect(result.success).toBe(false);
+    expect(unlinkSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/clean.test.ts
+++ b/packages/cli/src/commands/clean.test.ts
@@ -1,4 +1,4 @@
-import { clean, cleanOrphanedIpfs, CleanIpfsStats } from './clean';
+import { clean, cleanOrphanedIpfs } from './clean';
 import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import prompts from 'prompts';
@@ -116,7 +116,7 @@ describe('cleanOrphanedIpfs function', () => {
     });
 
     const result = await cleanOrphanedIpfs(false);
-    
+
     expect(result.success).toBe(true);
     expect(result.stats.orphanedFiles).toBe(0);
   });
@@ -157,7 +157,7 @@ describe('cleanOrphanedIpfs function', () => {
     jest.spyOn(fs, 'unlink').mockImplementation(() => Promise.resolve());
 
     const result = await cleanOrphanedIpfs(false);
-    
+
     expect(result.success).toBe(true);
     expect(result.stats.totalFiles).toBe(2);
     expect(result.stats.orphanedFiles).toBe(1);
@@ -195,7 +195,7 @@ describe('cleanOrphanedIpfs function', () => {
     const unlinkSpy = jest.spyOn(fs, 'unlink').mockImplementation(() => Promise.resolve());
 
     const result = await cleanOrphanedIpfs(true);
-    
+
     expect(result.success).toBe(false);
     expect(unlinkSpy).not.toHaveBeenCalled();
   });
@@ -210,6 +210,7 @@ describe('cleanOrphanedIpfs function', () => {
     // - ipfs://QmOrphan is not referenced by anything
     // All of QmRoot, QmNested, QmDeep should be kept; QmOrphan should be deleted
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const crypto = require('crypto');
     const hashOf = (cid: string) => {
       const md5 = crypto.createHash('md5').update(cid.toLowerCase()).digest('hex');
@@ -227,12 +228,7 @@ describe('cleanOrphanedIpfs function', () => {
         return Promise.resolve(['package_1.0.0_1-main.txt']);
       }
       if (dir.includes('ipfs_cache')) {
-        return Promise.resolve([
-          `${rootHash}.json`,
-          `${nestedHash}.json`,
-          `${deepHash}.json`,
-          `${orphanHash}.json`,
-        ]);
+        return Promise.resolve([`${rootHash}.json`, `${nestedHash}.json`, `${deepHash}.json`, `${orphanHash}.json`]);
       }
       return Promise.resolve([]);
     });
@@ -245,14 +241,18 @@ describe('cleanOrphanedIpfs function', () => {
       }
       // Cache files with nested IPFS references
       if (pathStr.includes(rootHash)) {
-        return Promise.resolve(JSON.stringify({
-          state: { "deploy.Contract": { url: "ipfs://QmNested" } }
-        })) as any;
+        return Promise.resolve(
+          JSON.stringify({
+            state: { 'deploy.Contract': { url: 'ipfs://QmNested' } },
+          })
+        ) as any;
       }
       if (pathStr.includes(nestedHash)) {
-        return Promise.resolve(JSON.stringify({
-          state: { "deploy.Sub": { metaUrl: "ipfs://QmDeep" } }
-        })) as any;
+        return Promise.resolve(
+          JSON.stringify({
+            state: { 'deploy.Sub': { metaUrl: 'ipfs://QmDeep' } },
+          })
+        ) as any;
       }
       if (pathStr.includes(deepHash)) {
         return Promise.resolve(JSON.stringify({ state: {} })) as any;
@@ -266,7 +266,7 @@ describe('cleanOrphanedIpfs function', () => {
     jest.spyOn(fs, 'unlink').mockImplementation(() => Promise.resolve());
 
     const result = await cleanOrphanedIpfs(false);
-    
+
     expect(result.success).toBe(true);
     expect(result.stats.totalFiles).toBe(4);
     // QmRoot (direct), QmNested (second-order), QmDeep (third-order) = 3 referenced

--- a/packages/cli/src/commands/clean.test.ts
+++ b/packages/cli/src/commands/clean.test.ts
@@ -99,7 +99,7 @@ describe('cleanSuperfluousIpfs function', () => {
       return Promise.resolve([]);
     });
 
-    // Mock tag file contents
+    // Mock tag file contents and cache file contents
     jest.spyOn(fs, 'readFile').mockImplementation((path: any) => {
       const pathStr = path.toString();
       if (pathStr.includes('.txt') && !pathStr.includes('.meta')) {
@@ -107,6 +107,10 @@ describe('cleanSuperfluousIpfs function', () => {
       }
       if (pathStr.includes('.meta')) {
         return Promise.resolve('ipfs://QmMeta') as any;
+      }
+      // Cache files - return JSON without nested IPFS URLs
+      if (pathStr.includes('ipfs_cache')) {
+        return Promise.resolve('{"state": {}}') as any;
       }
       return Promise.resolve('') as any;
     });
@@ -141,11 +145,15 @@ describe('cleanSuperfluousIpfs function', () => {
       return Promise.resolve([]);
     });
 
-    // Mock tag file contents
+    // Mock tag file contents and cache file contents
     jest.spyOn(fs, 'readFile').mockImplementation((path: any) => {
       const pathStr = path.toString();
       if (pathStr.includes('.txt')) {
         return Promise.resolve('ipfs://QmXyz') as any;
+      }
+      // Cache files - no nested IPFS URLs
+      if (pathStr.includes('ipfs_cache')) {
+        return Promise.resolve('{"state": {}}') as any;
       }
       return Promise.resolve('') as any;
     });
@@ -188,6 +196,10 @@ describe('cleanSuperfluousIpfs function', () => {
       if (pathStr.includes('.txt')) {
         return Promise.resolve('ipfs://QmXyz') as any;
       }
+      // Cache files - no nested IPFS URLs
+      if (pathStr.includes('ipfs_cache')) {
+        return Promise.resolve('{"state": {}}') as any;
+      }
       return Promise.resolve('') as any;
     });
 
@@ -201,5 +213,86 @@ describe('cleanSuperfluousIpfs function', () => {
     
     expect(result.success).toBe(false);
     expect(unlinkSpy).not.toHaveBeenCalled();
+  });
+});
+
+  it('should preserve second-order IPFS dependencies', async () => {
+    (existsSync as jest.Mock).mockReturnValue(true);
+
+    // We have:
+    // - Tag references ipfs://QmRoot
+    // - QmRoot's cache file contains a reference to ipfs://QmNested
+    // - QmNested's cache file contains a reference to ipfs://QmDeep
+    // - ipfs://QmOrphan is not referenced by anything
+    // All of QmRoot, QmNested, QmDeep should be kept; QmOrphan should be deleted
+
+    const crypto = require('crypto');
+    const hashOf = (cid: string) => {
+      const md5 = crypto.createHash('md5').update(cid.toLowerCase()).digest('hex');
+      return `${md5}-${cid.toLowerCase()}`;
+    };
+
+    const rootHash = hashOf('QmRoot');
+    const nestedHash = hashOf('QmNested');
+    const deepHash = hashOf('QmDeep');
+    const orphanHash = hashOf('QmOrphan');
+
+    // @ts-ignore
+    jest.spyOn(fs, 'readdir').mockImplementation((dir: string) => {
+      if (dir.includes('tags')) {
+        return Promise.resolve(['package_1.0.0_1-main.txt']);
+      }
+      if (dir.includes('ipfs_cache')) {
+        return Promise.resolve([
+          `${rootHash}.json`,
+          `${nestedHash}.json`,
+          `${deepHash}.json`,
+          `${orphanHash}.json`,
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    jest.spyOn(fs, 'readFile').mockImplementation((filePath: any) => {
+      const pathStr = filePath.toString();
+      // Tag file
+      if (pathStr.includes('.txt')) {
+        return Promise.resolve('ipfs://QmRoot') as any;
+      }
+      // Cache files with nested IPFS references
+      if (pathStr.includes(rootHash)) {
+        return Promise.resolve(JSON.stringify({
+          state: { "deploy.Contract": { url: "ipfs://QmNested" } }
+        })) as any;
+      }
+      if (pathStr.includes(nestedHash)) {
+        return Promise.resolve(JSON.stringify({
+          state: { "deploy.Sub": { metaUrl: "ipfs://QmDeep" } }
+        })) as any;
+      }
+      if (pathStr.includes(deepHash)) {
+        return Promise.resolve(JSON.stringify({ state: {} })) as any;
+      }
+      if (pathStr.includes(orphanHash)) {
+        return Promise.resolve(JSON.stringify({ state: {} })) as any;
+      }
+      return Promise.resolve('') as any;
+    });
+
+    jest.spyOn(fs, 'stat').mockImplementation(() => 
+      Promise.resolve({ size: 500 } as any)
+    );
+
+    jest.spyOn(fs, 'unlink').mockImplementation(() => Promise.resolve());
+
+    const result = await cleanSuperfluousIpfs(false);
+    
+    expect(result.success).toBe(true);
+    expect(result.stats.totalFiles).toBe(4);
+    // QmRoot (direct), QmNested (second-order), QmDeep (third-order) = 3 referenced
+    expect(result.stats.referencedFiles).toBe(3);
+    // Only QmOrphan should be superfluous
+    expect(result.stats.superfluousFiles).toBe(1);
+    expect(result.stats.deletedFiles).toBe(1);
   });
 });

--- a/packages/cli/src/commands/clean.test.ts
+++ b/packages/cli/src/commands/clean.test.ts
@@ -213,7 +213,7 @@ describe('cleanOrphanedIpfs function', () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const crypto = require('crypto');
     const hashOf = (cid: string) => {
-      const md5 = crypto.createHash('md5').update(cid.toLowerCase()).digest('hex');
+      const md5 = crypto.createHash('md5').update(cid).digest('hex');
       return `${md5}-${cid.toLowerCase()}`;
     };
 

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -1,13 +1,13 @@
 import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import crypto from 'crypto';
 import Debug from 'debug';
 import prompts from 'prompts';
 
 import { log } from '../util/console';
 import { resolveCliSettings } from '../settings';
 import { IPFSLoader } from '@usecannon/builder';
+import { CliLoader } from '../loader';
 
 const debug = Debug('cannon:cli:clean');
 
@@ -65,16 +65,6 @@ export async function clean(confirm = true) {
 }
 
 /**
- * Get the cache file path for an IPFS URL
- * Matches the logic in CliLoader.getCacheHash
- */
-function getCacheHash(url: string): string {
-  const qmhash = url.replace(IPFSLoader.PREFIX, '');
-  const md5 = crypto.createHash('md5').update(qmhash).digest('hex');
-  return `${md5}-${qmhash.toLowerCase()}`;
-}
-
-/**
  * Read all tag files and extract referenced IPFS URLs
  */
 async function getReferencedIpfsUrls(tagsDir: string): Promise<Set<string>> {
@@ -129,7 +119,7 @@ async function resolveIpfsDependencies(rootUrls: Set<string>, ipfsCacheDir: stri
 
   while (queue.length > 0) {
     const url = queue.pop()!;
-    const cacheHash = getCacheHash(url);
+    const cacheHash = CliLoader.getCacheHash(url);
     const cacheFile = path.join(ipfsCacheDir, `${cacheHash}.json`);
 
     try {
@@ -167,16 +157,15 @@ async function getIpfsCacheFiles(ipfsCacheDir: string): Promise<string[]> {
 export interface CleanIpfsStats {
   totalFiles: number;
   referencedFiles: number;
-  superfluousFiles: number;
+  orphanedFiles: number;
   deletedFiles: number;
   failedFiles: number;
-  freedBytes: number;
 }
 
 /**
- * Clean superfluous IPFS packages (packages not referenced by any tag)
+ * Clean orphaned IPFS packages (packages not referenced by any tag)
  */
-export async function cleanSuperfluousIpfs(confirm = true): Promise<{ success: boolean; stats: CleanIpfsStats }> {
+export async function cleanOrphanedIpfs(confirm = true): Promise<{ success: boolean; stats: CleanIpfsStats }> {
   const settings = resolveCliSettings();
 
   const tagsDir = path.join(settings.cannonDirectory, 'tags');
@@ -185,10 +174,9 @@ export async function cleanSuperfluousIpfs(confirm = true): Promise<{ success: b
   const stats: CleanIpfsStats = {
     totalFiles: 0,
     referencedFiles: 0,
-    superfluousFiles: 0,
+    orphanedFiles: 0,
     deletedFiles: 0,
     failedFiles: 0,
-    freedBytes: 0,
   };
 
   // Get all directly referenced IPFS URLs from tags
@@ -207,11 +195,11 @@ export async function cleanSuperfluousIpfs(confirm = true): Promise<{ success: b
   // Build a set of referenced cache hashes for quick lookup
   const referencedHashes = new Set<string>();
   for (const url of referencedUrls) {
-    referencedHashes.add(getCacheHash(url));
+    referencedHashes.add(CliLoader.getCacheHash(url));
   }
 
-  // Find superfluous files (not referenced by any tag)
-  const superfluousFiles: { file: string; size: number }[] = [];
+  // Find orphaned files (not referenced by any tag)
+  const orphanedFiles: string[] = [];
 
   for (const file of cacheFiles) {
     // Extract the hash part from the filename (format: {md5}-{cid}.json)
@@ -221,35 +209,29 @@ export async function cleanSuperfluousIpfs(confirm = true): Promise<{ success: b
       stats.referencedFiles++;
       debug(`File ${file} is referenced, keeping`);
     } else {
-      const filePath = path.join(ipfsCacheDir, file);
-      const fileStat = await fs.stat(filePath);
-      superfluousFiles.push({ file, size: fileStat.size });
-      stats.superfluousFiles++;
-      debug(`File ${file} is superfluous, marking for deletion`);
+      orphanedFiles.push(file);
+      stats.orphanedFiles++;
+      debug(`File ${file} is orphaned, marking for deletion`);
     }
   }
 
-  if (stats.superfluousFiles === 0) {
-    log('No superfluous IPFS packages found.');
+  if (stats.orphanedFiles === 0) {
+    log('No orphaned IPFS packages found.');
     return { success: true, stats };
   }
 
   // Show what will be deleted
-  log(`Found ${stats.superfluousFiles} superfluous IPFS package(s) (out of ${stats.totalFiles} total):`);
-  for (const { file, size } of superfluousFiles) {
-    log(`  - ${file} (${formatBytes(size)})`);
+  log(`Found ${stats.orphanedFiles} orphaned IPFS package(s) (out of ${stats.totalFiles} total):`);
+  for (const file of orphanedFiles) {
+    log(`  - ${file}`);
   }
-  log();
-
-  const totalSize = superfluousFiles.reduce((sum, f) => sum + f.size, 0);
-  log(`Total space to free: ${formatBytes(totalSize)}`);
   log();
 
   if (confirm) {
     const confirmation = await prompts({
       type: 'confirm',
       name: 'value',
-      message: 'Delete these superfluous IPFS packages?',
+      message: 'Delete these orphaned IPFS packages?',
       initial: false,
     });
 
@@ -259,13 +241,12 @@ export async function cleanSuperfluousIpfs(confirm = true): Promise<{ success: b
     }
   }
 
-  // Delete superfluous files
-  for (const { file, size } of superfluousFiles) {
+  // Delete orphaned files
+  for (const file of orphanedFiles) {
     const filePath = path.join(ipfsCacheDir, file);
     try {
       await fs.unlink(filePath);
       stats.deletedFiles++;
-      stats.freedBytes += size;
       debug(`Deleted ${file}`);
     } catch (error: unknown) {
       stats.failedFiles++;
@@ -276,21 +257,10 @@ export async function cleanSuperfluousIpfs(confirm = true): Promise<{ success: b
   }
 
   log();
-  log(`Deleted ${stats.deletedFiles} superfluous IPFS package(s), freed ${formatBytes(stats.freedBytes)}.`);
+  log(`Deleted ${stats.deletedFiles} orphaned IPFS package(s).`);
   if (stats.failedFiles > 0) {
     log(`Failed to delete ${stats.failedFiles} file(s).`);
   }
 
   return { success: true, stats };
-}
-
-/**
- * Format bytes to human-readable string
- */
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B';
-  const k = 1024;
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
 }

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -6,7 +6,7 @@ import prompts from 'prompts';
 
 import { log } from '../util/console';
 import { resolveCliSettings } from '../settings';
-import { IPFSLoader } from '@usecannon/builder';
+
 import { CliLoader } from '../loader';
 
 const debug = Debug('cannon:cli:clean');
@@ -92,7 +92,6 @@ async function getReferencedIpfsUrls(tagsDir: string): Promise<Set<string>> {
 
   return referencedUrls;
 }
-
 
 /**
  * Extract all IPFS URLs from a string (e.g., JSON content of a cached IPFS file).

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -103,6 +103,55 @@ async function getReferencedIpfsUrls(tagsDir: string): Promise<Set<string>> {
   return referencedUrls;
 }
 
+
+/**
+ * Extract all IPFS URLs from a string (e.g., JSON content of a cached IPFS file).
+ * Looks for ipfs://Qm... and ipfs://bafy... patterns.
+ */
+function extractIpfsUrls(content: string): Set<string> {
+  const urls = new Set<string>();
+  const regex = /ipfs:\/\/[A-Za-z0-9]+/g;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    urls.add(match[0]);
+  }
+  return urls;
+}
+
+/**
+ * Recursively resolve all IPFS dependencies starting from a set of root URLs.
+ * Reads the content of each referenced IPFS cache file and looks for additional
+ * IPFS URLs, building a complete dependency graph.
+ */
+async function resolveIpfsDependencies(rootUrls: Set<string>, ipfsCacheDir: string): Promise<Set<string>> {
+  const allReferencedUrls = new Set<string>(rootUrls);
+  const queue = [...rootUrls];
+
+  while (queue.length > 0) {
+    const url = queue.pop()!;
+    const cacheHash = getCacheHash(url);
+    const cacheFile = path.join(ipfsCacheDir, `${cacheHash}.json`);
+
+    try {
+      const content = await fs.readFile(cacheFile, 'utf-8');
+      const nestedUrls = extractIpfsUrls(content);
+
+      for (const nestedUrl of nestedUrls) {
+        if (!allReferencedUrls.has(nestedUrl)) {
+          allReferencedUrls.add(nestedUrl);
+          queue.push(nestedUrl);
+          debug(`Found nested IPFS dependency: ${nestedUrl} (from ${url})`);
+        }
+      }
+    } catch {
+      // Cache file may not exist locally, that's fine
+      debug(`Could not read cache file for ${url}, skipping dependency scan`);
+    }
+  }
+
+  return allReferencedUrls;
+}
+
 /**
  * Get all IPFS cache files
  */
@@ -142,9 +191,13 @@ export async function cleanSuperfluousIpfs(confirm = true): Promise<{ success: b
     freedBytes: 0,
   };
 
-  // Get all referenced IPFS URLs from tags
-  const referencedUrls = await getReferencedIpfsUrls(tagsDir);
-  debug(`Found ${referencedUrls.size} referenced IPFS URLs in tags`);
+  // Get all directly referenced IPFS URLs from tags
+  const directUrls = await getReferencedIpfsUrls(tagsDir);
+  debug(`Found ${directUrls.size} directly referenced IPFS URLs in tags`);
+
+  // Recursively resolve all IPFS dependencies (second-order and deeper)
+  const referencedUrls = await resolveIpfsDependencies(directUrls, ipfsCacheDir);
+  debug(`Found ${referencedUrls.size} total referenced IPFS URLs (including nested dependencies)`);
 
   // Get all IPFS cache files
   const cacheFiles = await getIpfsCacheFiles(ipfsCacheDir);

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -1,11 +1,13 @@
 import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
+import crypto from 'crypto';
 import Debug from 'debug';
 import prompts from 'prompts';
 
 import { log } from '../util/console';
 import { resolveCliSettings } from '../settings';
+import { IPFSLoader } from '@usecannon/builder';
 
 const debug = Debug('cannon:cli:clean');
 
@@ -60,4 +62,182 @@ export async function clean(confirm = true) {
   );
 
   return true;
+}
+
+/**
+ * Get the cache file path for an IPFS URL
+ * Matches the logic in CliLoader.getCacheHash
+ */
+function getCacheHash(url: string): string {
+  const qmhash = url.replace(IPFSLoader.PREFIX, '');
+  const md5 = crypto.createHash('md5').update(qmhash).digest('hex');
+  return `${md5}-${qmhash.toLowerCase()}`;
+}
+
+/**
+ * Read all tag files and extract referenced IPFS URLs
+ */
+async function getReferencedIpfsUrls(tagsDir: string): Promise<Set<string>> {
+  const referencedUrls = new Set<string>();
+
+  if (!existsSync(tagsDir)) {
+    return referencedUrls;
+  }
+
+  const tagFiles = await fs.readdir(tagsDir);
+
+  for (const file of tagFiles) {
+    // Process both .txt files (main package URL) and .meta files (metadata URL)
+    if (!file.endsWith('.txt') && !file.endsWith('.meta')) continue;
+
+    const filePath = path.join(tagsDir, file);
+    const content = await fs.readFile(filePath, 'utf-8');
+    const url = content.trim();
+
+    if (url.startsWith('ipfs://')) {
+      referencedUrls.add(url);
+      debug(`Found referenced URL in ${file}: ${url}`);
+    }
+  }
+
+  return referencedUrls;
+}
+
+/**
+ * Get all IPFS cache files
+ */
+async function getIpfsCacheFiles(ipfsCacheDir: string): Promise<string[]> {
+  if (!existsSync(ipfsCacheDir)) {
+    return [];
+  }
+
+  const files = await fs.readdir(ipfsCacheDir);
+  return files.filter((f) => f.endsWith('.json'));
+}
+
+export interface CleanIpfsStats {
+  totalFiles: number;
+  referencedFiles: number;
+  superfluousFiles: number;
+  deletedFiles: number;
+  failedFiles: number;
+  freedBytes: number;
+}
+
+/**
+ * Clean superfluous IPFS packages (packages not referenced by any tag)
+ */
+export async function cleanSuperfluousIpfs(confirm = true): Promise<{ success: boolean; stats: CleanIpfsStats }> {
+  const settings = resolveCliSettings();
+
+  const tagsDir = path.join(settings.cannonDirectory, 'tags');
+  const ipfsCacheDir = path.join(settings.cannonDirectory, 'ipfs_cache');
+
+  const stats: CleanIpfsStats = {
+    totalFiles: 0,
+    referencedFiles: 0,
+    superfluousFiles: 0,
+    deletedFiles: 0,
+    failedFiles: 0,
+    freedBytes: 0,
+  };
+
+  // Get all referenced IPFS URLs from tags
+  const referencedUrls = await getReferencedIpfsUrls(tagsDir);
+  debug(`Found ${referencedUrls.size} referenced IPFS URLs in tags`);
+
+  // Get all IPFS cache files
+  const cacheFiles = await getIpfsCacheFiles(ipfsCacheDir);
+  stats.totalFiles = cacheFiles.length;
+  debug(`Found ${cacheFiles.length} IPFS cache files`);
+
+  // Build a set of referenced cache hashes for quick lookup
+  const referencedHashes = new Set<string>();
+  for (const url of referencedUrls) {
+    referencedHashes.add(getCacheHash(url));
+  }
+
+  // Find superfluous files (not referenced by any tag)
+  const superfluousFiles: { file: string; size: number }[] = [];
+
+  for (const file of cacheFiles) {
+    // Extract the hash part from the filename (format: {md5}-{cid}.json)
+    const hashPart = file.replace('.json', '');
+
+    if (referencedHashes.has(hashPart)) {
+      stats.referencedFiles++;
+      debug(`File ${file} is referenced, keeping`);
+    } else {
+      const filePath = path.join(ipfsCacheDir, file);
+      const fileStat = await fs.stat(filePath);
+      superfluousFiles.push({ file, size: fileStat.size });
+      stats.superfluousFiles++;
+      debug(`File ${file} is superfluous, marking for deletion`);
+    }
+  }
+
+  if (stats.superfluousFiles === 0) {
+    log('No superfluous IPFS packages found.');
+    return { success: true, stats };
+  }
+
+  // Show what will be deleted
+  log(`Found ${stats.superfluousFiles} superfluous IPFS package(s) (out of ${stats.totalFiles} total):`);
+  for (const { file, size } of superfluousFiles) {
+    log(`  - ${file} (${formatBytes(size)})`);
+  }
+  log();
+
+  const totalSize = superfluousFiles.reduce((sum, f) => sum + f.size, 0);
+  log(`Total space to free: ${formatBytes(totalSize)}`);
+  log();
+
+  if (confirm) {
+    const confirmation = await prompts({
+      type: 'confirm',
+      name: 'value',
+      message: 'Delete these superfluous IPFS packages?',
+      initial: false,
+    });
+
+    if (!confirmation.value) {
+      log('Cancelled.');
+      return { success: false, stats };
+    }
+  }
+
+  // Delete superfluous files
+  for (const { file, size } of superfluousFiles) {
+    const filePath = path.join(ipfsCacheDir, file);
+    try {
+      await fs.unlink(filePath);
+      stats.deletedFiles++;
+      stats.freedBytes += size;
+      debug(`Deleted ${file}`);
+    } catch (error: unknown) {
+      stats.failedFiles++;
+      if (error instanceof Error) {
+        debug(`Failed to delete ${file}: ${error.message}`);
+      }
+    }
+  }
+
+  log();
+  log(`Deleted ${stats.deletedFiles} superfluous IPFS package(s), freed ${formatBytes(stats.freedBytes)}.`);
+  if (stats.failedFiles > 0) {
+    log(`Failed to delete ${stats.failedFiles} file(s).`);
+  }
+
+  return { success: true, stats };
+}
+
+/**
+ * Format bytes to human-readable string
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
 }

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -796,8 +796,8 @@ export const commandsConfig: CommandsConfig = {
         description: 'Do not ask for confirmation before deleting',
       },
       {
-        flags: '--ipfs-superfluous',
-        description: 'Only delete IPFS packages not referenced by any tag in the tags folder',
+        flags: '--ipfs',
+        description: 'Only delete orphaned IPFS packages not referenced by any tag',
       },
     ],
   },

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -795,6 +795,10 @@ export const commandsConfig: CommandsConfig = {
         flags: '--no-confirm',
         description: 'Do not ask for confirmation before deleting',
       },
+      {
+        flags: '--ipfs-superfluous',
+        description: 'Only delete IPFS packages not referenced by any tag in the tags folder',
+      },
     ],
   },
   plugin: {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -915,17 +915,17 @@ applyCommandsConfig(program.command('setup'), commandsConfig.setup).action(async
   }
 });
 
-applyCommandsConfig(program.command('clean'), commandsConfig.clean).action(async function (options: { confirm?: boolean; ipfsSuperfluous?: boolean }) {
+applyCommandsConfig(program.command('clean'), commandsConfig.clean).action(async function (options: { confirm?: boolean; ipfs?: boolean }) {
   try {
     logSpinnerEnd();
-    const { clean, cleanSuperfluousIpfs } = await import('./commands/clean');
+    const { clean, cleanOrphanedIpfs } = await import('./commands/clean');
     
     // With --no-confirm flag, Commander sets confirm to false
     // Without the flag, confirm is undefined (default to true for confirmation)
     const shouldConfirm = options.confirm !== false;
     
-    if (options.ipfsSuperfluous) {
-      const { success } = await cleanSuperfluousIpfs(shouldConfirm);
+    if (options.ipfs) {
+      const { success } = await cleanOrphanedIpfs(shouldConfirm);
       if (success) log('Complete!');
     } else {
       const executed = await clean(shouldConfirm);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -915,15 +915,18 @@ applyCommandsConfig(program.command('setup'), commandsConfig.setup).action(async
   }
 });
 
-applyCommandsConfig(program.command('clean'), commandsConfig.clean).action(async function (options: { confirm?: boolean; ipfs?: boolean }) {
+applyCommandsConfig(program.command('clean'), commandsConfig.clean).action(async function (options: {
+  confirm?: boolean;
+  ipfs?: boolean;
+}) {
   try {
     logSpinnerEnd();
     const { clean, cleanOrphanedIpfs } = await import('./commands/clean');
-    
+
     // With --no-confirm flag, Commander sets confirm to false
     // Without the flag, confirm is undefined (default to true for confirmation)
     const shouldConfirm = options.confirm !== false;
-    
+
     if (options.ipfs) {
       const { success } = await cleanOrphanedIpfs(shouldConfirm);
       if (success) log('Complete!');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -915,12 +915,22 @@ applyCommandsConfig(program.command('setup'), commandsConfig.setup).action(async
   }
 });
 
-applyCommandsConfig(program.command('clean'), commandsConfig.clean).action(async function ({ noConfirm }) {
+applyCommandsConfig(program.command('clean'), commandsConfig.clean).action(async function (options: { confirm?: boolean; ipfsSuperfluous?: boolean }) {
   try {
     logSpinnerEnd();
-    const { clean } = await import('./commands/clean');
-    const executed = await clean(!noConfirm);
-    if (executed) log('Complete!');
+    const { clean, cleanSuperfluousIpfs } = await import('./commands/clean');
+    
+    // With --no-confirm flag, Commander sets confirm to false
+    // Without the flag, confirm is undefined (default to true for confirmation)
+    const shouldConfirm = options.confirm !== false;
+    
+    if (options.ipfsSuperfluous) {
+      const { success } = await cleanSuperfluousIpfs(shouldConfirm);
+      if (success) log('Complete!');
+    } else {
+      const executed = await clean(shouldConfirm);
+      if (executed) log('Complete!');
+    }
 
     logSpinnerEnd();
   } catch (err) {


### PR DESCRIPTION
## Summary

Add a new mode to the `cannon clean` command that deletes IPFS packages not referenced by any tag in the tags folder.

## Usage

```bash
# Delete superfluous IPFS packages with confirmation
cannon clean --ipfs-superfluous

# Delete without confirmation (useful for scripts)
cannon clean --ipfs-superfluous --no-confirm
```

## How it works

1. Scans the `tags/` folder for all `.txt` and `.meta` files
2. Extracts IPFS URLs from these files
3. Compares against all files in `ipfs_cache/`
4. Identifies files not referenced by any tag
5. Prompts for confirmation before deletion (unless `--no-confirm`)

## Benefits

- Helps users free disk space by removing orphaned IPFS cache files
- Safe: only removes files that are definitely not referenced
- Shows exactly what will be deleted and how much space will be freed

## Testing

- Unit tests added for the new functionality
- Manually tested with local Cannon cache

---

Draft PR - ready for initial review.