### PR TITLE
fix(verify): etherscan v2 API compatibility and bug fixes

### DIFF
--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -109,6 +109,7 @@ export async function verify(
 
       // supply any linked libraries within the inputs since those are calculated at runtime
       const inputData = JSON.parse(contractArtifact.source.input);
+      delete inputData.settings.compilationTarget;
       _.set(inputData, 'settings.libraries', contractInfo.linkedLibraries);
 
       if (service === 'etherscan' || service === 'all') {
@@ -118,7 +119,6 @@ export async function verify(
           try {
             const reqData: { [k: string]: string } = {
               apikey: cliSettings.etherscanApiKey,
-              chainid: chainId.toString(),
               module: 'contract',
               action: 'verifysourcecode',
               contractaddress: contractInfo.address,
@@ -139,7 +139,11 @@ export async function verify(
 
             debug('verification request', reqData);
 
-            const res = await axios.post(etherscanApi, reqData, {
+            // Etherscan v2 requires chainid as a query string parameter
+            const etherscanVerifyUrl = new URL(etherscanApi);
+            etherscanVerifyUrl.searchParams.set('chainid', chainId.toString());
+
+            const res = await axios.post(etherscanVerifyUrl.toString(), reqData, {
               headers: {
                 'content-type': 'application/x-www-form-urlencoded',
                 'User-Agent': 'Cannon CLI',
@@ -151,7 +155,7 @@ export async function verify(
               logSpinner(`Etherscan: ${c} (${contractInfo.address}):\tCannot verify:`, res.data.result);
             } else {
               logSpinner(`Etherscan: ${c} (${contractInfo.address}):\tSubmitted verification (${res.data.result})`);
-              guids[c]['etherscan'] = res.data.result;
+              _.set(guids, [c, 'etherscan'], res.data.result);
             }
           } catch (err) {
             logSpinner(`Etherscan: ${c} (${contractInfo.address}): Verification request failed:`, err);
@@ -223,13 +227,17 @@ export async function verify(
     for (const v in guids[c]) {
       for (;;) {
         if (v === 'etherscan') {
+          // Etherscan v2 requires chainid as a query string parameter
+          const etherscanStatusUrl = new URL(etherscanApi);
+          etherscanStatusUrl.searchParams.set('chainid', chainId.toString());
+
           const res = await axios.post(
-            etherscanApi,
+            etherscanStatusUrl.toString(),
             {
               apiKey: cliSettings.etherscanApiKey,
               module: 'contract',
               action: 'checkverifystatus',
-              guid: guids[c],
+              guid: guids[c]['etherscan'],
             },
             {
               headers: {

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -60,6 +60,10 @@ export async function verify(
 
   const etherscanApi = cliSettings.etherscanApiUrl || ETHERSCAN_DEFAULT_SERVER_URL;
 
+  // Etherscan v2 requires chainid as a query string parameter
+  const etherscanUrl = new URL(etherscanApi);
+  etherscanUrl.searchParams.set('chainid', chainId.toString());
+
   if (service === 'etherscan' || (service === 'all' && !cliSettings.etherscanApiKey)) {
     log('Using generic API key for Etherscan. If this is incorrect, specify CANNON_ETHERSCAN_API_KEY');
   }
@@ -121,6 +125,7 @@ export async function verify(
               apikey: cliSettings.etherscanApiKey,
               module: 'contract',
               action: 'verifysourcecode',
+              chainid: chainId.toString(),
               contractaddress: contractInfo.address,
               // need to parse to get the inner structure, then stringify again
               sourceCode: JSON.stringify(inputData),
@@ -139,11 +144,7 @@ export async function verify(
 
             debug('verification request', reqData);
 
-            // Etherscan v2 requires chainid as a query string parameter
-            const etherscanVerifyUrl = new URL(etherscanApi);
-            etherscanVerifyUrl.searchParams.set('chainid', chainId.toString());
-
-            const res = await axios.post(etherscanVerifyUrl.toString(), reqData, {
+            const res = await axios.post(etherscanUrl.toString(), reqData, {
               headers: {
                 'content-type': 'application/x-www-form-urlencoded',
                 'User-Agent': 'Cannon CLI',
@@ -227,12 +228,8 @@ export async function verify(
     for (const v in guids[c]) {
       for (;;) {
         if (v === 'etherscan') {
-          // Etherscan v2 requires chainid as a query string parameter
-          const etherscanStatusUrl = new URL(etherscanApi);
-          etherscanStatusUrl.searchParams.set('chainid', chainId.toString());
-
           const res = await axios.post(
-            etherscanStatusUrl.toString(),
+            etherscanUrl.toString(),
             {
               apiKey: cliSettings.etherscanApiKey,
               module: 'contract',


### PR DESCRIPTION
## Problem

Etherscan v1 API was deprecated August 2025. The cannon verify command needs updates for v2 compatibility, plus several bugs in the verification flow.

## Changes

### Etherscan v2 API compatibility
- Move `chainid` from POST body to query string parameter for `verifysourcecode` and `checkverifystatus` endpoints (v2 requirement)
- `isEtherscanVerified` already uses query params via URLSearchParams, so no change needed there

### Bug fixes
- **Delete `compilationTarget`** from standard JSON input before sending to Etherscan. Without this, the `compilationTarget` in settings conflicts with the top-level `contractname` parameter, causing verification failures.
- **Fix `checkverifystatus` guid reference** — was passing `guids[c]` (the whole sub-object) instead of `guids[c][etherscan]` (the actual guid string)
- **Use `_.set` for etherscan guid assignment** — direct assignment `guids[c][etherscan]` crashes when `guids[c]` is undefined

## Testing
- Built locally, no TS compilation errors from changes
- Tested against real Etherscan v2 API for contract verification