### PR TITLE
docs: add on-chain upgrade attestation guide

### DIFF
--- a/packages/website/guides/upgrade-attestation.mdx
+++ b/packages/website/guides/upgrade-attestation.mdx
@@ -1,0 +1,152 @@
+---
+title: On-Chain Upgrade Attestation
+description: Understand how Cannon tracks deployment history on-chain for seamless upgrades.
+---
+
+## On-Chain Upgrade Attestation
+
+When building packages for live networks, Cannon automatically records deployment information on-chain. This mechanism enables seamless upgrades by allowing Cannon to automatically discover previous deployments made by the same deployer.
+
+### How It Works
+
+At the end of every `cannon build` on a live network (not the local Cannon chain), Cannon writes an **attestation** to a simple on-chain key-value storage contract. This attestation links:
+
+- **Your address** (the deployer)
+- **The package name and preset**
+- **The IPFS URL** of the deployment data
+- **A timestamp**
+
+The storage contract is deployed at a deterministic address using CREATE2, ensuring it's available on any EVM-compatible chain:
+
+```
+0x14570ce88f490a80342cc156a6a0ebc173609f5e
+```
+
+### The Storage Contract
+
+The on-chain storage is a minimal contract with a simple interface:
+
+```solidity
+contract Storage {
+    mapping(address => mapping(bytes32 => bytes)) store;
+
+    function set(bytes32 k, bytes memory v) external {
+        store[msg.sender][k] = v;
+    }
+
+    function getWithAddress(address s, bytes32 k) external view returns (bytes memory) {
+        return store[s][k];
+    }
+}
+```
+
+**Key points:**
+- Each deployer has their own namespace (keyed by their address)
+- The key is `keccak256(packageName@preset)`
+- The value is `timestamp_ipfsUrl`
+
+This design ensures:
+1. **Privacy by default**: Only you can see your own deployment records
+2. **No permission required**: Anyone can write to their own namespace
+3. **Tamper-proof**: Records are immutable once written
+
+### Automatic Upgrade Detection
+
+When you run `cannon build` without specifying `--upgrade-from`, Cannon will:
+
+1. Query the on-chain storage contract for any previous attestations from the configured **deployers**
+2. If found, load the previous deployment state from the IPFS URL
+3. Continue the build from that state, only executing new or modified operations
+
+This means you can upgrade your protocol simply by:
+
+```bash
+# First deployment
+cannon build --rpc-url https://eth-mainnet.example.com
+
+# Later upgrade (Cannon automatically finds the previous deployment)
+cannon build --rpc-url https://eth-mainnet.example.com
+```
+
+### Configuring Deployers
+
+By default, Cannon uses the default signer's address to look up previous deployments. You can specify additional deployer addresses in your cannonfile using the `deployers` field:
+
+```toml
+name = "my-protocol"
+version = "1.0.0"
+deployers = [
+    "0x1234...abcd",  # Previous deployer 1
+    "0x5678...efgh",  # Previous deployer 2
+]
+
+[contract.MyContract]
+artifact = "MyContract"
+```
+
+This is useful when:
+- **Ownership has transferred**: New deployers can pick up where previous ones left off
+- **Multi-sig deployments**: You want Cannon to recognize deployments from any authorized signer
+- **Team deployments**: Multiple team members can upgrade the same package
+
+### When to Disable It
+
+There are scenarios where you might want to skip writing the upgrade attestation:
+
+1. **Read-only RPC**: Building against a node that doesn't accept transactions
+2. **Gas optimization**: You're doing a one-off build and don't need upgrade tracking
+3. **Custom upgrade flow**: You're managing upgrades through a different mechanism
+
+To disable the on-chain attestation:
+
+```bash
+cannon build --skip-upgrade-record
+```
+
+<Alert variant="warning">
+  <AlertDescription>
+    If you use <code>--skip-upgrade-record</code>, future builds won't automatically detect this deployment. You'll need to manually specify <code>--upgrade-from</code> when upgrading.
+  </AlertDescription>
+</Alert>
+
+### Manual Upgrade Specification
+
+If you've disabled upgrade recording or need to upgrade from a specific deployment, use the `--upgrade-from` flag:
+
+```bash
+# Upgrade from a specific IPFS hash
+cannon build --upgrade-from ipfs://Qm...
+
+# Upgrade from a specific package reference
+cannon build --upgrade-from my-protocol:1.0.0@main
+```
+
+### Troubleshooting
+
+#### "Failed to write upgrade record to on-chain state"
+
+This error occurs when Cannon cannot write the attestation to the on-chain storage. Common causes:
+
+1. **Insufficient gas**: Ensure your signer has enough ETH for the transaction
+2. **RPC issues**: The RPC endpoint may not be accepting transactions
+
+If this fails repeatedly, Cannon will suggest using `--upgrade-from` with the current deployment URL for future upgrades.
+
+#### Previous deployment not found
+
+If Cannon isn't finding your previous deployment:
+
+1. **Check deployers**: Ensure the previous deployer's address is in your `deployers` list
+2. **Verify package name**: The package name and preset must match exactly
+3. **Check network**: Ensure you're building on the same chain as the previous deployment
+
+### Technical Details
+
+| Property | Value |
+|----------|-------|
+| Storage Contract | `0x14570ce88f490a80342cc156a6a0ebc173609f5e` |
+| CREATE2 Deployer | `0x4e59b44847b379578588920ca78fbf26c0b4956c` |
+| Key Format | `keccak256(packageName@preset)` |
+| Value Format | `timestamp_ipfsUrl` |
+
+The storage contract is deployed deterministically using CREATE2, meaning it will exist at the same address on any EVM chain. If the contract doesn't exist yet, Cannon will deploy it automatically during your first build.

--- a/packages/website/guides/upgrade-attestation.mdx
+++ b/packages/website/guides/upgrade-attestation.mdx
@@ -22,6 +22,12 @@ The storage contract is deployed at a deterministic address using CREATE2, ensur
 0x14570ce88f490a80342cc156a6a0ebc173609f5e
 ```
 
+<Alert variant="info">
+  <AlertDescription>
+    This contract is automatically deployed by the Cannon CLI if it doesn't already exist on the target chain.
+  </AlertDescription>
+</Alert>
+
 ### The Storage Contract
 
 The on-chain storage is a minimal contract with a simple interface:
@@ -43,12 +49,9 @@ contract Storage {
 **Key points:**
 - Each deployer has their own namespace (keyed by their address)
 - The key is `keccak256(packageName@preset)`
-- The value is `timestamp_ipfsUrl`
+- The value is in the format `timestamp_ipfsUrl`
 
-This design ensures:
-1. **Privacy by default**: Only you can see your own deployment records
-2. **No permission required**: Anyone can write to their own namespace
-3. **Tamper-proof**: Records are immutable once written
+The on-chain records contract provides a way to indicate on-chain what deployment was completed by the deployer. Each deployer's records are namespaced by their address, allowing Cannon to look up previous deployments for any given package and preset.
 
 ### Automatic Upgrade Detection
 
@@ -64,7 +67,7 @@ This means you can upgrade your protocol simply by:
 # First deployment
 cannon build --rpc-url https://eth-mainnet.example.com
 
-# Later upgrade (Cannon automatically finds the previous deployment)
+# Later upgrade: Repeat the same command
 cannon build --rpc-url https://eth-mainnet.example.com
 ```
 
@@ -80,22 +83,18 @@ deployers = [
     "0x5678...efgh",  # Previous deployer 2
 ]
 
-[contract.MyContract]
+[deploy.MyContract]
 artifact = "MyContract"
 ```
+
+For reproducibility, it is recommended to explicitly specify the list of deployers that may be used for a release.
 
 This is useful when:
 - **Ownership has transferred**: New deployers can pick up where previous ones left off
 - **Multi-sig deployments**: You want Cannon to recognize deployments from any authorized signer
 - **Team deployments**: Multiple team members can upgrade the same package
 
-### When to Disable It
-
-There are scenarios where you might want to skip writing the upgrade attestation:
-
-1. **Read-only RPC**: Building against a node that doesn't accept transactions
-2. **Gas optimization**: You're doing a one-off build and don't need upgrade tracking
-3. **Custom upgrade flow**: You're managing upgrades through a different mechanism
+### How to Disable Upgrade Attestation
 
 To disable the on-chain attestation:
 

--- a/packages/website/src/constants/links.ts
+++ b/packages/website/src/constants/links.ts
@@ -15,6 +15,7 @@ export const links = {
   COMPARISON: '/learn/guides/comparison',
   BUILD_TROUBLESHOOTING: '/learn/guides/troubleshooting',
   MIGRATE: '/learn/guides/migrate',
+  UPGRADE_ATTESTATION: '/learn/guides/upgrade-attestation',
   QUEUE_WITH_GITOPS: '/learn/guides/get-started/queue-with-gitops',
   DEPLOYMENTS_REPO: '/learn/guides/get-started/deployments-repo',
   CLI: '/learn/cli',

--- a/packages/website/src/pages/learn/guides/guideLayout.tsx
+++ b/packages/website/src/pages/learn/guides/guideLayout.tsx
@@ -51,6 +51,7 @@ const getStartedGuides = [
 ];
 
 const advancedGuides = [
+  { text: 'On-Chain Upgrade Attestation', href: links.UPGRADE_ATTESTATION },
   { text: 'Manipulate the Package State', href: links.ALTER },
   { text: 'Deploy a Router', href: links.ROUTER },
   { text: 'Debugging Tips', href: links.DEBUG },


### PR DESCRIPTION
## Summary
Adds comprehensive documentation for the on-chain upgrade attestation mechanism.

## What's Covered
- **How it works**: Explains the automatic attestation written to on-chain storage at the end of builds
- **The storage contract**: Details about the CREATE2-deployed key-value store
- **Automatic upgrade detection**: How Cannon finds previous deployments automatically
- **Configuring deployers**: Using the `deployers` field in cannonfiles
- **Disabling the feature**: Using `--skip-upgrade-record` flag
- **Manual upgrade specification**: Using `--upgrade-from` flag
- **Troubleshooting**: Common issues and solutions

## Why This Matters
This is a point of confusion for many users. The documentation explains:
1. What the upgrade attestation mechanism is
2. Why it exists (enables seamless upgrades)
3. How to configure it (deployers field)
4. How to disable it when needed

## Files Changed
- `packages/website/guides/upgrade-attestation.mdx` - New guide
- `packages/website/src/constants/links.ts` - Added link constant
- `packages/website/src/pages/learn/guides/guideLayout.tsx` - Added to sidebar

## Test Plan
1. Run `pnpm --filter @usecannon/website run build` to verify contentlayer builds correctly
2. Verify the guide appears in the Advanced Topics section of the guides sidebar
3. Review the content for accuracy and clarity