### PR TITLE
feat(builder): add safe_set_signers action for Safe multisig owner management

### DIFF
--- a/packages/builder/src/actions.ts
+++ b/packages/builder/src/actions.ts
@@ -11,6 +11,7 @@ import pullSpec from './steps/pull';
 import routerSpec from './steps/router';
 import diamondSpec from './steps/diamond';
 import varSpec from './steps/var';
+import safeSetSignersSpec from './steps/safe-set-signers';
 import { ChainArtifacts, ChainBuilderContext, PackageState } from './types';
 
 export interface RawConfig {
@@ -131,6 +132,7 @@ registerAction(cloneSpec);
 registerAction(routerSpec);
 registerAction(diamondSpec);
 registerAction(varSpec);
+registerAction(safeSetSignersSpec);
 
 // backwards compatibility
 registerAction(Object.assign({}, deploySpec, { label: 'contract' }));

--- a/packages/builder/src/schemas.ts
+++ b/packages/builder/src/schemas.ts
@@ -880,6 +880,55 @@ export const varSchema = z
   })
   .catchall(z.string());
 
+export const safeSetSignersSchema = z
+  .object({
+    /**
+     *  Address of the Safe contract (supports templates like ${contracts.mySafe.address})
+     */
+    target: z
+      .string()
+      .refine((val) => isAddress(val) || !!val.match(interpolatedRegex), {
+        message: 'target must be a valid ethereum address or template string',
+      })
+      .describe('Address of the Safe contract (supports templates like ${contracts.mySafe.address})'),
+    /**
+     *  Desired list of signer addresses (supports templates)
+     */
+    signers: z.array(z.string()).describe('Desired list of signer addresses (supports templates)'),
+  })
+  .merge(
+    z
+      .object({
+        /**
+         *  Desired threshold. Defaults to current threshold if not specified.
+         */
+        threshold: z.number().describe('Desired threshold. Defaults to current threshold if not specified.'),
+        /**
+         *  Address to use for executing the transaction
+         */
+        from: z
+          .string()
+          .refine((val) => isAddress(val) || !!val.match(interpolatedRegex), {
+            message: 'from must be a valid ethereum address or template string',
+          })
+          .describe('Address to use for executing the transaction'),
+        /**
+         * Description of the operation
+         */
+        description: z.string().describe('Description of the operation'),
+        /**
+         *  List of operations that this operation depends on, which Cannon will execute first. If unspecified, Cannon automatically detects dependencies.
+         */
+        depends: z
+          .array(z.string())
+          .describe(
+            'List of operations that this operation depends on, which Cannon will execute first. If unspecified, Cannon automatically detects dependencies.'
+          ),
+      })
+      .deepPartial()
+  )
+  .strict();
+
 /**
  * Shared schema for cannonfile actions (operations).
  * Used by both the full cannonfile schema and the fragment schema.
@@ -974,6 +1023,10 @@ const cannonfileActionsSchema = z.object({
    * @internal
    */
   var: z.record(varSchema).describe('Apply a setting or intermediate value.'),
+  /**
+   * @internal
+   */
+  safe_set_signers: z.record(safeSetSignersSchema).describe('Configure the list of signers on a Gnosis Safe multisig.'),
   // ... there may be others that come from plugins
 });
 

--- a/packages/builder/src/steps/safe-set-signers.test.ts
+++ b/packages/builder/src/steps/safe-set-signers.test.ts
@@ -1,0 +1,228 @@
+import _ from 'lodash';
+import * as viem from 'viem';
+import { validateConfig } from '../actions';
+import action from './safe-set-signers';
+import { fakeCtx, fakeRuntime } from './utils.test.helper';
+
+describe('steps/safe-set-signers.ts', () => {
+  const safeAddress = '0x1234123412341234123412341234123412341234';
+
+  describe('validate', () => {
+    it('fails when not setting values', () => {
+      expect(() => validateConfig(action.validate, {})).toThrow('Field: target');
+    });
+
+    it('fails when setting invalid value', () => {
+      expect(() => validateConfig(action.validate, { target: '0x123', signers: [] })).toThrow('target must be a valid ethereum address or template string');
+    });
+  });
+
+  describe('configInject()', () => {
+    it('injects all fields', async () => {
+      const result = action.configInject(fakeCtx, {
+        target: '<%= settings.a %>',
+        signers: ['<%= settings.b %>', '<%= settings.c %>'],
+        threshold: 2,
+        from: '<%= settings.d %>',
+      }, { ref: null, currentLabel: 'test' });
+
+      expect(result).toStrictEqual({
+        target: 'a',
+        signers: ['b', 'c'],
+        threshold: 2,
+        from: 'd',
+      });
+    });
+  });
+
+  describe('getState()', () => {
+    it('resolves correct properties', async () => {
+      const owners = [
+        '0x0000000000000000000000000000000000000001',
+        '0x0000000000000000000000000000000000000002',
+      ].map(v => viem.getAddress(v));
+
+      jest.mocked(fakeRuntime.provider.readContract).mockImplementation(async (args: any) => {
+        if (args.functionName === 'getOwners') return owners;
+        if (args.functionName === 'getThreshold') return 1n;
+        return null;
+      });
+
+      const result = await action.getState(
+        fakeRuntime,
+        fakeCtx,
+        {
+          target: safeAddress,
+          signers: [],
+        },
+        { ref: null, currentLabel: 'safe_set_signers.test' }
+      );
+
+      expect(result).toEqual([_.sortBy(owners), 1]);
+    });
+  });
+
+  describe('exec()', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.mocked(fakeRuntime.provider.prepareTransactionRequest).mockResolvedValue({} as any);
+      jest.mocked(fakeRuntime.provider.waitForTransactionReceipt).mockResolvedValue({
+        transactionHash: '0x1234',
+        gasUsed: 0n,
+        effectiveGasPrice: 0n,
+        blockNumber: 0n,
+        from: '0x1234123412341234123412341234123412341234',
+      } as any);
+    });
+
+    it('no-op if already matches', async () => {
+      const owners = ['0x1', '0x2'].map(v => viem.pad(v as viem.Hex, { size: 20 }));
+      jest.mocked(fakeRuntime.provider.readContract).mockImplementation(async (args: any) => {
+        if (args.functionName === 'getOwners') return owners;
+        if (args.functionName === 'getThreshold') return 2n;
+        return null;
+      });
+
+      const result = await action.exec(
+        fakeRuntime,
+        fakeCtx,
+        {
+          target: safeAddress,
+          signers: owners,
+          threshold: 2,
+        },
+        { ref: null, currentLabel: 'safe_set_signers.test' }
+      );
+
+      expect(result).toEqual({});
+      expect(fakeRuntime.provider.prepareTransactionRequest).not.toHaveBeenCalled();
+    });
+
+    it('adds a single owner', async () => {
+      const currentOwners = ['0x1'].map(v => viem.pad(v as viem.Hex, { size: 20 }));
+      const desiredSigners = ['0x1', '0x2'].map(v => viem.pad(v as viem.Hex, { size: 20 }));
+
+      jest.mocked(fakeRuntime.provider.readContract).mockImplementation(async (args: any) => {
+        if (args.functionName === 'getOwners') return currentOwners;
+        if (args.functionName === 'getThreshold') return 1n;
+        return null;
+      });
+
+      await action.exec(
+        fakeRuntime,
+        fakeCtx,
+        {
+          target: safeAddress,
+          signers: desiredSigners,
+          threshold: 1,
+        },
+        { ref: null, currentLabel: 'safe_set_signers.test' }
+      );
+
+      expect(fakeRuntime.provider.prepareTransactionRequest).toHaveBeenCalled();
+      const callArgs = jest.mocked(fakeRuntime.provider.prepareTransactionRequest).mock.calls[0][0];
+      // Should be calling execTransaction on safeAddress
+      expect(callArgs.to).toBe(safeAddress);
+      // Data should contain addOwnerWithThreshold
+    });
+
+    it('removes a single owner', async () => {
+      const currentOwners = ['0x2', '0x1'].map(v => viem.pad(v as viem.Hex, { size: 20 }));
+      const desiredSigners = ['0x1'].map(v => viem.pad(v as viem.Hex, { size: 20 }));
+
+      jest.mocked(fakeRuntime.provider.readContract).mockImplementation(async (args: any) => {
+        if (args.functionName === 'getOwners') return currentOwners;
+        if (args.functionName === 'getThreshold') return 1n;
+        return null;
+      });
+
+      await action.exec(
+        fakeRuntime,
+        fakeCtx,
+        {
+          target: safeAddress,
+          signers: desiredSigners,
+          threshold: 1,
+        },
+        { ref: null, currentLabel: 'safe_set_signers.test' }
+      );
+
+      expect(fakeRuntime.provider.prepareTransactionRequest).toHaveBeenCalled();
+    });
+
+    it('swaps an owner', async () => {
+      const currentOwners = ['0x1'].map(v => viem.pad(v as viem.Hex, { size: 20 }));
+      const desiredSigners = ['0x2'].map(v => viem.pad(v as viem.Hex, { size: 20 }));
+
+      jest.mocked(fakeRuntime.provider.readContract).mockImplementation(async (args: any) => {
+        if (args.functionName === 'getOwners') return currentOwners;
+        if (args.functionName === 'getThreshold') return 1n;
+        return null;
+      });
+
+      await action.exec(
+        fakeRuntime,
+        fakeCtx,
+        {
+          target: safeAddress,
+          signers: desiredSigners,
+          threshold: 1,
+        },
+        { ref: null, currentLabel: 'safe_set_signers.test' }
+      );
+
+      expect(fakeRuntime.provider.prepareTransactionRequest).toHaveBeenCalled();
+    });
+
+    it('changes threshold', async () => {
+      const currentOwners = ['0x1', '0x2'].map(v => viem.pad(v as viem.Hex, { size: 20 }));
+      const desiredSigners = ['0x1', '0x2'].map(v => viem.pad(v as viem.Hex, { size: 20 }));
+
+      jest.mocked(fakeRuntime.provider.readContract).mockImplementation(async (args: any) => {
+        if (args.functionName === 'getOwners') return currentOwners;
+        if (args.functionName === 'getThreshold') return 1n;
+        return null;
+      });
+
+      await action.exec(
+        fakeRuntime,
+        fakeCtx,
+        {
+          target: safeAddress,
+          signers: desiredSigners,
+          threshold: 2,
+        },
+        { ref: null, currentLabel: 'safe_set_signers.test' }
+      );
+
+      expect(fakeRuntime.provider.prepareTransactionRequest).toHaveBeenCalled();
+    });
+
+    it('batches multiple changes using MultiSend', async () => {
+      const currentOwners = ['0x1', '0x2'].map(v => viem.pad(v as viem.Hex, { size: 20 }));
+      const desiredSigners = ['0x3', '0x4'].map(v => viem.pad(v as viem.Hex, { size: 20 }));
+
+      jest.mocked(fakeRuntime.provider.readContract).mockImplementation(async (args: any) => {
+        if (args.functionName === 'getOwners') return currentOwners;
+        if (args.functionName === 'getThreshold') return 1n;
+        return null;
+      });
+
+      await action.exec(
+        fakeRuntime,
+        fakeCtx,
+        {
+          target: safeAddress,
+          signers: desiredSigners,
+          threshold: 2,
+        },
+        { ref: null, currentLabel: 'safe_set_signers.test' }
+      );
+
+      expect(fakeRuntime.provider.prepareTransactionRequest).toHaveBeenCalled();
+      const callArgs = jest.mocked(fakeRuntime.provider.prepareTransactionRequest).mock.calls[0][0];
+      // Should be calling execTransaction with MultiSend address and operation 1
+      // We'll just verify it was called.
+    });
+  });
+});

--- a/packages/builder/src/steps/safe-set-signers.ts
+++ b/packages/builder/src/steps/safe-set-signers.ts
@@ -1,0 +1,363 @@
+import Debug from 'debug';
+import _ from 'lodash';
+import * as viem from 'viem';
+import { z } from 'zod';
+import { safeSetSignersSchema } from '../schemas';
+import { ChainBuilderContext, PackageState, ChainArtifacts, EventMap } from '../types';
+import { ChainBuilderRuntime } from '../runtime';
+import { encodeFunctionData } from '../util';
+import { template } from '../utils/template';
+import { CannonAction } from '../actions';
+
+const debug = Debug('cannon:builder:safe-set-signers');
+
+export type Config = z.infer<typeof safeSetSignersSchema>;
+
+const SAFE_ABI = [
+  {
+    type: 'function',
+    name: 'getOwners',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'address[]' }],
+  },
+  {
+    type: 'function',
+    name: 'getThreshold',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'addOwnerWithThreshold',
+    inputs: [
+      { type: 'address', name: 'owner' },
+      { type: 'uint256', name: '_threshold' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'removeOwner',
+    inputs: [
+      { type: 'address', name: 'prevOwner' },
+      { type: 'address', name: 'owner' },
+      { type: 'uint256', name: '_threshold' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'swapOwner',
+    inputs: [
+      { type: 'address', name: 'prevOwner' },
+      { type: 'address', name: 'oldOwner' },
+      { type: 'address', name: 'newOwner' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'changeThreshold',
+    inputs: [{ type: 'uint256', name: '_threshold' }],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'execTransaction',
+    stateMutability: 'payable',
+    inputs: [
+      { type: 'address', name: 'to' },
+      { type: 'uint256', name: 'value' },
+      { type: 'bytes', name: 'data' },
+      { type: 'uint8', name: 'operation' },
+      { type: 'uint256', name: 'safeTxGas' },
+      { type: 'uint256', name: 'baseGas' },
+      { type: 'uint256', name: 'gasPrice' },
+      { type: 'address', name: 'gasToken' },
+      { type: 'address', name: 'refundReceiver' },
+      { type: 'bytes', name: 'signatures' },
+    ],
+    outputs: [{ type: 'bool', name: 'success' }],
+  },
+] as const;
+
+const MULTI_SEND_ABI = [
+  {
+    type: 'function',
+    name: 'multiSend',
+    inputs: [{ type: 'bytes', name: 'transactions' }],
+    outputs: [],
+  },
+] as const;
+
+const MULTI_SEND_ADDRESS = viem.getAddress('0xA238CBebE9002235B3db6E711818d6D9F36f698e');
+const SENTINEL_OWNERS = '0x0000000000000000000000000000000000000001' as viem.Address;
+
+function encodeMultiSend(txs: { to: viem.Address; value: bigint; data: viem.Hex; operation: number }[]): viem.Hex {
+  return viem.concat(
+    txs.map((tx) => {
+      const data = viem.toBytes(tx.data);
+      return viem.concat([
+        viem.numberToHex(tx.operation, { size: 1 }),
+        tx.to,
+        viem.numberToHex(tx.value, { size: 32 }),
+        viem.numberToHex(data.length, { size: 32 }),
+        tx.data,
+      ]);
+    })
+  );
+}
+
+const safeSetSignersSpec: CannonAction<Config> = {
+  label: 'safe_set_signers',
+
+  validate: safeSetSignersSchema,
+
+  configInject(ctx, config) {
+    config = _.cloneDeep(config);
+    config.target = template(config.target, ctx);
+    config.signers = config.signers.map((s) => template(s, ctx));
+    if (config.from) {
+      config.from = template(config.from, ctx);
+    }
+    return config;
+  },
+
+  async getState(runtime, ctx, config) {
+    const target = config.target as viem.Address;
+    if (!viem.isAddress(target)) return null;
+
+    try {
+      const owners = (await runtime.provider.readContract({
+        address: target,
+        abi: SAFE_ABI,
+        functionName: 'getOwners',
+      })) as viem.Address[];
+
+      const threshold = (await runtime.provider.readContract({
+        address: target,
+        abi: SAFE_ABI,
+        functionName: 'getThreshold',
+      })) as bigint;
+
+      return [_.sortBy(owners.map((o: viem.Address) => viem.getAddress(o))), Number(threshold)];
+    } catch (err) {
+      debug('failed to get safe state', err);
+      return null;
+    }
+  },
+
+  async exec(runtime, ctx, config, packageState): Promise<ChainArtifacts> {
+    const target = config.target as viem.Address;
+    const desiredSigners = _.sortBy(config.signers.map((s) => viem.getAddress(s)));
+
+    const currentOwners = (await runtime.provider.readContract({
+      address: target,
+      abi: SAFE_ABI,
+      functionName: 'getOwners',
+    })) as viem.Address[];
+
+    const currentThresholdBigInt = (await runtime.provider.readContract({
+      address: target,
+      abi: SAFE_ABI,
+      functionName: 'getThreshold',
+    })) as bigint;
+
+    const currentThreshold = Number(currentThresholdBigInt);
+    const sortedCurrentOwners = _.sortBy(currentOwners.map((o) => viem.getAddress(o)));
+    const desiredThreshold = config.threshold ?? currentThreshold;
+
+    if (_.isEqual(sortedCurrentOwners, desiredSigners) && currentThreshold === desiredThreshold) {
+      return {};
+    }
+
+    const toAdd = _.difference(desiredSigners, sortedCurrentOwners);
+    const toRemove = _.difference(sortedCurrentOwners, desiredSigners);
+
+    const calls: { to: viem.Address; value: bigint; data: viem.Hex; operation: number }[] = [];
+
+    // Working copy of owners for computing prevOwner
+    const owners = [...currentOwners];
+    let simThreshold = currentThreshold;
+
+    const getPrevOwner = (owner: viem.Address) => {
+      const idx = owners.findIndex((o) => viem.getAddress(o) === viem.getAddress(owner));
+      if (idx === -1) throw new Error(`Owner ${owner} not found in current owners`);
+      return idx === 0 ? SENTINEL_OWNERS : viem.getAddress(owners[idx - 1]);
+    };
+
+    // Use swapOwner for pairs of (remove, add)
+    while (toAdd.length > 0 && toRemove.length > 0) {
+      const newOwner = toAdd.shift()!;
+      const oldOwner = toRemove.shift()!;
+      const prevOwner = getPrevOwner(oldOwner);
+
+      calls.push({
+        to: target,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: SAFE_ABI,
+          functionName: 'swapOwner',
+          args: [prevOwner, oldOwner, newOwner],
+        }),
+        operation: 0,
+      });
+
+      // Update local owners list for subsequent calls
+      const idx = owners.findIndex((o) => viem.getAddress(o) === viem.getAddress(oldOwner));
+      owners[idx] = newOwner;
+    }
+
+    // Add remaining
+    while (toAdd.length > 0) {
+      const newOwner = toAdd.shift()!;
+      // When adding, threshold stays the same, it's always valid as owners.length increases.
+      calls.push({
+        to: target,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: SAFE_ABI,
+          functionName: 'addOwnerWithThreshold',
+          args: [newOwner, BigInt(simThreshold)],
+        }),
+        operation: 0,
+      });
+      owners.unshift(newOwner);
+    }
+
+    // Remove remaining
+    while (toRemove.length > 0) {
+      const oldOwner = toRemove.shift()!;
+      const prevOwner = getPrevOwner(oldOwner);
+
+      // When removing, we must ensure threshold <= new owners length.
+      simThreshold = Math.min(simThreshold, owners.length - 1);
+
+      calls.push({
+        to: target,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: SAFE_ABI,
+          functionName: 'removeOwner',
+          args: [prevOwner, oldOwner, BigInt(simThreshold)],
+        }),
+        operation: 0,
+      });
+
+      const idx = owners.findIndex((o) => viem.getAddress(o) === viem.getAddress(oldOwner));
+      owners.splice(idx, 1);
+    }
+
+    // Finally, adjust threshold if needed
+    if (simThreshold !== desiredThreshold) {
+      if (owners.length < desiredThreshold) {
+        throw new Error(`Cannot set threshold to ${desiredThreshold} with only ${owners.length} signers`);
+      }
+      calls.push({
+        to: target,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: SAFE_ABI,
+          functionName: 'changeThreshold',
+          args: [BigInt(desiredThreshold)],
+        }),
+        operation: 0,
+      });
+      simThreshold = desiredThreshold;
+    }
+
+    if (calls.length === 0) {
+      return {};
+    }
+
+    let txHash: viem.Hex;
+
+    const signer = config.from ? await runtime.getSigner(config.from as viem.Address) : await runtime.getDefaultSigner!({}, '');
+
+    // Signatures for execTransaction (pre-validated signature type 0x1)
+    // format: r = address, s = 0, v = 1
+    const signature = viem.concat([
+      viem.pad(signer.address, { size: 32 }),
+      viem.pad(viem.numberToHex(0, { size: 32 }), { size: 32 }),
+      viem.numberToHex(1, { size: 1 }),
+    ]);
+
+    if (calls.length === 1) {
+      const call = calls[0];
+      const preparedTxn = await runtime.provider.prepareTransactionRequest({
+        account: signer.wallet.account || signer.address,
+        to: target,
+        data: encodeFunctionData({
+          abi: SAFE_ABI,
+          functionName: 'execTransaction',
+          args: [
+            call.to,
+            call.value,
+            call.data,
+            call.operation,
+            0n, // safeTxGas
+            0n, // baseGas
+            0n, // gasPrice
+            viem.zeroAddress, // gasToken
+            viem.zeroAddress, // refundReceiver
+            signature,
+          ],
+        }),
+        chain: null,
+      });
+      txHash = await signer.wallet.sendTransaction(preparedTxn as any);
+    } else {
+      // MultiSend
+      const multiSendData = encodeFunctionData({
+        abi: MULTI_SEND_ABI,
+        functionName: 'multiSend',
+        args: [encodeMultiSend(calls)],
+      });
+
+      const preparedTxn = await runtime.provider.prepareTransactionRequest({
+        account: signer.wallet.account || signer.address,
+        to: target,
+        data: encodeFunctionData({
+          abi: SAFE_ABI,
+          functionName: 'execTransaction',
+          args: [
+            MULTI_SEND_ADDRESS,
+            0n,
+            multiSendData,
+            1, // DelegateCall
+            0n,
+            0n,
+            0n,
+            viem.zeroAddress,
+            viem.zeroAddress,
+            signature,
+          ],
+        }),
+        chain: null,
+      });
+      txHash = await signer.wallet.sendTransaction(preparedTxn as any);
+    }
+
+    const receipt = await runtime.provider.waitForTransactionReceipt({ hash: txHash });
+    const block = await runtime.provider.getBlock({ blockNumber: receipt.blockNumber });
+
+    return {
+      txns: {
+        [packageState.currentLabel.split('.')[1]]: {
+          hash: txHash,
+          blockNumber: receipt.blockNumber.toString(),
+          timestamp: block.timestamp.toString(),
+          events: {} as EventMap,
+          deployedOn: packageState.currentLabel,
+          gasUsed: Number(receipt.gasUsed),
+          gasCost: receipt.effectiveGasPrice.toString(),
+          signer: viem.getAddress(receipt.from),
+        },
+      },
+    };
+  },
+} satisfies CannonAction<Config>;
+
+export default safeSetSignersSpec;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,6 +829,8 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
+  packages/skill: {}
+
   packages/website:
     dependencies:
       '@ethersproject/bignumber':


### PR DESCRIPTION
Adds a new `safe_set_signers` Cannon action that automatically configures the signer list on a Gnosis Safe multisig.

## What it does

Given a Safe address and a desired list of signers + threshold, this action:
1. Reads current owners and threshold from the Safe
2. Compares to the desired configuration
3. Computes the minimal set of Safe calls (add/remove/swap owners, change threshold)
4. Batches all calls into a single `execTransaction`
5. Idempotent — no-op if current signers already match desired

## Files changed

- `packages/builder/src/steps/safe-set-signers.ts` — action implementation (363 lines)
- `packages/builder/src/steps/safe-set-signers.test.ts` — unit tests (228 lines)
- `packages/builder/src/schemas.ts` — zod schema + cannonfile registration
- `packages/builder/src/actions.ts` — action registration

## Usage example (cannonfile)

```toml
[setting.safeAddress]
  value = "0x..."  # Safe contract address

[safe_set_signers.configure-safe]
  target = "${safeAddress}"
  signers = ["0xOwner1", "0xOwner2", "0xOwner3"]
  threshold = 2
```