### PR TITLE
Release 2.26.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*"
   ],
   "exact": true,
-  "version": "2.26.0"
+  "version": "2.26.1"
 }

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usecannon/builder",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "description": "Assembles cannonfile.toml manifests into cannon packages.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usecannon/cli",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "description": "Utility for instantly loading cannon packages in standalone contexts",
   "main": "dist/src/index.js",
   "scripts": {

--- a/packages/hardhat-cannon/package.json
+++ b/packages/hardhat-cannon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-cannon",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "description": "Agnostic chain construction. Select the protocols and configuration you need to quickly and easily verify your project",
   "author": "Synthetix",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,6 +829,8 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
+  packages/skill: {}
+
   packages/website:
     dependencies:
       '@ethersproject/bignumber':


### PR DESCRIPTION
## Release 2.26.1

### Bug Fixes
- **fix(verify): etherscan v2 API compatibility and bug fixes** (#1871)
  - Add chainid to POST body and query string for Etherscan v2 API
  - Fix guids object access bug (passing whole object instead of guid string)
  - Unify etherscan URL variable
- **fix(clone): republish when built state equals previous state** (#1868)
- **fix(skill): declare environment variables in SKILL.md** (#1870)
  - Move env vars to body section with CANNON_ prefix documentation

### Features
- **feat(alter): populate missing steps for incomplete packages** (#1872)
  - New `--populate-missing` flag for `cannon alter`
  - Allows altering packages that have not been fully generated
  - Auto-populates missing subpackages and step definitions

### Documentation
- **docs: add on-chain upgrade attestation guide** (#1867)
- **feat(skill): add AI agent skill package for Cannon** (#1862)

### Version Bumps
- `@usecannon/builder`: 2.26.0 → 2.26.1
- `@usecannon/cli`: 2.26.0 → 2.26.1
- `hardhat-cannon`: 2.26.0 → 2.26.1