### PR TITLE
feat(cli): add --match-contract filter to inspect command

### DIFF
--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -581,6 +581,11 @@ export const commandsConfig: CommandsConfig = {
         flags: '-s --sources',
         description: 'Show contract sources',
       },
+      {
+        flags: '--match-contract <name>',
+        description: 'Regex to filter contracts by name. Only matching contracts are shown/exported.',
+        defaultValue: '',
+      },
       ...debugVerbosity,
     ],
   },

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -1,7 +1,9 @@
 import {
+  BundledChainBuilderOutputs,
   ChainArtifacts,
   ChainDefinition,
   ContractData,
+  ContractMap,
   DeploymentInfo,
   DeploymentState,
   fetchIPFSAvailability,
@@ -90,13 +92,14 @@ export async function inspect(
     if (matchContract) {
       const regex = new RegExp(matchContract);
       const stateContracts = _getNestedStateContracts(deployInfo.state);
-      contractsAndDetails = {};
+      const filtered: ContractMap = {};
       for (const [filepath, contractData] of stateContracts.entries()) {
         const contractName = path.basename(filepath, '.json');
         if (regex.test(contractName)) {
-          contractsAndDetails[contractName] = contractData;
+          filtered[contractName] = contractData;
         }
       }
+      contractsAndDetails = filtered;
     }
 
     const miscData = await loader.ipfs.read(deployInfo.miscUrl);
@@ -193,13 +196,14 @@ function _filterState(state: DeploymentState, regex: RegExp): DeploymentState {
 function _filterArtifacts(artifacts: ChainArtifacts, regex: RegExp): ChainArtifacts {
   const newArtifacts: ChainArtifacts = { ...artifacts };
   if (newArtifacts.contracts) {
-    newArtifacts.contracts = _.pickBy(newArtifacts.contracts, (v, k) => regex.test(k));
+    newArtifacts.contracts = _.pickBy(newArtifacts.contracts, (v, k) => regex.test(k)) as ContractMap;
   }
   if (newArtifacts.imports) {
-    newArtifacts.imports = _.pickBy(
+    const filteredImports = _.pickBy(
       _.mapValues(newArtifacts.imports, (i) => _filterArtifacts(i, regex)),
       (v) => Object.keys(v.contracts || {}).length > 0 || Object.keys(v.imports || {}).length > 0
-    );
+    ) as BundledChainBuilderOutputs;
+    newArtifacts.imports = filteredImports;
   }
   return newArtifacts;
 }

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -32,10 +32,16 @@ export async function inspect(
   cliSettings: CliSettings,
   out: FormatType,
   writeDeployments: string,
-  sources: boolean
+  sources: boolean,
+  matchContract = ''
 ) {
   if (out && !formatTypes.includes(out)) {
     throw new Error(`invalid --out value: "${out}". Valid types are: '${formatTypes.join("' | '")}'`);
+  }
+
+  if (matchContract) {
+    const regex = new RegExp(matchContract);
+    deployInfo.state = _filterState(deployInfo.state, regex);
   }
 
   const resolver = await createDefaultReadRegistry(cliSettings);
@@ -79,7 +85,20 @@ export async function inspect(
     const packageOwner = deployInfo.def.setting?.owner?.defaultValue;
     const localSource = getSourceFromRegistry(resolver.registries);
     const ipfsAvailabilityScore = await fetchIPFSAvailability(cliSettings.ipfsUrl, ipfsUrl.replace('ipfs://', ''));
-    const contractsAndDetails = getContractsAndDetails(deployInfo.state);
+    let contractsAndDetails = getContractsAndDetails(deployInfo.state);
+
+    if (matchContract) {
+      const regex = new RegExp(matchContract);
+      const stateContracts = _getNestedStateContracts(deployInfo.state);
+      contractsAndDetails = {};
+      for (const [filepath, contractData] of stateContracts.entries()) {
+        const contractName = path.basename(filepath, '.json');
+        if (regex.test(contractName)) {
+          contractsAndDetails[contractName] = contractData;
+        }
+      }
+    }
+
     const miscData = await loader.ipfs.read(deployInfo.miscUrl);
     const contractSources = _listSourceCodeContracts(miscData);
 
@@ -162,6 +181,27 @@ function _getNestedStateFiles(artifacts: ChainArtifacts, pathname: string, resul
   }
 
   return result;
+}
+
+function _filterState(state: DeploymentState, regex: RegExp): DeploymentState {
+  return _.pickBy(
+    _.mapValues(state, (val) => ({ ...val, artifacts: _filterArtifacts(val.artifacts, regex) })),
+    (val) => Object.keys(val.artifacts.contracts || {}).length > 0 || Object.keys(val.artifacts.imports || {}).length > 0
+  );
+}
+
+function _filterArtifacts(artifacts: ChainArtifacts, regex: RegExp): ChainArtifacts {
+  const newArtifacts: ChainArtifacts = { ...artifacts };
+  if (newArtifacts.contracts) {
+    newArtifacts.contracts = _.pickBy(newArtifacts.contracts, (v, k) => regex.test(k));
+  }
+  if (newArtifacts.imports) {
+    newArtifacts.imports = _.pickBy(
+      _.mapValues(newArtifacts.imports, (i) => _filterArtifacts(i, regex)),
+      (v) => Object.keys(v.contracts || {}).length > 0 || Object.keys(v.imports || {}).length > 0
+    );
+  }
+  return newArtifacts;
 }
 
 // TODO: types

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -653,7 +653,8 @@ applyCommandsConfig(program.command('inspect'), commandsConfig.inspect).action(a
       cliSettings,
       options.json ? 'deploy-json' : options.out,
       options.writeDeployments,
-      options.sources
+      options.sources,
+      options.matchContract
     );
 
     logSpinnerEnd();


### PR DESCRIPTION
Adds a `--match-contract` flag to the `cannon inspect` command that accepts a regex pattern to filter which contracts are shown in the output.

This is useful when working with large deployments where you only care about specific contracts.

**Usage:**
```bash
# Show only contracts matching "Proxy"
cannon inspect my-package:1.0.0 --match-contract "Proxy"

# Export only specific contracts as JSON
cannon inspect my-package:1.0.0 --out artifact-json --match-contract "^Core"

# Write only matching contract deployments
cannon inspect my-package:1.0.0 --write-deployments ./output --match-contract "Token"
```

The filter works across all output modes:
- `overview`: Only shows matching contracts in the contract list
- `artifact-json`: Only includes matching contracts in the JSON output
- `deploy-json`: Only includes matching contracts from the deployment state
- `--write-deployments`: Only writes files for matching contracts

The pattern is applied recursively through nested imports.

Related: #1761 (original request for more output control)