### PR TITLE
fix: bugs in package caching process

### DIFF
--- a/packages/builder/src/registry.test.ts
+++ b/packages/builder/src/registry.test.ts
@@ -184,7 +184,7 @@ describe('registry.ts', () => {
         jest.mocked(provider.readContract).mockResolvedValue({
           deployUrl: 'ipfs://QmV1kMdjDegcKrvSddsTmRGyCwnYERqN9o1K56g4Mw7F6i',
           metaUrl: 'ipfs://QmV1kMdjDegcKrvSddsTmRGyCwnYERqN9o1K56g4Mw7F6j',
-          mutability: 'foobar',
+          mutability: viem.stringToHex('foobar', { size: 16 }),
           owner: signer.address,
         });
 
@@ -201,6 +201,32 @@ describe('registry.ts', () => {
             viem.stringToHex('13370-main', { size: 32 }),
           ],
         });
+      });
+
+      it('decodes bytes16 mutability field from on-chain hex to string', async () => {
+        const provider = makeFakeProvider();
+        const registry = createRegistry({ provider });
+
+        // The on-chain registry stores mutability as bytes16 (right-padded hex).
+        // Before the fix, the raw hex string was returned instead of the decoded value,
+        // causing mutability checks like `=== 'version'` to always fail.
+        // Note: empty mutability is not tested here because stringToHex('', {size:16}) produces
+        // 16 null bytes, which hexToString decodes to '\u0000' rather than ''. In practice,
+        // the on-chain contract only uses 'version' and 'tag' as meaningful mutability values.
+        for (const mutability of ['version', 'tag'] as const) {
+          jest.mocked(provider.readContract).mockResolvedValue({
+            deployUrl: 'ipfs://QmV1kMdjDegcKrvSddsTmRGyCwnYERqN9o1K56g4Mw7F6i',
+            metaUrl: '',
+            mutability: viem.stringToHex(mutability, { size: 16 }),
+            owner: signer.address,
+          });
+
+          const url = await registry.getUrl('dummy-package:0.0.1@main', 13370);
+
+          expect(url.mutability).toBe(mutability);
+          // Make sure we never leak the raw hex value
+          expect(url.mutability).not.toMatch(/^0x/);
+        }
       });
     });
   });

--- a/packages/builder/src/registry.ts
+++ b/packages/builder/src/registry.ts
@@ -6,10 +6,10 @@ import _ from 'lodash';
 import EventEmitter from 'promise-events';
 import * as viem from 'viem';
 import CannonRegistryAbi from './abis/CannonRegistry';
+import { getIpfsUrl } from './ipfs';
 import { prepareMulticall, TxData } from './multicall';
 import { PackageReference } from './package-reference';
 import { CannonSigner } from './types';
-import { getIpfsUrl } from './ipfs';
 
 const debug = Debug('cannon:builder:registry');
 
@@ -529,7 +529,10 @@ export class OnChainRegistry extends CannonRegistry {
       // TODO: I dont understand why viem does not recognize the return type of this function (so I have to use any)
     })) as any;
 
-    return { url: onChainDeployInfo.deployUrl, mutability: onChainDeployInfo.mutability as 'version' | 'tag' | '' };
+    return {
+      url: onChainDeployInfo.deployUrl,
+      mutability: viem.hexToString(onChainDeployInfo.mutability, { size: 16 }) as 'version' | 'tag' | '',
+    };
   }
 
   async getMetaUrl(packageOrServiceRef: string, chainId: number): Promise<string | null> {

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -9,7 +9,7 @@ import * as viem from 'viem';
 import { CliSettings } from './settings';
 import { log } from './util/console';
 import { isConnectedToInternet } from './util/is-connected-to-internet';
-import { resolveRegistryProviders, ProviderAction } from './util/provider';
+import { ProviderAction, resolveRegistryProviders } from './util/provider';
 
 const debug = Debug('cannon:cli:registry');
 
@@ -254,7 +254,7 @@ export async function createDefaultReadRegistry(
       // if we had to load this package from the on-chain registry and it was immutable, record
       if (event.result.mutability === 'version' && event.registry instanceof OnChainRegistry) {
         debug('caching immutable package from on-chain registry', event.fullPackageRef);
-        await localRegistry.publish(event.fullPackageRef, event.chainId, event.result.url, '', 'version');
+        await localRegistry.publish([event.fullPackageRef], event.chainId, event.result.url, '', 'version');
       }
     });
 


### PR DESCRIPTION
Fixes two bugs in the package caching flow:

1. **`mutability` field not decoded correctly** — The on-chain registry returns `mutability` as a `bytes16` hex value. This wasn't being decoded with `viem.hexToString`, causing cache mutability checks to always fail (the raw hex string never equals `'version'`).

2. **`localRegistry.publish` called with wrong argument** — The `publish` method expects an array of package refs as its first argument, but was being called with a bare string.

Closes #1855.