### PR TITLE
fix(cli): hide internal paths in download logs

### DIFF
--- a/packages/cli/src/loader.test.ts
+++ b/packages/cli/src/loader.test.ts
@@ -17,7 +17,7 @@ describe('LocalLoader', function LocalLoaderTestCases() {
 
   it('getLabel should return label', () => {
     const result = loader.getLabel();
-    expect(result).toEqual(dir);
+    expect(result).toEqual('local blobs');
   });
 
   it('read should return JSON from the path', async () => {

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -29,7 +29,7 @@ export class LocalLoader implements CannonLoader {
   }
 
   getLabel(): string {
-    return this.dir;
+    return 'local blobs';
   }
 
   read(url: string): Promise<any> {
@@ -94,7 +94,7 @@ export class CliLoader implements CannonLoader {
       case LoaderAction.read:
         return this.readIpfs ? this.readIpfs.getLabel() : this.repo.getLabel();
       case LoaderAction.local:
-        return this.dir;
+        return 'local cache';
       case LoaderAction.write:
         return this.writeIpfs ? this.writeIpfs.getLabel() : '';
       case LoaderAction.repo:


### PR DESCRIPTION
## Summary

Loader `getLabel()` was returning raw filesystem paths (e.g. `/home/vscode/.local/share/cannon/ipfs_cache`) which appeared in build output like:

```
Downloading ipfs://QmPKAzjR1qQbJsbc3b5mmrJcFZPbwimmUa9sPYV28uQWVz via /home/vscode/.local/share/cannon/ipfs_cache
```

Now shows:
```
Downloading ipfs://QmPKAzjR1qQbJsbc3b5mmrJcFZPbwimmUa9sPYV28uQWVz via local cache
```

## Changes
- `LocalLoader.getLabel()` → `"local blobs"` instead of directory path
- `CliLoader.getLabel()` local action → `"local cache"` instead of directory path

## Test Plan
- Run `cannon build` and verify download log lines show `local cache` instead of filesystem paths